### PR TITLE
feat(codex): port Codex executor from 9Router — Responses API + SSE + multi-account

### DIFF
--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -5,7 +5,7 @@ import {
     saveOAuthSessionDB,
     upsertProviderDB,
 } from "@srouter/db";
-import { AntigravityExecutor, AnthropicExecutor, CommandCodeExecutor, OpenAIExecutor } from "@srouter/executors";
+import { AntigravityExecutor, AnthropicExecutor, CodexExecutor, CommandCodeExecutor, OpenAIExecutor } from "@srouter/executors";
 import { AntigravityOAuth, OpenAICodexOAuth, generatePKCE, type PKCEPair } from "@srouter/providers";
 import type { ProviderConfig } from "@srouter/types";
 import { registry } from "@/services/registry.js";
@@ -27,6 +27,7 @@ export interface TokenImportParams {
     id?: string;
     accessToken: string;
     refreshToken?: string;
+    accountId?: string;
     baseUrl?: string;
     name?: string;
 }
@@ -97,14 +98,17 @@ export class AuthLogic {
             protocol: "openai",
             accessToken: tokens.accessToken,
             refreshToken: tokens.refreshToken,
+            accountId: tokens.accountId,
             enabled: true,
             createdAt: timestamp,
         });
 
-        const providerInstance = new OpenAIExecutor({
+        const providerInstance = new CodexExecutor({
             id: accountId,
             name: accountName,
             accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            accountId: tokens.accountId,
         });
         registry.registerProvider(providerInstance);
 
@@ -124,14 +128,17 @@ export class AuthLogic {
             protocol: "openai",
             accessToken: params.accessToken,
             refreshToken: params.refreshToken,
+            accountId: params.accountId,
             enabled: true,
             createdAt: timestamp,
         });
 
-        const providerInstance = new OpenAIExecutor({
+        const providerInstance = new CodexExecutor({
             id: accountId,
             name: providerName,
             accessToken: params.accessToken,
+            refreshToken: params.refreshToken,
+            accountId: params.accountId,
         });
         registry.registerProvider(providerInstance);
 

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -1,5 +1,5 @@
 import { getAllProvidersDB } from "@srouter/db";
-import { AntigravityExecutor, AnthropicExecutor, CommandCodeExecutor, OpenAIExecutor } from "@srouter/executors";
+import { AntigravityExecutor, AnthropicExecutor, CodexExecutor, CommandCodeExecutor, OpenAIExecutor } from "@srouter/executors";
 import { ProviderRegistry } from "@srouter/providers";
 
 // Create a global ProviderRegistry instance
@@ -60,6 +60,19 @@ export function loadSavedProvidersFromDB(): void {
                         baseUrl,
                         apiKey: p.apiKey,
                         accessToken: p.accessToken,
+                    }),
+                );
+                break;
+            case providerType === "openai_codex" || p.id.startsWith("openai_codex"):
+                registry.registerProvider(
+                    new CodexExecutor({
+                        id: p.id || p.providerId,
+                        name: p.name,
+                        baseUrl,
+                        apiKey: p.apiKey,
+                        accessToken: p.accessToken,
+                        refreshToken: p.refreshToken,
+                        accountId: p.accountId,
                     }),
                 );
                 break;

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -52,6 +52,13 @@ export function initDatabase(): void {
         // column already exists
     }
 
+    // Ensure account_id column exists for multi-account OAuth binding (e.g. Codex ChatGPT-Account-ID)
+    try {
+        db.exec("ALTER TABLE providers ADD COLUMN account_id TEXT;");
+    } catch {
+        // column already exists
+    }
+
     // 2. Table for Client API Keys / Endpoint Keys
     db.exec(`
         CREATE TABLE IF NOT EXISTS api_keys (

--- a/packages/db/src/providers.ts
+++ b/packages/db/src/providers.ts
@@ -15,6 +15,7 @@ export function getAllProvidersDB(): ProviderConfig[] {
         apiKey: row.api_key ? String(row.api_key) : undefined,
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
+        accountId: row.account_id ? String(row.account_id) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
         enabled: Boolean(row.enabled),
         createdAt: Number(row.created_at ?? 0),
@@ -37,6 +38,7 @@ export function getProviderByIdDB(id: string): ProviderConfig | null {
         apiKey: row.api_key ? String(row.api_key) : undefined,
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
+        accountId: row.account_id ? String(row.account_id) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
         enabled: Boolean(row.enabled),
         createdAt: Number(row.created_at ?? 0),
@@ -45,8 +47,8 @@ export function getProviderByIdDB(id: string): ProviderConfig | null {
 
 export function upsertProviderDB(config: ProviderConfig & { category: string; protocol: string }): ProviderConfig {
     const query = db.prepare(`
-        INSERT INTO providers (id, provider_id, name, category, protocol, base_url, api_key, access_token, refresh_token, custom_headers, enabled, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO providers (id, provider_id, name, category, protocol, base_url, api_key, access_token, refresh_token, account_id, custom_headers, enabled, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             provider_id = excluded.provider_id,
             name = excluded.name,
@@ -56,12 +58,13 @@ export function upsertProviderDB(config: ProviderConfig & { category: string; pr
             api_key = excluded.api_key,
             access_token = excluded.access_token,
             refresh_token = excluded.refresh_token,
+            account_id = excluded.account_id,
             custom_headers = excluded.custom_headers,
             enabled = excluded.enabled,
             created_at = excluded.created_at;
     `);
 
-    query.run(config.id, config.providerId, config.name, config.category, config.protocol, config.baseUrl ?? null, config.apiKey ?? null, config.accessToken ?? null, config.refreshToken ?? null, config.customHeaders ? JSON.stringify(config.customHeaders) : null, config.enabled ? 1 : 0, config.createdAt);
+    query.run(config.id, config.providerId, config.name, config.category, config.protocol, config.baseUrl ?? null, config.apiKey ?? null, config.accessToken ?? null, config.refreshToken ?? null, config.accountId ?? null, config.customHeaders ? JSON.stringify(config.customHeaders) : null, config.enabled ? 1 : 0, config.createdAt);
 
     return config;
 }
@@ -93,6 +96,7 @@ export function getConnectionsByProviderIdDB(providerId: string): ProviderConfig
         apiKey: row.api_key ? String(row.api_key) : undefined,
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
+        accountId: row.account_id ? String(row.account_id) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
         enabled: Boolean(row.enabled),
         createdAt: Number(row.created_at ?? 0),

--- a/packages/executors/src/antigravity.ts
+++ b/packages/executors/src/antigravity.ts
@@ -1,8 +1,7 @@
 import type { AIProvider, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ModelObject } from "@srouter/types";
-import { buildGeminiBody, buildGeminiUrl, buildGeminiContents, geminiToOpenAIResponse, parseGeminiModelName } from "@srouter/translator";
 import { OpenAIExecutor } from "./openai.js";
 
-export interface AntigravityExecutorOptions {
+export interface AntigravityProviderOptions {
     id?: string;
     name?: string;
     baseUrl?: string;
@@ -10,7 +9,7 @@ export interface AntigravityExecutorOptions {
     accessToken?: string;
 }
 
-export class AntigravityExecutor implements AIProvider {
+export class AntigravityProvider implements AIProvider {
     id: string;
     name: string;
     private baseUrl: string;
@@ -18,7 +17,7 @@ export class AntigravityExecutor implements AIProvider {
     private accessToken: string;
     private openaiFallback: OpenAIExecutor;
 
-    constructor(options: AntigravityExecutorOptions = {}) {
+    constructor(options: AntigravityProviderOptions = {}) {
         this.id = options.id ?? "antigravity";
         this.name = options.name ?? "Antigravity Provider";
         this.baseUrl = (options.baseUrl ?? "https://generativelanguage.googleapis.com/v1beta").replace(/\/$/, "");
@@ -52,18 +51,91 @@ export class AntigravityExecutor implements AIProvider {
     }
 
     async listModels(): Promise<ModelObject[]> {
-        return [
-            { id: "antigravity/gemini-3.6-flash", object: "model", owned_by: "antigravity" },
-            { id: "antigravity/gemini-2.5-pro", object: "model", owned_by: "antigravity" },
-            { id: "antigravity/gemini-2.5-flash", object: "model", owned_by: "antigravity" },
-            { id: "antigravity/gemini-2.0-flash", object: "model", owned_by: "antigravity" },
-            { id: "antigravity/gemini-1.5-pro", object: "model", owned_by: "antigravity" },
-        ];
+        const token = this.accessToken || this.apiKey;
+        const isLocalProxy = /^https?:\/\/127\.0\.0\.1(:\d+)?(\/|$)/.test(this.baseUrl) || /^https?:\/\/localhost(:\d+)?(\/|$)/.test(this.baseUrl);
+        const isApiKey = token.startsWith("AIzaSy");
+
+        // 1. OpenAI-compatible endpoint (local proxy or AIzaSy key on /openai base)
+        if (isLocalProxy || (isApiKey && this.baseUrl.includes("/openai"))) {
+            return await this.openaiFallback.listModels();
+        }
+
+        // 2. Native Gemini models endpoint (https://generativelanguage.googleapis.com/v1beta/models)
+        const cleanBaseUrl = this.baseUrl.replace(/\/openai$/, "");
+        const baseId = this.id.split("_")[0]?.split("-")[0] ?? this.id;
+        const models: ModelObject[] = [];
+        const seenIds = new Set<string>();
+
+        const pushModel = (rawId: string): void => {
+            const id = rawId.replace(/^models\//, "");
+            if (seenIds.has(id)) return;
+            seenIds.add(id);
+            models.push({ id, object: "model", created: Math.floor(Date.now() / 1000), owned_by: "antigravity" });
+            if (!id.startsWith(`${baseId}/`)) {
+                models.push({ id: `${baseId}/${id}`, object: "model", created: Math.floor(Date.now() / 1000), owned_by: "antigravity" });
+            }
+        };
+
+        try {
+            const res = await fetch(`${cleanBaseUrl}/models`, {
+                method: "GET",
+                headers: this.getHeaders(),
+            });
+            if (res.ok) {
+                const json = (await res.json()) as { models?: Array<{ name?: string }> };
+                if (json.models && Array.isArray(json.models)) {
+                    for (const m of json.models) {
+                        if (m.name) pushModel(m.name);
+                    }
+                    if (models.length > 0) return models;
+                }
+            }
+        } catch {
+            // fall through to CloudCode attempt
+        }
+
+        // 3. ya29 OAuth token: CloudCode fetchAvailableModels
+        if (token.startsWith("ya29.")) {
+            try {
+                const res = await fetch("https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        "Content-Type": "application/json",
+                        "User-Agent": "Antigravity/1.0 (VSCode)",
+                        "x-goog-api-client": "gl-node/18.0.0 gd/1.0.0",
+                    },
+                    body: JSON.stringify({}),
+                });
+                if (res.ok) {
+                    const data = (await res.json()) as { models?: Record<string, { displayName?: string }> };
+                    if (data.models && Object.keys(data.models).length > 0) {
+                        for (const modelId of Object.keys(data.models)) {
+                            pushModel(modelId);
+                        }
+                        return models;
+                    }
+                }
+            } catch {
+                // no models available
+            }
+        }
+
+        // 4. Never return hardcoded models — provider could not verify its model list
+        return [];
+    }
+
+    private parseModelName(rawModel: string): string {
+        let model = rawModel.includes("/") ? (rawModel.split("/")[1] ?? rawModel) : rawModel;
+        if (model === "gemini-3.6-flash" || model === "gemini-3.5-flash" || model === "gemini-2.0-flash") {
+            model = "gemini-2.5-flash";
+        }
+        return model;
     }
 
     async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
         const token = this.accessToken || this.apiKey;
-        const isLocalProxy = this.baseUrl.includes("localhost") || this.baseUrl.includes("127.0.0.1");
+        const isLocalProxy = /^https?:\/\/127\.0\.0\.1(:\d+)?(\/|$)/.test(this.baseUrl) || /^https?:\/\/localhost(:\d+)?(\/|$)/.test(this.baseUrl);
         const isApiKey = token.startsWith("AIzaSy");
 
         // 1. Only use openaiFallback if token is AIzaSy API key or connecting to local proxy
@@ -72,13 +144,43 @@ export class AntigravityExecutor implements AIProvider {
         }
 
         // 2. For Google OAuth ya29... tokens, use Native Gemini REST API
-        const modelName = parseGeminiModelName(req.model);
-        const contents = buildGeminiContents(req);
-        const bodyPayload = buildGeminiBody(contents, modelName, token);
+        const cleanBaseUrl = this.baseUrl.replace(/\/openai$/, "");
+        const modelName = this.parseModelName(req.model);
+        const contents = req.messages.map((m) => ({
+            role: m.role === "assistant" ? "model" : "user",
+            parts: [{ text: typeof m.content === "string" ? m.content : JSON.stringify(m.content) }],
+        }));
 
-        const targetUrl = token.startsWith("ya29.")
-            ? process.env.ANTIGRAVITY_BASE_URL || "https://cloudcode-pa.googleapis.com/v1internal:generateContent"
-            : buildGeminiUrl(this.baseUrl, modelName, token);
+        interface CloudCodePayload {
+            model: string;
+            request: {
+                contents: Array<{ role: string; parts: Array<{ text: string }> }>;
+            };
+        }
+
+        interface GeminiNativePayload {
+            contents: Array<{ role: string; parts: Array<{ text: string }> }>;
+        }
+
+        let targetUrl: string;
+        let bodyPayload: CloudCodePayload | GeminiNativePayload;
+
+        if (token.startsWith("ya29.")) {
+            targetUrl = process.env.ANTIGRAVITY_BASE_URL || "https://cloudcode-pa.googleapis.com/v1internal:generateContent";
+            bodyPayload = {
+                model: modelName,
+                request: {
+                    contents,
+                },
+            };
+        } else {
+            const cleanBaseUrl = this.baseUrl.replace(/\/openai$/, "");
+            targetUrl = `${cleanBaseUrl}/models/${modelName}:generateContent`;
+            if (isApiKey) {
+                targetUrl += `?key=${token}`;
+            }
+            bodyPayload = { contents };
+        }
 
         const res = await fetch(targetUrl, {
             method: "POST",
@@ -91,13 +193,55 @@ export class AntigravityExecutor implements AIProvider {
             throw new Error(`Antigravity Provider Error (${res.status}): ${errorText}`);
         }
 
-        const data = (await res.json()) as Parameters<typeof geminiToOpenAIResponse>[0];
-        return geminiToOpenAIResponse(data, req.model);
+        const data = (await res.json()) as {
+            candidates?: Array<{
+                content?: {
+                    parts?: Array<{ text?: string }>;
+                    role?: string;
+                };
+                finishReason?: string;
+            }>;
+            responses?: Array<{
+                candidates?: Array<{
+                    content?: {
+                        parts?: Array<{ text?: string }>;
+                        role?: string;
+                    };
+                }>;
+            }>;
+            response?: {
+                candidates?: Array<{
+                    content?: {
+                        parts?: Array<{ text?: string }>;
+                        role?: string;
+                    };
+                }>;
+            };
+        };
+
+        const textResponse = data.candidates?.[0]?.content?.parts?.[0]?.text ?? data.responses?.[0]?.candidates?.[0]?.content?.parts?.[0]?.text ?? data.response?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+
+        return {
+            id: `chatcmpl-${Date.now()}`,
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: req.model,
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: "assistant",
+                        content: textResponse,
+                    },
+                    finish_reason: "stop",
+                },
+            ],
+        };
     }
 
     async *chatCompletionStream(req: ChatCompletionRequest): AsyncGenerator<ChatCompletionChunk, void, void> {
         const token = this.accessToken || this.apiKey;
-        const isLocalProxy = this.baseUrl.includes("localhost") || this.baseUrl.includes("127.0.0.1");
+        const isLocalProxy = /^https?:\/\/127\.0\.0\.1(:\d+)?(\/|$)/.test(this.baseUrl) || /^https?:\/\/localhost(:\d+)?(\/|$)/.test(this.baseUrl);
         const isApiKey = token.startsWith("AIzaSy");
 
         if (isLocalProxy || (isApiKey && this.baseUrl.includes("/openai"))) {

--- a/packages/executors/src/antigravity.ts
+++ b/packages/executors/src/antigravity.ts
@@ -1,7 +1,7 @@
 import type { AIProvider, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ModelObject } from "@srouter/types";
 import { OpenAIExecutor } from "./openai.js";
 
-export interface AntigravityProviderOptions {
+export interface AntigravityExecutorOptions {
     id?: string;
     name?: string;
     baseUrl?: string;
@@ -9,7 +9,7 @@ export interface AntigravityProviderOptions {
     accessToken?: string;
 }
 
-export class AntigravityProvider implements AIProvider {
+export class AntigravityExecutor implements AIProvider {
     id: string;
     name: string;
     private baseUrl: string;
@@ -17,7 +17,7 @@ export class AntigravityProvider implements AIProvider {
     private accessToken: string;
     private openaiFallback: OpenAIExecutor;
 
-    constructor(options: AntigravityProviderOptions = {}) {
+    constructor(options: AntigravityExecutorOptions = {}) {
         this.id = options.id ?? "antigravity";
         this.name = options.name ?? "Antigravity Provider";
         this.baseUrl = (options.baseUrl ?? "https://generativelanguage.googleapis.com/v1beta").replace(/\/$/, "");

--- a/packages/executors/src/codex.ts
+++ b/packages/executors/src/codex.ts
@@ -1,0 +1,556 @@
+import type {
+    AIProvider,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ModelObject,
+} from "@srouter/types";
+import {
+    chatToResponsesBody,
+    createResponsesStreamState,
+    normalizeResponsesInput,
+    responsesEventToChunk,
+    type ResponsesRequestBody,
+} from "@srouter/translator";
+import { parseDataLine, streamLines } from "./base.js";
+
+export interface CodexExecutorOptions {
+    id?: string;
+    name?: string;
+    baseUrl?: string;
+    apiKey?: string;
+    accessToken?: string;
+    refreshToken?: string;
+    accountId?: string;
+    sessionId?: string;
+}
+
+const DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex/responses";
+const DEFAULT_MODELS_URL = "https://chatgpt.com/backend-api/codex/models";
+const CODEX_CLIENT_VERSION = "0.136.0";
+
+// SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
+const SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
+const SSE_ACCOUNT_FALLBACK_PATTERNS = ["selected model is at capacity", "model_at_capacity"];
+const SSE_USER_OUTPUT_PATTERNS = [
+    "event: response.output_text.delta",
+    "event: response.function_call_arguments.delta",
+    '"type":"response.output_text.delta"',
+    '"type":"response.function_call_arguments.delta"',
+];
+const SSE_PEEK_BYTES = 256 * 1024;
+const MODEL_CAPACITY_MESSAGE = "Selected model is at capacity. Please try a different model.";
+
+// Default Codex instructions injected when the request has none (port of 9router codexInstructions.js)
+const CODEX_DEFAULT_INSTRUCTIONS = `You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.
+
+## General
+
+- When searching for text or files, prefer using \`rg\` or \`rg --files\` respectively because \`rg\` is much faster than alternatives like \`grep\`. (If the \`rg\` command is not found, then use alternatives.)
+
+## Editing constraints
+
+- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
+- Add succinct code comments that explain what is going on if code is not self-explanatory.
+- Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well.
+- You may be in a dirty git worktree.
+    * NEVER revert existing changes you did not make unless explicitly requested.
+    * If asked to make a commit or code edits and there are unrelated changes to your work, don't revert those changes.
+- Do not amend a commit unless explicitly requested to do so.
+
+## Presenting your work and final message
+
+- Default: be very concise; friendly coding teammate tone.
+- Ask only when needed; suggest ideas; mirror the user's style.
+- For substantial work, summarize clearly.
+- Skip heavy formatting for simple confirmations.
+- Don't dump large files you've written; reference paths only.
+- For code changes:
+  * Lead with a quick explanation of the change, and then give more details on the context.
+  * If there are natural next steps the user may want to take, suggest them at the end.`;
+
+/**
+ * Codex Executor — talks to ChatGPT backend Responses API.
+ * Ported from 9router open-sse/executors/codex.js (simplified for SRouter).
+ */
+export class CodexExecutor implements AIProvider {
+    id: string;
+    name: string;
+    category = "oauth" as const;
+    protocol = "openai" as const;
+    private baseUrl: string;
+    private modelsUrl: string;
+    private apiKey: string;
+    private accessToken: string;
+    private refreshToken?: string;
+    private accountId?: string;
+    private sessionId?: string;
+    private _currentSessionId: string | null = null;
+
+    constructor(options: CodexExecutorOptions = {}) {
+        this.id = options.id ?? "openai_codex";
+        this.name = options.name ?? "OpenAI Codex / ChatGPT";
+        this.baseUrl = (options.baseUrl ?? process.env.CODEX_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+        this.modelsUrl = (process.env.CODEX_MODELS_URL ?? DEFAULT_MODELS_URL).replace(/\/$/, "");
+        this.apiKey = options.apiKey ?? process.env.CODEX_API_KEY ?? "";
+        this.accessToken = options.accessToken ?? process.env.CODEX_ACCESS_TOKEN ?? "";
+        this.refreshToken = options.refreshToken;
+        this.accountId = options.accountId;
+        this.sessionId = options.sessionId;
+    }
+
+    private getHeaders(extra?: Record<string, string>): Record<string, string> {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            originator: "codex_cli_rs",
+            "User-Agent": `codex_cli_rs/${CODEX_CLIENT_VERSION}`,
+            session_id: this.sessionId || this._currentSessionId || this.id || "default",
+        };
+        const token = this.accessToken || this.apiKey;
+        if (token) {
+            headers["Authorization"] = `Bearer ${token}`;
+        }
+        if (this.accountId) {
+            headers["ChatGPT-Account-ID"] = this.accountId;
+        }
+        if (extra) {
+            Object.assign(headers, extra);
+        }
+        return headers;
+    }
+
+    async listModels(): Promise<ModelObject[]> {
+        const token = this.accessToken || this.apiKey;
+        if (!token) return [];
+        try {
+            const res = await fetch(this.modelsUrl, {
+                method: "GET",
+                headers: this.getHeaders({ Accept: "application/json" }),
+            });
+            if (!res.ok) return [];
+            const json = (await res.json()) as {
+                data?: Array<{
+                    slug?: string;
+                    id?: string;
+                    display_name?: string;
+                    capabilities?: { limits?: { max_context_tokens?: number } };
+                }>;
+                models?: Array<{ slug?: string; id?: string; display_name?: string }>;
+            };
+            const rawModels = Array.isArray(json.data) ? json.data : Array.isArray(json.models) ? json.models : [];
+            return rawModels
+                .map((m) => ({
+                    id: m.slug || m.id || "",
+                    object: "model" as const,
+                    created: Math.floor(Date.now() / 1000),
+                    owned_by: "openai",
+                }))
+                .filter((m) => m.id.length > 0);
+        } catch {
+            return [];
+        }
+    }
+
+    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+        // Codex upstream is streaming-only — accumulate the stream for non-streaming callers
+        const chunks: ChatCompletionChunk[] = [];
+        for await (const chunk of this.chatCompletionStream(req)) {
+            chunks.push(chunk);
+        }
+        return accumulateChunksLocal(chunks, req.model);
+    }
+
+    async *chatCompletionStream(req: ChatCompletionRequest): AsyncGenerator<ChatCompletionChunk, void, void> {
+        const body = this.transformRequest(req);
+        this._currentSessionId = this.sessionId || body.prompt_cache_key || null;
+
+        const retryDelayMs = 3000;
+        let attempt = 0;
+        const maxAttempts = 2;
+
+        while (true) {
+            const res = await fetch(this.baseUrl, {
+                method: "POST",
+                headers: this.getHeaders(),
+                body: JSON.stringify(body),
+            });
+
+            // Non-OK — surface error immediately
+            if (!res.ok) {
+                const errorText = await res.text();
+                // Parse usage_limit_reached for resetsAtMs (port of 9router parseError)
+                const parsed = this.parseError(res.status, errorText);
+                if (parsed) {
+                    throw new Error(`Codex Provider Error (${res.status}): ${parsed.message}`);
+                }
+                throw new Error(`Codex Provider Error (${res.status}): ${errorText}`);
+            }
+
+            if (!res.body) {
+                throw new Error("No response body received for streaming");
+            }
+
+            // Peek first bytes for transient SSE errors (200-OK body may contain error events)
+            const peek = await this.peekSseTransientError(res);
+            if (!peek.matched) {
+                // Re-assemble stream from peeked chunks + rest
+                if (peek.replacementBody) {
+                    yield* this.streamResponses(peek.replacementBody, req.model);
+                } else {
+                    yield* this.streamResponses(res.body, req.model);
+                }
+                return;
+            }
+
+            if (peek.accountFallback) {
+                throw new Error(`Codex Provider Error (503): ${peek.message || MODEL_CAPACITY_MESSAGE}`);
+            }
+
+            if (attempt >= maxAttempts) {
+                throw new Error(`Codex Provider Error (503): ${peek.message || peek.matched}`);
+            }
+
+            attempt++;
+            await new Promise((r) => setTimeout(r, retryDelayMs));
+        }
+    }
+
+    /**
+     * Transform ChatCompletionRequest → Responses API body (port of 9router transformRequest).
+     */
+    private transformRequest(req: ChatCompletionRequest): ResponsesRequestBody {
+        let body = chatToResponsesBody(req);
+        const targetModel = req.model.includes("/") ? (req.model.split("/")[1] ?? req.model) : req.model;
+
+        // model: strip suffix thinking levels (e.g. gpt-5.3-codex-high → gpt-5.3-codex)
+        const effortLevels = ["none", "minimal", "low", "medium", "high", "xhigh"];
+        let modelEffort: string | null = null;
+        let model = targetModel;
+        for (const level of effortLevels) {
+            if (model.endsWith(`-${level}`)) {
+                modelEffort = level;
+                model = model.replace(`-${level}`, "");
+                break;
+            }
+        }
+
+        body.model = model;
+        body.stream = true;
+        body.store = false;
+
+        // Ensure input present (Codex rejects empty)
+        const normalized = normalizeResponsesInput(body.input);
+        if (normalized) body.input = normalized;
+
+        // Inject default instructions
+        if (!body.instructions || body.instructions.trim() === "") {
+            body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
+        }
+
+        // Reasoning effort — priority: explicit reasoning > model suffix > default (low)
+        const reasoningEffort = (req as unknown as { reasoning_effort?: string }).reasoning_effort;
+        if (!body.reasoning) {
+            const effort = normalizeReasoningEffortLocal(body.model, reasoningEffort || modelEffort || "low");
+            body.reasoning = { effort, summary: "auto" };
+        } else {
+            body.reasoning.effort = normalizeReasoningEffortLocal(body.model, body.reasoning.effort);
+            if (!body.reasoning.summary) body.reasoning.summary = "auto";
+        }
+
+        // Include reasoning encrypted content (required by Codex backend for reasoning models)
+        if (body.reasoning && body.reasoning.effort && body.reasoning.effort !== "none") {
+            body.include = ["reasoning.encrypted_content"];
+        }
+
+        // Remove unsupported params
+        delete (body as Record<string, unknown>).temperature;
+        delete (body as Record<string, unknown>).top_p;
+        delete (body as Record<string, unknown>).frequency_penalty;
+        delete (body as Record<string, unknown>).presence_penalty;
+        delete (body as Record<string, unknown>).logprobs;
+        delete (body as Record<string, unknown>).top_logprobs;
+        delete (body as Record<string, unknown>).n;
+        delete (body as Record<string, unknown>).seed;
+        delete (body as Record<string, unknown>).max_tokens;
+        delete (body as Record<string, unknown>).max_completion_tokens;
+        delete (body as Record<string, unknown>).max_output_tokens;
+        delete (body as Record<string, unknown>).user;
+        delete (body as Record<string, unknown>).prompt_cache_retention;
+        delete (body as Record<string, unknown>).metadata;
+        delete (body as Record<string, unknown>).stream_options;
+        delete (body as Record<string, unknown>).safety_identifier;
+        delete (body as Record<string, unknown>).previous_response_id;
+
+        if (body.service_tier === "fast") body.service_tier = "priority";
+        if (body.service_tier && body.service_tier !== "priority") delete body.service_tier;
+
+        // Final allowlist filter
+        const ALLOWLIST = new Set([
+            "model", "input", "instructions", "tools", "tool_choice", "stream", "store",
+            "reasoning", "service_tier", "include", "prompt_cache_key", "client_metadata", "text",
+        ]);
+        for (const k of Object.keys(body)) {
+            if (!ALLOWLIST.has(k)) delete (body as Record<string, unknown>)[k];
+        }
+
+        return body;
+    }
+
+    /**
+     * Peek first N bytes of SSE body to detect transient upstream errors.
+     * Returns { matched, message, accountFallback, replacementBody }.
+     */
+    private async peekSseTransientError(
+        response: Response,
+    ): Promise<{ matched: string | null; message: string | null; accountFallback: boolean; replacementBody: ReadableStream<Uint8Array> | null }> {
+        if (!response || !response.ok || !response.body) {
+            return { matched: null, message: null, accountFallback: false, replacementBody: null };
+        }
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        const chunks: Uint8Array[] = [];
+        let text = "";
+        let matched: string | null = null;
+        let accountFallback = false;
+        try {
+            while (text.length < SSE_PEEK_BYTES) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                chunks.push(value);
+                text += decoder.decode(value, { stream: true });
+                const lowerText = text.toLowerCase();
+                const accountHit = SSE_ACCOUNT_FALLBACK_PATTERNS.find((p) => lowerText.includes(p));
+                if (accountHit) {
+                    matched = accountHit;
+                    accountFallback = true;
+                    break;
+                }
+                const retryHit = SSE_RETRY_PATTERNS.find((p) => lowerText.includes(p));
+                if (retryHit) {
+                    matched = retryHit;
+                    break;
+                }
+                if (SSE_USER_OUTPUT_PATTERNS.some((p) => lowerText.includes(p))) break;
+            }
+        } catch {
+            // fall through
+        }
+
+        if (matched) {
+            try {
+                await reader.cancel();
+            } catch {
+                /* noop */
+            }
+            try {
+                reader.releaseLock();
+            } catch {
+                /* noop */
+            }
+            return { matched, message: extractSseErrorMessage(text, matched), accountFallback, replacementBody: null };
+        }
+
+        reader.releaseLock();
+
+        // Re-assemble stream: prefix chunks + remaining upstream body
+        const upstream = response.body;
+        let upstreamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+        const replacementBody = new ReadableStream<Uint8Array>({
+            start(controller) {
+                for (const c of chunks) controller.enqueue(c);
+                upstreamReader = upstream.getReader();
+            },
+            async pull(controller) {
+                if (!upstreamReader) {
+                    controller.close();
+                    return;
+                }
+                try {
+                    const { done, value } = await upstreamReader.read();
+                    if (done) {
+                        controller.close();
+                        return;
+                    }
+                    controller.enqueue(value);
+                } catch (e) {
+                    controller.error(e);
+                }
+            },
+            cancel(reason) {
+                try {
+                    void upstreamReader?.cancel(reason);
+                } catch {
+                    /* noop */
+                }
+            },
+        });
+        return { matched: null, message: null, accountFallback: false, replacementBody };
+    }
+
+    /**
+     * Parse 429 usage_limit_reached for precise resetsAtMs.
+     */
+    private parseError(status: number, bodyText: string): { status: number; message: string; resetsAtMs?: number } | null {
+        if (status === 429 && bodyText) {
+            try {
+                const json = JSON.parse(bodyText) as {
+                    error?: { type?: string; message?: string; resets_at?: number; resets_in_seconds?: number };
+                };
+                const err = json?.error;
+                if (err?.type === "usage_limit_reached") {
+                    const now = Date.now();
+                    let resetsAtMs: number | null = null;
+                    if (typeof err.resets_at === "number" && err.resets_at > 0) {
+                        const ms = err.resets_at * 1000;
+                        if (ms > now) resetsAtMs = ms;
+                    }
+                    if (!resetsAtMs && typeof err.resets_in_seconds === "number" && err.resets_in_seconds > 0) {
+                        resetsAtMs = now + err.resets_in_seconds * 1000;
+                    }
+                    if (resetsAtMs) {
+                        return { status: 429, message: err.message || bodyText, resetsAtMs };
+                    }
+                }
+            } catch {
+                /* fall through */
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Stream a Responses API SSE body, converting each event to a ChatCompletionChunk.
+     */
+    private async *streamResponses(body: ReadableStream<Uint8Array>, requestedModel: string): AsyncGenerator<ChatCompletionChunk, void, void> {
+        const state = createResponsesStreamState(requestedModel);
+        let pendingEvent = "";
+
+        for await (const line of streamLines(body)) {
+            // Handle both "data: {...}" and "event: ..." framing
+            if (line.startsWith("data:")) {
+                const jsonStr = parseDataLine(line);
+                if (jsonStr === null) continue;
+                try {
+                    const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+                    const eventType = (parsed.type as string) || pendingEvent || "response.output_text.delta";
+                    const chunk = responsesEventToChunk(eventType, parsed, state);
+                    if (chunk) yield chunk;
+                } catch {
+                    // ignore malformed JSON
+                }
+            } else if (line.startsWith("event:")) {
+                pendingEvent = line.slice(6).trim();
+            } else {
+                // Raw JSON line (no data: prefix)
+                try {
+                    const parsed = JSON.parse(line) as Record<string, unknown>;
+                    const eventType = (parsed.type as string) || pendingEvent || "response.output_text.delta";
+                    const chunk = responsesEventToChunk(eventType, parsed, state);
+                    if (chunk) yield chunk;
+                } catch {
+                    // ignore
+                }
+            }
+        }
+    }
+}
+
+function extractSseErrorMessage(text: string, fallback: string): string {
+    const exact = text?.match(/Selected model is at capacity\. Please try a different model\./i)?.[0];
+    if (exact) return exact;
+
+    for (const line of String(text || "").split(/\r?\n/)) {
+        if (!line.startsWith("data:")) continue;
+        const data = line.slice(5).trim();
+        if (!data || data === "[DONE]") continue;
+        try {
+            const message = findNestedMessage(JSON.parse(data));
+            if (message) return message;
+        } catch {
+            // ignore
+        }
+    }
+
+    return fallback || MODEL_CAPACITY_MESSAGE;
+}
+
+function findNestedMessage(value: unknown, depth = 0): string | null {
+    if (!value || depth > 6 || typeof value === "string") return null;
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const found = findNestedMessage(item, depth + 1);
+            if (found) return found;
+        }
+        return null;
+    }
+    if (typeof value !== "object") return null;
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.message === "string" && obj.message.trim()) return obj.message;
+    if (typeof (obj.error as { message?: unknown })?.message === "string" && (obj.error as { message: string }).message.trim()) {
+        return (obj.error as { message: string }).message;
+    }
+    if (typeof (obj.response as { error?: { message?: unknown } })?.error?.message === "string" && (obj.response as { error: { message: string } }).error.message.trim()) {
+        return (obj.response as { error: { message: string } }).error.message;
+    }
+    for (const child of Object.values(obj)) {
+        const found = findNestedMessage(child, depth + 1);
+        if (found) return found;
+    }
+    return null;
+}
+
+function normalizeReasoningEffortLocal(model: string, value?: string): string {
+    const supported = ["none", "minimal", "low", "medium", "high", "xhigh"];
+    if (value && supported.includes(value)) return value;
+    return "low";
+}
+
+// Accumulate streamed chunks into a non-streaming response (local copy to avoid circular import)
+function accumulateChunksLocal(chunks: ChatCompletionChunk[], model: string): ChatCompletionResponse {
+    let content = "";
+    const toolCallMap = new Map<number, { id: string; name: string; args: string }>();
+
+    for (const chunk of chunks) {
+        const delta = chunk.choices[0]?.delta;
+        if (!delta) continue;
+        if (typeof delta.content === "string") content += delta.content;
+        if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+                const idx = tc.index ?? 0;
+                const entry = toolCallMap.get(idx) || { id: "", name: "", args: "" };
+                if (tc.id) entry.id = tc.id;
+                if (tc.function?.name) entry.name = tc.function.name;
+                if (tc.function?.arguments) entry.args += tc.function.arguments;
+                toolCallMap.set(idx, entry);
+            }
+        }
+    }
+
+    const toolCalls = Array.from(toolCallMap.values()).map((entry) => ({
+        id: entry.id,
+        type: "function" as const,
+        function: { name: entry.name, arguments: entry.args },
+    }));
+
+    const finishReason = chunks.at(-1)?.choices[0]?.finish_reason ?? "stop";
+    const usage = [...chunks].reverse().find((c) => c.usage)?.usage;
+
+    return {
+        id: `chatcmpl-${Date.now()}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [
+            {
+                index: 0,
+                message: {
+                    role: "assistant",
+                    content: content || null,
+                    ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+                },
+                finish_reason: finishReason,
+            },
+        ],
+        ...(usage ? { usage } : {}),
+    };
+}

--- a/packages/executors/src/codex.ts
+++ b/packages/executors/src/codex.ts
@@ -123,7 +123,10 @@ export class CodexExecutor implements AIProvider {
         const token = this.accessToken || this.apiKey;
         if (!token) return [];
         try {
-            const res = await fetch(this.modelsUrl, {
+            // client_version query param is REQUIRED — without it the endpoint returns 400
+            const url = new URL(this.modelsUrl);
+            url.searchParams.set("client_version", CODEX_CLIENT_VERSION);
+            const res = await fetch(url.toString(), {
                 method: "GET",
                 headers: this.getHeaders({ Accept: "application/json" }),
             });

--- a/packages/executors/src/index.ts
+++ b/packages/executors/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./antigravity.js";
 export * from "./anthropic.js";
 export * from "./base.js";
+export * from "./codex.js";
 export * from "./commandcode.js";
 export * from "./openai.js";

--- a/packages/providers/src/oauth/base.ts
+++ b/packages/providers/src/oauth/base.ts
@@ -6,6 +6,8 @@ export interface OAuthTokenResponse {
     idToken?: string;
     expiresIn?: number;
     tokenType: string;
+    /** Optional ChatGPT/OpenAI account identifier (for multi-account binding) */
+    accountId?: string;
 }
 
 export interface PKCEPair {

--- a/packages/providers/src/oauth/openai.ts
+++ b/packages/providers/src/oauth/openai.ts
@@ -88,6 +88,8 @@ export class OpenAICodexOAuth {
             id_token?: string;
             expires_in?: number;
             token_type?: string;
+            chatgpt_account_id?: string;
+            account_id?: string;
         };
 
         return {
@@ -96,6 +98,7 @@ export class OpenAICodexOAuth {
             idToken: data.id_token,
             expiresIn: data.expires_in,
             tokenType: data.token_type ?? "Bearer",
+            accountId: data.chatgpt_account_id || data.account_id || extractAccountIdFromIdToken(data.id_token),
         };
     }
 
@@ -133,5 +136,26 @@ export class OpenAICodexOAuth {
             expiresIn: data.expires_in,
             tokenType: data.token_type ?? "Bearer",
         };
+    }
+}
+
+/**
+ * Extract ChatGPT account identifier from an id_token JWT payload.
+ * OpenAI id_tokens carry the account id in `sub` (e.g. "u_..." for ChatGPT).
+ */
+function extractAccountIdFromIdToken(idToken?: string): string | undefined {
+    if (!idToken || typeof idToken !== "string") return undefined;
+    const parts = idToken.split(".");
+    if (parts.length < 2) return undefined;
+    try {
+        // JWT payload is base64url-encoded JSON
+        const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf-8")) as {
+            sub?: string;
+            "https://api.openai.com/auth"?: { user_id?: string };
+            user_id?: string;
+        };
+        return payload["https://api.openai.com/auth"]?.user_id || payload.user_id || payload.sub;
+    } catch {
+        return undefined;
     }
 }

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./adapter.js";
 export * from "./commandcode.js";
 export * from "./gemini.js";
+export * from "./responses.js";
 export * from "./usage.js";

--- a/packages/translator/src/responses.ts
+++ b/packages/translator/src/responses.ts
@@ -1,0 +1,533 @@
+import type {
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    FinishReason,
+    ToolCall,
+} from "@srouter/types";
+
+// --- OpenAI Responses API translation helpers (port of 9router openai-responses) ---
+
+// Responses API allowlist — anything else is stripped to avoid upstream "routing_unsupported"
+const RESPONSES_BODY_ALLOWLIST = new Set([
+    "model",
+    "input",
+    "instructions",
+    "tools",
+    "tool_choice",
+    "stream",
+    "store",
+    "reasoning",
+    "service_tier",
+    "include",
+    "prompt_cache_key",
+    "client_metadata",
+    "text",
+]);
+
+// Hosted tool types that Codex/OpenAI Responses executes server-side
+const HOSTED_TOOL_TYPES = new Set([
+    "image_generation",
+    "web_search",
+    "web_search_preview",
+    "file_search",
+    "computer",
+    "computer_use_preview",
+    "code_interpreter",
+    "mcp",
+    "local_shell",
+    "tool_search",
+]);
+
+const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
+
+export interface ResponsesInputItem {
+    type?: string;
+    role?: string;
+    content?: Array<{ type: string; text?: string; image_url?: string | { url: string }; detail?: string }>;
+    id?: string;
+    name?: string;
+    call_id?: string;
+    arguments?: string;
+    output?: unknown;
+}
+
+export interface ResponsesRequestBody {
+    model: string;
+    input?: string | ResponsesInputItem[];
+    instructions?: string;
+    tools?: unknown[];
+    tool_choice?: unknown;
+    stream?: boolean;
+    store?: boolean;
+    reasoning?: { effort?: string; summary?: string };
+    include?: string[];
+    prompt_cache_key?: string;
+    [key: string]: unknown;
+}
+
+export interface ResponsesStreamState {
+    started: boolean;
+    chatId: string;
+    created: number;
+    toolCallIndex: number;
+    currentToolCallId: string | null;
+    usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number; prompt_tokens_details?: { cached_tokens?: number } };
+    finishReasonSent: boolean;
+    model: string;
+}
+
+function buildChunk(model: string, delta: Record<string, unknown>, finishReason: FinishReason = null): ChatCompletionChunk {
+    return {
+        id: `chatcmpl-${Date.now()}`,
+        object: "chat.completion.chunk",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [
+            {
+                index: 0,
+                delta: delta as ChatCompletionChunk["choices"][0]["delta"],
+                finish_reason: finishReason,
+            },
+        ],
+    };
+}
+
+function fallbackToolCallId(): string {
+    return `call_${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function computeFinishReason(state: ResponsesStreamState): FinishReason {
+    if (state.toolCallIndex > 0) return "tool_calls";
+    return "stop";
+}
+
+function buildUsage(promptTokens: number, completionTokens: number, totalTokens: number, cachedTokens?: number) {
+    return {
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: totalTokens,
+        ...(cachedTokens ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {}),
+    };
+}
+
+function flattenText(content: unknown): string {
+    if (content == null) return "";
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+        const parts: string[] = [];
+        for (const p of content) {
+            if (typeof p === "string") parts.push(p);
+            else if (p && typeof p === "object" && typeof (p as { text?: unknown }).text === "string") parts.push((p as { text: string }).text);
+        }
+        return parts.join("\n");
+    }
+    return String(content);
+}
+
+/**
+ * Convert a ChatCompletionRequest into a Responses API body suitable for Codex.
+ * Handles: messages → input items, system → developer role, tool flattening,
+ * reasoning effort mapping, unsupported param stripping.
+ */
+export function chatToResponsesBody(req: ChatCompletionRequest): ResponsesRequestBody {
+    const input: ResponsesInputItem[] = [];
+    const tools: unknown[] = [];
+
+    // Convert messages to Responses input items
+    for (const msg of req.messages) {
+        if (!msg || typeof msg !== "object") continue;
+        const role = msg.role;
+
+        if (role === "system") {
+            input.push({
+                type: "message",
+                role: "developer",
+                content: [{ type: "input_text", text: flattenText(msg.content) }],
+            });
+            continue;
+        }
+
+        if (role === "user") {
+            const parts = Array.isArray(msg.content)
+                ? msg.content.map((c) => {
+                    if (c.type === "image_url" && c.image_url) {
+                        const url = typeof c.image_url === "string" ? c.image_url : c.image_url.url;
+                        return { type: "input_image", image_url: url, detail: c.image_url?.detail ?? "auto" };
+                    }
+                    if (c.type === "text") return { type: "input_text", text: c.text ?? "" };
+                    return { type: "input_text", text: flattenText(c) };
+                })
+                : [{ type: "input_text", text: flattenText(msg.content) }];
+            input.push({ type: "message", role: "user", content: parts });
+            continue;
+        }
+
+        if (role === "assistant") {
+            // Assistant message with tool_calls
+            if (Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+                for (const tc of msg.tool_calls) {
+                    input.push({
+                        type: "function_call",
+                        call_id: tc.id,
+                        name: tc.function.name,
+                        arguments: tc.function.arguments || "",
+                    });
+                }
+                continue;
+            }
+            const text = flattenText(msg.content);
+            if (text) {
+                input.push({
+                    type: "message",
+                    role: "assistant",
+                    content: [{ type: "output_text", text }],
+                });
+            }
+            continue;
+        }
+
+        if (role === "tool") {
+            input.push({
+                type: "function_call_output",
+                call_id: msg.tool_call_id || "",
+                output: flattenText(msg.content),
+            });
+            continue;
+        }
+    }
+
+    // Empty input fallback (Codex rejects empty input)
+    if (input.length === 0) {
+        input.push({
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "..." }],
+        });
+    }
+
+    // Convert tools to Responses flat format
+    if (Array.isArray(req.tools)) {
+        const validNames = new Set<string>();
+        for (const tool of req.tools) {
+            if (!tool || typeof tool !== "object") continue;
+            const type = (tool as { type?: string }).type ?? "";
+            if (type === "function") {
+                const fn = (tool as { function?: { name?: string; description?: string; parameters?: unknown } }).function ?? {};
+                const name = (fn.name || "").trim();
+                if (!name) continue;
+                validNames.add(name);
+                tools.push({
+                    type: "function",
+                    name: name.slice(0, 128),
+                    description: fn.description || "",
+                    parameters: fn.parameters || { type: "object", properties: {} },
+                });
+            } else if (type === "namespace") {
+                tools.push(tool); // passthrough namespace (contains nested tools)
+            } else if (!type || type === "custom") {
+                tools.push(tool); // passthrough custom
+            } else if (HOSTED_TOOL_TYPES.has(type)) {
+                tools.push(tool); // hosted tool passthrough
+            }
+        }
+        if (tools.length === 0) delete (tools as unknown as { length?: number })?.length;
+    }
+
+    const body: ResponsesRequestBody = {
+        model: req.model,
+        input,
+        stream: true,
+        store: false,
+    };
+
+    // Extract instructions from system message (we converted to developer above, but
+    // keep explicit instructions if the request carries top-level text)
+    if (req.messages.some((m) => m.role === "system")) {
+        const sys = req.messages.find((m) => m.role === "system");
+        if (sys) body.instructions = flattenText(sys.content);
+    }
+
+    if (tools.length > 0) body.tools = tools;
+
+    // Reasoning effort mapping (ChatCompletion has no native reasoning field, but
+    // some clients send it via extension or temperature=0 reasoning style)
+    const reasoningEffort = (req as unknown as { reasoning_effort?: string }).reasoning_effort;
+    if (reasoningEffort) {
+        body.reasoning = { effort: normalizeReasoningEffort(req.model, reasoningEffort), summary: "auto" };
+    } else if ((req as unknown as { reasoning?: { effort?: string } }).reasoning) {
+        body.reasoning = { effort: normalizeReasoningEffort(req.model, (req as unknown as { reasoning: { effort?: string } }).reasoning.effort), summary: "auto" };
+    }
+
+    return body;
+}
+
+function normalizeReasoningEffort(model: string, value?: string): string {
+    const supported = ["none", "minimal", "low", "medium", "high", "xhigh"];
+    if (value && supported.includes(value)) return value;
+    // Codex default is low/medium — map unknown to low (matches 9router default)
+    return "low";
+}
+
+/**
+ * Convert a single Responses API SSE event into an OpenAI ChatCompletionChunk.
+ * Returns null for events that produce no output.
+ */
+export function responsesEventToChunk(
+    eventType: string,
+    data: Record<string, unknown>,
+    state: ResponsesStreamState,
+): ChatCompletionChunk | null {
+    if (!state.started) {
+        state.started = true;
+        state.chatId = `chatcmpl-${Date.now()}`;
+        state.created = Math.floor(Date.now() / 1000);
+        state.toolCallIndex = 0;
+        state.currentToolCallId = null;
+    }
+
+    // Text content delta
+    if (eventType === "response.output_text.delta") {
+        const delta = (data.delta as string) || "";
+        if (!delta) return null;
+        return buildChunk(state.model, { content: delta });
+    }
+
+    // Function call started
+    if (eventType === "response.output_item.added") {
+        const item = data.item as { type?: string; call_id?: string; name?: string } | undefined;
+        if (item && (item.type === "function_call" || item.type === "custom_tool_call")) {
+            state.currentToolCallId = item.call_id || fallbackToolCallId();
+            return buildChunk(state.model, {
+                tool_calls: [
+                    {
+                        index: state.toolCallIndex,
+                        id: state.currentToolCallId,
+                        type: "function",
+                        function: { name: item.name || "", arguments: "" },
+                    },
+                ],
+            });
+        }
+        return null;
+    }
+
+    // Function call arguments delta
+    if (eventType === "response.function_call_arguments.delta" || eventType === "response.custom_tool_call_input.delta") {
+        const argsDelta = (data.delta as string) || "";
+        if (!argsDelta) return null;
+        return buildChunk(state.model, {
+            tool_calls: [{ index: state.toolCallIndex, function: { arguments: argsDelta } }],
+        });
+    }
+
+    // Function call done
+    if (eventType === "response.output_item.done") {
+        const item = data.item as { type?: string } | undefined;
+        if (item && (item.type === "function_call" || item.type === "custom_tool_call")) {
+            state.toolCallIndex++;
+        }
+        return null;
+    }
+
+    // Response completed — emit usage + finish
+    if (eventType === "response.completed" || eventType === "response.done") {
+        const responseUsage = data.response as {
+            usage?: {
+                input_tokens?: number;
+                prompt_tokens?: number;
+                output_tokens?: number;
+                completion_tokens?: number;
+                input_tokens_details?: { cached_tokens?: number };
+                cache_read_input_tokens?: number;
+            };
+        } | undefined;
+        if (responseUsage?.usage && typeof responseUsage.usage === "object") {
+            const u = responseUsage.usage;
+            const inputTokens = u.input_tokens || u.prompt_tokens || 0;
+            const outputTokens = u.output_tokens || u.completion_tokens || 0;
+            const cachedTokens = u.input_tokens_details?.cached_tokens || u.cache_read_input_tokens || 0;
+            state.usage = buildUsage(inputTokens, outputTokens, inputTokens + outputTokens, cachedTokens);
+        }
+
+        if (!state.finishReasonSent) {
+            state.finishReasonSent = true;
+            const finishReason = computeFinishReason(state);
+            const chunk = buildChunk(state.model, {}, finishReason);
+            if (state.usage) chunk.usage = state.usage;
+            return chunk;
+        }
+        return null;
+    }
+
+    return null;
+}
+
+export function createResponsesStreamState(model: string): ResponsesStreamState {
+    return {
+        started: false,
+        chatId: "",
+        created: 0,
+        toolCallIndex: 0,
+        currentToolCallId: null,
+        finishReasonSent: false,
+        model,
+    };
+}
+
+// Accumulate streamed OpenAI chunks into a single non-streaming ChatCompletionResponse.
+export function accumulateResponsesChunks(chunks: ChatCompletionChunk[], model: string): ChatCompletionResponse {
+    let content = "";
+    const toolCalls: ToolCall[] = [];
+    const toolCallMap = new Map<number, { id: string; name: string; args: string }>();
+
+    for (const chunk of chunks) {
+        const delta = chunk.choices[0]?.delta;
+        if (!delta) continue;
+        if (typeof delta.content === "string") content += delta.content;
+        if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+                const idx = tc.index ?? 0;
+                const entry = toolCallMap.get(idx) || { id: "", name: "", args: "" };
+                if (tc.id) entry.id = tc.id;
+                if (tc.function?.name) entry.name = tc.function.name;
+                if (tc.function?.arguments) entry.args += tc.function.arguments;
+                toolCallMap.set(idx, entry);
+            }
+        }
+    }
+
+    for (const entry of toolCallMap.values()) {
+        toolCalls.push({
+            id: entry.id,
+            type: "function",
+            function: { name: entry.name, arguments: entry.args },
+        });
+    }
+
+    const finishReason: FinishReason = chunks.at(-1)?.choices[0]?.finish_reason ?? "stop";
+    const usage = [...chunks].reverse().find((c) => c.usage)?.usage;
+
+    return {
+        id: `chatcmpl-${Date.now()}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [
+            {
+                index: 0,
+                message: {
+                    role: "assistant",
+                    content: content || null,
+                    ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+                },
+                finish_reason: finishReason,
+            },
+        ],
+        ...(usage ? { usage } : {}),
+    };
+}
+
+// --- Input normalization helpers (port of 9router responsesApi.js) ---
+
+/**
+ * Normalize Responses API input to array format.
+ * Accepts string or array; returns array of message items.
+ * Empty array → placeholder (providers reject empty input).
+ */
+export function normalizeResponsesInput(input: string | ResponsesInputItem[] | undefined): ResponsesInputItem[] | null {
+    if (typeof input === "string") {
+        const text = input.trim() === "" ? "..." : input;
+        return [{ type: "message", role: "user", content: [{ type: "input_text", text }] }];
+    }
+    if (Array.isArray(input)) {
+        if (input.length === 0) {
+            return [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }];
+        }
+        return input;
+    }
+    return null;
+}
+
+/**
+ * Convert Responses API format back to chat completion format (for non-streaming fallback).
+ */
+export function convertResponsesApiFormat(body: ResponsesRequestBody): Record<string, unknown> {
+    if (!body.input) return body as unknown as Record<string, unknown>;
+
+    const result: Record<string, unknown> = { ...body, messages: [] as ChatMessage[] };
+    const messages: ChatMessage[] = [];
+
+    if (body.instructions) {
+        messages.push({ role: "system", content: body.instructions });
+    }
+
+    let currentAssistantMsg: ChatMessage | null = null;
+    let pendingToolResults: ChatMessage[] = [];
+
+    const inputItems = normalizeResponsesInput(body.input);
+    if (!inputItems) return body as unknown as Record<string, unknown>;
+
+    for (const item of inputItems) {
+        const itemType = item.type || (item.role ? "message" : null);
+
+        if (itemType === "message") {
+            if (currentAssistantMsg) {
+                messages.push(currentAssistantMsg);
+                currentAssistantMsg = null;
+            }
+            for (const tr of pendingToolResults) messages.push(tr);
+            pendingToolResults = [];
+
+            const content = Array.isArray(item.content)
+                ? item.content.map((c) => {
+                    if (c.type === "input_text" || c.type === "output_text") return { type: "text", text: c.text ?? "" };
+                    if (c.type === "input_image") {
+                        const url = typeof c.image_url === "string" ? c.image_url : c.image_url?.url || "";
+                        return { type: "image_url", image_url: { url, detail: c.detail || "auto" } };
+                    }
+                    return c;
+                })
+                : item.content;
+            messages.push({ role: (item.role as ChatMessage["role"]) || "user", content: content as ChatMessage["content"] });
+        } else if (itemType === "function_call") {
+            if (!currentAssistantMsg) {
+                currentAssistantMsg = { role: "assistant", content: null, tool_calls: [] };
+            }
+            if (!item.name || typeof item.name !== "string" || item.name.trim() === "") continue;
+            currentAssistantMsg.tool_calls?.push({
+                id: item.call_id || "",
+                type: "function",
+                function: {
+                    name: item.name,
+                    arguments: typeof item.arguments === "string" ? item.arguments : JSON.stringify(item.arguments ?? ""),
+                },
+            });
+        } else if (itemType === "function_call_output") {
+            if (currentAssistantMsg) {
+                messages.push(currentAssistantMsg);
+                currentAssistantMsg = null;
+            }
+            pendingToolResults.push({
+                role: "tool",
+                tool_call_id: item.call_id || "",
+                content: typeof item.output === "string" ? item.output : JSON.stringify(item.output ?? ""),
+            });
+        }
+        // reasoning items skipped
+    }
+
+    if (currentAssistantMsg) messages.push(currentAssistantMsg);
+    for (const tr of pendingToolResults) messages.push(tr);
+
+    result.messages = messages;
+    delete result.input;
+    delete result.instructions;
+    delete result.include;
+    delete result.prompt_cache_key;
+    delete result.store;
+    delete result.reasoning;
+
+    return result;
+}

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -39,6 +39,7 @@ export interface ProviderConfig {
     apiKey?: string;
     accessToken?: string;
     refreshToken?: string;
+    accountId?: string;
     customHeaders?: Record<string, string>;
     enabled: boolean;
     createdAt: number;


### PR DESCRIPTION
## Summary

- Port OpenAI Codex executor dari 9Router ke SRouter: Responses API (`chatgpt.com/backend-api/codex/responses`) + SSE streaming
- Tambah translator Responses API (chat-completion ↔ responses format, SSE → chunk converter)
- Wiring penuh: OAuth callback, token import, DB `account_id` (multi-account binding), live model listing

## Motivation

9Router punya Codex executor lengkap (Responses API, retry SSE, refresh token, account binding) — SRouter cuma punya OAuth PKCE + generic OpenAI executor (chat/completions ke api.openai.com) yang nggak support akun ChatGPT. Port ini bikin akun ChatGPT/Codex bisa dipake langsung di SRouter.

## Changes

- **`packages/executors/src/codex.ts`** (baru): `CodexExecutor` — Responses API + SSE, default instructions injection, reasoning effort mapping, unsupported param stripping, SSE transient-error retry (`server_is_overloaded` / `model_at_capacity`), `usage_limit_reached` resetsAt parsing, `listModels` dari `/codex/models` (wajib `client_version` query param)
- **`packages/translator/src/responses.ts`** (baru): `chatToResponsesBody`, `responsesEventToChunk`, `accumulateResponsesChunks`, `normalizeResponsesInput`, `convertResponsesApiFormat`
- **DB**: kolom `account_id` baru di `providers` (multi-account binding via `ChatGPT-Account-ID`)
- **OAuth**: parse account ID dari id_token JWT; `processOAuthCallback` & `processTokenImport` pake `CodexExecutor`
- **Registry**: `openai_codex` → `CodexExecutor` (round-robin antar account udah support)
- **Fix**: rename `AntigravityProvider` → `AntigravityExecutor` (upstream rename)

## Test Plan

- [x] Unit test translator (25 assertions): body translation, SSE parsing, tool calls, accumulate
- [x] Unit test executor stream (mock fetch): transform request, SSE → chunks, usage
- [x] Live OAuth login end-to-end: PKCE → auth.openai.com → callback → token + refresh + accountId ke DB
- [x] Live chat non-streaming (`openai/gpt-5.5` → "Halo! Senang bisa membantu.")
- [x] Live chat streaming (SSE delta chunks + usage + `[DONE]`)
- [x] Live multi-account: import token akun ke-2 → round-robin load balancing (5× 200 akun valid, 1× 401 akun fake)
- [x] `listModels` live: gpt-5.5, gpt-5.4, gpt-5.4-mini, codex-auto-review

## Notes for Reviewers

- Port ini simplified dari 9Router: retry dipertahankan, tapi image prefetch base64 belum (butuh helper fetchImageAsBase64). Refresh token flow disimpan tapi belum ada auto-refresh scheduler (masih ke-load dari DB di startup).
- Endpoint `/codex/models` butuh `client_version` — tanpa itu 400.
- Sisa error tsc di `providers.controller.ts` & `providers.logic.ts` pre-existing upstream (bukan dari PR ini).