### PR TITLE
feat(antigravity): upgrade executor from 9Router — IDE envelope + native SSE + retry + tools

### DIFF
--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -198,7 +198,9 @@ export class AuthLogic {
         const accountId = `antigravity_${timestamp}`;
         const accountName = `Antigravity (Account #${timestamp.toString().slice(-4)})`;
         const token = tokens.accessToken || "";
-        const baseUrl = process.env.ANTIGRAVITY_BASE_URL || "https://generativelanguage.googleapis.com/v1beta/openai";
+        // Antigravity IDE backend (daily-cloudcode-pa) — NOT the Gemini public endpoint.
+        // The IDE envelope (project/requestId/sessionId) is only accepted by the IDE host.
+        const baseUrl = process.env.ANTIGRAVITY_BASE_URL || "https://daily-cloudcode-pa.googleapis.com";
 
         const providerConfig = upsertProviderDB({
             id: accountId,
@@ -228,7 +230,7 @@ export class AuthLogic {
         const timestamp = Date.now();
         const accountId = params.id || `antigravity_${timestamp}`;
         const providerName = params.name || `Antigravity (Account #${timestamp.toString().slice(-4)})`;
-        const baseUrl = params.baseUrl || process.env.ANTIGRAVITY_BASE_URL || "https://generativelanguage.googleapis.com/v1beta/openai";
+        const baseUrl = params.baseUrl || process.env.ANTIGRAVITY_BASE_URL || "https://daily-cloudcode-pa.googleapis.com";
 
         const providerConfig = upsertProviderDB({
             id: accountId,

--- a/packages/executors/src/antigravity.ts
+++ b/packages/executors/src/antigravity.ts
@@ -1,5 +1,27 @@
-import type { AIProvider, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ModelObject } from "@srouter/types";
+import type {
+    AIProvider,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ModelObject,
+} from "@srouter/types";
+import {
+    ANTIGRAVITY_IDE_BASE_URL,
+    ANTIGRAVITY_IDE_USER_AGENT,
+    buildAntigravityEnvelope,
+    buildGeminiContents,
+    buildGeminiStreamUrl,
+    cleanJSONSchemaForAntigravity,
+    createGeminiStreamState,
+    generateProjectId,
+    generateSessionId,
+    geminiStreamToOpenAIChunks,
+    parseGeminiResponse,
+    sanitizeFunctionName,
+    type GeminiContent,
+} from "@srouter/translator";
 import { OpenAIExecutor } from "./openai.js";
+import { parseDataLine, streamLines } from "./base.js";
 
 export interface AntigravityExecutorOptions {
     id?: string;
@@ -7,35 +29,107 @@ export interface AntigravityExecutorOptions {
     baseUrl?: string;
     apiKey?: string;
     accessToken?: string;
+    refreshToken?: string;
+    projectId?: string;
 }
 
+const MAX_RETRY_AFTER_MS = 10000;
+const ANTIGRAVITY_TRANSIENT_RETRY_MAX_MS = 15000;
+const MAX_ANTIGRAVITY_OUTPUT_TOKENS = 64000;
+
+const ANTIGRAVITY_TRANSIENT_ERROR_PATTERNS = [
+    /high\s+traffic/i,
+    /agent\s+(execution\s+)?terminated\s+due\s+to\s+error/i,
+    /capacity/i,
+    /temporarily\s+unavailable/i,
+    /timeout/i,
+    /stream\s+(ended|closed|terminated|interrupted)/i,
+    /empty\s+response/i,
+];
+
+const ANTIGRAVITY_TRANSIENT_STATUSES = new Set([500, 502, 503, 504]);
+
+// Fields Google generateContent rejects (Claude/OpenAI/Qwen thinking fields)
+const ANTIGRAVITY_REQUEST_BLACKLIST = [
+    "output_config",
+    "thinking",
+    "reasoning_effort",
+    "reasoning",
+    "enable_thinking",
+    "thinking_budget",
+    "thinkingConfig",
+];
+
+const stripBlacklisted = (obj: Record<string, unknown>): void => {
+    for (const key of ANTIGRAVITY_REQUEST_BLACKLIST) delete obj[key];
+};
+
+// Image generation model name patterns
+const IMAGE_MODEL_PATTERNS = [/image/i, /imagen/i, /image-generation/i];
+
+function isImageModel(model: string): boolean {
+    return IMAGE_MODEL_PATTERNS.some((p) => p.test(model));
+}
+
+// Parse aspect ratio / resolution from model name suffixes
+function parseImageConfig(model: string): Record<string, string> {
+    const config: Record<string, string> = { aspectRatio: "1:1" };
+    const resMatch = model.match(/(\d+)x(\d+)$/);
+    if (resMatch) {
+        const w = parseInt(resMatch[1]);
+        const h = parseInt(resMatch[2]);
+        if (w <= 16 && h <= 16) {
+            config.aspectRatio = `${w}:${h}`;
+        } else {
+            const gcd = (a: number, b: number): number => (b ? gcd(b, a % b) : a);
+            const d = gcd(w, h);
+            config.aspectRatio = `${w / d}:${h / d}`;
+        }
+    }
+    return config;
+}
+
+/**
+ * Antigravity Executor — Google Antigravity IDE backend (daily-cloudcode-pa).
+ * Ported from 9router open-sse/executors/antigravity.js (envelope + native SSE + retry).
+ * Falls back to OpenAI-compatible endpoint for local proxy / AIzaSy API keys.
+ */
 export class AntigravityExecutor implements AIProvider {
     id: string;
     name: string;
+    category = "oauth" as const;
+    protocol = "openai" as const;
     private baseUrl: string;
     private apiKey: string;
     private accessToken: string;
+    private refreshToken?: string;
+    private projectId: string;
+    private sessionId: string;
     private openaiFallback: OpenAIExecutor;
 
     constructor(options: AntigravityExecutorOptions = {}) {
         this.id = options.id ?? "antigravity";
         this.name = options.name ?? "Antigravity Provider";
-        this.baseUrl = (options.baseUrl ?? "https://generativelanguage.googleapis.com/v1beta").replace(/\/$/, "");
+        this.baseUrl = (options.baseUrl ?? process.env.ANTIGRAVITY_BASE_URL ?? ANTIGRAVITY_IDE_BASE_URL).replace(/\/$/, "");
         this.apiKey = options.apiKey ?? process.env.ANTIGRAVITY_API_KEY ?? "";
         this.accessToken = options.accessToken ?? process.env.ANTIGRAVITY_ACCESS_TOKEN ?? "";
+        this.refreshToken = options.refreshToken;
+        this.projectId = options.projectId ?? process.env.ANTIGRAVITY_PROJECT_ID ?? generateProjectId();
+        this.sessionId = generateSessionId();
 
         this.openaiFallback = new OpenAIExecutor({
             id: this.id,
             name: this.name,
             baseUrl: options.baseUrl || "https://generativelanguage.googleapis.com/v1beta/openai",
-            apiKey: this.apiKey,
+            apiKey: options.apiKey,
             accessToken: this.accessToken,
         });
     }
 
-    private getHeaders(): Record<string, string> {
+    private getHeaders(extra?: Record<string, string>): Record<string, string> {
         const headers: Record<string, string> = {
             "Content-Type": "application/json",
+            "User-Agent": ANTIGRAVITY_IDE_USER_AGENT,
         };
         const token = this.accessToken || this.apiKey;
         if (token) {
@@ -43,24 +137,44 @@ export class AntigravityExecutor implements AIProvider {
             if (token.startsWith("AIzaSy")) {
                 headers["x-goog-api-key"] = token;
             } else if (token.startsWith("ya29.")) {
-                headers["User-Agent"] = "Antigravity/1.0 (VSCode)";
                 headers["x-goog-api-client"] = "gl-node/18.0.0 gd/1.0.0";
             }
+        }
+        if (extra) {
+            Object.assign(headers, extra);
         }
         return headers;
     }
 
-    async listModels(): Promise<ModelObject[]> {
+    private isLocalProxy(): boolean {
+        return /^https?:\/\/127\.0\.0\.1(:\d+)?(\/|$)/.test(this.baseUrl) || /^https?:\/\/localhost(:\d+)?(\/|$)/.test(this.baseUrl);
+    }
+
+    private isApiKey(): boolean {
         const token = this.accessToken || this.apiKey;
-        const isLocalProxy = /^https?:\/\/127\.0\.0\.1(:\d+)?(\/|$)/.test(this.baseUrl) || /^https?:\/\/localhost(:\d+)?(\/|$)/.test(this.baseUrl);
-        const isApiKey = token.startsWith("AIzaSy");
+        return token.startsWith("AIzaSy");
+    }
+
+    private isYa29(): boolean {
+        const token = this.accessToken || this.apiKey;
+        return token.startsWith("ya29.");
+    }
+
+    private getToken(): string {
+        return this.accessToken || this.apiKey;
+    }
+
+    async listModels(): Promise<ModelObject[]> {
+        const token = this.getToken();
+        const isLocalProxy = this.isLocalProxy();
+        const isApiKey = this.isApiKey();
 
         // 1. OpenAI-compatible endpoint (local proxy or AIzaSy key on /openai base)
         if (isLocalProxy || (isApiKey && this.baseUrl.includes("/openai"))) {
             return await this.openaiFallback.listModels();
         }
 
-        // 2. Native Gemini models endpoint (https://generativelanguage.googleapis.com/v1beta/models)
+        // 2. Native Gemini models endpoint
         const cleanBaseUrl = this.baseUrl.replace(/\/openai$/, "");
         const baseId = this.id.split("_")[0]?.split("-")[0] ?? this.id;
         const models: ModelObject[] = [];
@@ -102,7 +216,7 @@ export class AntigravityExecutor implements AIProvider {
                     headers: {
                         Authorization: `Bearer ${token}`,
                         "Content-Type": "application/json",
-                        "User-Agent": "Antigravity/1.0 (VSCode)",
+                        "User-Agent": ANTIGRAVITY_IDE_USER_AGENT,
                         "x-goog-api-client": "gl-node/18.0.0 gd/1.0.0",
                     },
                     body: JSON.stringify({}),
@@ -126,148 +240,368 @@ export class AntigravityExecutor implements AIProvider {
     }
 
     private parseModelName(rawModel: string): string {
-        let model = rawModel.includes("/") ? (rawModel.split("/")[1] ?? rawModel) : rawModel;
-        if (model === "gemini-3.6-flash" || model === "gemini-3.5-flash" || model === "gemini-2.0-flash") {
-            model = "gemini-2.5-flash";
+        // Strip any {alias}/ or {providerId}/ prefix — keep the real model id
+        return rawModel.includes("/") ? (rawModel.split("/")[1] ?? rawModel) : rawModel;
+    }
+
+    /**
+     * Build the Antigravity request envelope + sanitized request body.
+     * Port of 9router transformRequest (standard agent request path).
+     */
+    private buildRequest(model: string, req: ChatCompletionRequest, stream: boolean): { url: string; body: Record<string, unknown> } {
+        const cleanBaseUrl = this.baseUrl.replace(/\/openai$/, "");
+        const modelName = this.parseModelName(model);
+
+        // Build contents (with tool support)
+        const contents = this.buildContentsWithTools(req);
+
+        // ─── Image generation: different request structure ───
+        if (isImageModel(modelName)) {
+            const imageConfig = parseImageConfig(modelName);
+            const cleanModel = modelName.replace(/-\d+x\d+$/, "");
+            const request: Record<string, unknown> = {
+                contents,
+                generationConfig: {
+                    temperature: 1.0,
+                    topP: 0.95,
+                    topK: 40,
+                    maxOutputTokens: 8192,
+                    imageConfig,
+                },
+                sessionId: this.sessionId,
+            };
+            const envelope = buildAntigravityEnvelope({
+                projectId: this.projectId,
+                model: cleanModel,
+                requestType: "image_gen",
+                request,
+                body: req as unknown as { requestId?: string },
+                sessionId: this.sessionId,
+            });
+            // Image gen MUST use non-streaming generateContent
+            const url = `${cleanBaseUrl}/v1internal:generateContent`;
+            return { url, body: envelope };
         }
-        return model;
+
+        // ─── Standard request ───
+        const tools = this.buildTools(req);
+
+        const request: Record<string, unknown> = {
+            contents,
+            sessionId: this.sessionId,
+            safetySettings: undefined,
+        };
+        if (tools.length > 0) {
+            request.tools = tools;
+            request.toolConfig = { functionCallingConfig: { mode: "VALIDATED" } };
+        }
+
+        stripBlacklisted(request);
+
+        const envelope = buildAntigravityEnvelope({
+            projectId: this.projectId,
+            model: modelName,
+            requestType: "agent",
+            request,
+            body: req as unknown as { requestId?: string },
+            sessionId: this.sessionId,
+        });
+
+        const url = stream
+            ? `${cleanBaseUrl}/v1internal:streamGenerateContent?alt=sse`
+            : `${cleanBaseUrl}/v1internal:generateContent`;
+
+        return { url, body: envelope };
+    }
+
+    /**
+     * Build Gemini contents from ChatCompletionRequest messages, mapping tools.
+     */
+    private buildContentsWithTools(req: ChatCompletionRequest): GeminiContent[] {
+        const contents: GeminiContent[] = [];
+        for (const m of req.messages) {
+            const role = m.role === "assistant" ? "model" : "user";
+            const parts: GeminiContent["parts"] = [];
+
+            if (m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+                for (const tc of m.tool_calls) {
+                    let args: Record<string, unknown> = {};
+                    try {
+                        args = JSON.parse(tc.function.arguments || "{}");
+                    } catch {
+                        args = { raw: tc.function.arguments };
+                    }
+                    parts.push({
+                        text: "",
+                        functionCall: { name: tc.function.name, args },
+                    });
+                }
+            } else if (m.role === "tool" && m.tool_call_id) {
+                parts.push({
+                    text: "",
+                    functionResponse: { name: m.tool_call_id, response: { result: typeof m.content === "string" ? m.content : JSON.stringify(m.content) } },
+                });
+            } else {
+                const text = typeof m.content === "string" ? m.content : Array.isArray(m.content) ? m.content.map((c) => (c.type === "text" ? c.text || "" : "")).join("\n") : String(m.content ?? "");
+                if (text) parts.push({ text });
+            }
+
+            if (parts.length === 0) parts.push({ text: "" });
+            contents.push({ role, parts });
+        }
+        if (contents.length === 0) {
+            contents.push({ role: "user", parts: [{ text: "..." }] });
+        }
+        return contents;
+    }
+
+    /**
+     * Build Gemini tools array from ChatCompletionRequest tools, sanitizing names + schemas.
+     */
+    private buildTools(req: ChatCompletionRequest): Array<Record<string, unknown>> {
+        if (!Array.isArray(req.tools) || req.tools.length === 0) return [];
+        const declarations: Array<Record<string, unknown>> = [];
+        const seenNames = new Set<string>();
+        for (const tool of req.tools) {
+            if (!tool || typeof tool !== "object") continue;
+            const type = (tool as { type?: string }).type;
+            if (type !== "function") continue;
+            const fn = (tool as { function?: { name?: string; description?: string; parameters?: unknown } }).function;
+            if (!fn) continue;
+            const name = sanitizeFunctionName(fn.name || "");
+            if (seenNames.has(name)) continue;
+            seenNames.add(name);
+            declarations.push({
+                name,
+                description: fn.description || "",
+                parameters: fn.parameters ? cleanJSONSchemaForAntigravity(structuredClone(fn.parameters)) : { type: "object", properties: { reason: { type: "string", description: "Brief explanation" } }, required: ["reason"] },
+            });
+        }
+        return declarations.length > 0 ? [{ functionDeclarations: declarations }] : [];
+    }
+
+    /**
+     * Build the URL + body for the OpenAI-compatible fallback path (local proxy / AIzaSy).
+     */
+    private buildFallbackRequest(req: ChatCompletionRequest, stream: boolean): { url: string; body: unknown } {
+        const targetModel = req.model.includes("/") ? (req.model.split("/")[1] ?? req.model) : req.model;
+        const body = { ...req, model: targetModel, stream };
+        return { url: `${this.openaiFallback["baseUrl"]}/chat/completions`, body };
     }
 
     async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
-        const token = this.accessToken || this.apiKey;
-        const isLocalProxy = /^https?:\/\/127\.0\.0\.1(:\d+)?(\/|$)/.test(this.baseUrl) || /^https?:\/\/localhost(:\d+)?(\/|$)/.test(this.baseUrl);
-        const isApiKey = token.startsWith("AIzaSy");
+        const token = this.getToken();
+        const isLocalProxy = this.isLocalProxy();
+        const isApiKey = this.isApiKey();
 
-        // 1. Only use openaiFallback if token is AIzaSy API key or connecting to local proxy
+        // 1. OpenAI-compatible fallback
         if (isLocalProxy || (isApiKey && this.baseUrl.includes("/openai"))) {
             return await this.openaiFallback.chatCompletion(req);
         }
 
-        // 2. For Google OAuth ya29... tokens, use Native Gemini REST API
-        const cleanBaseUrl = this.baseUrl.replace(/\/openai$/, "");
-        const modelName = this.parseModelName(req.model);
-        const contents = req.messages.map((m) => ({
-            role: m.role === "assistant" ? "model" : "user",
-            parts: [{ text: typeof m.content === "string" ? m.content : JSON.stringify(m.content) }],
-        }));
-
-        interface CloudCodePayload {
-            model: string;
-            request: {
-                contents: Array<{ role: string; parts: Array<{ text: string }> }>;
-            };
+        // 2. Native Antigravity — accumulate stream for non-streaming callers
+        const chunks: ChatCompletionChunk[] = [];
+        for await (const chunk of this.chatCompletionStream(req)) {
+            chunks.push(chunk);
         }
-
-        interface GeminiNativePayload {
-            contents: Array<{ role: string; parts: Array<{ text: string }> }>;
-        }
-
-        let targetUrl: string;
-        let bodyPayload: CloudCodePayload | GeminiNativePayload;
-
-        if (token.startsWith("ya29.")) {
-            targetUrl = process.env.ANTIGRAVITY_BASE_URL || "https://cloudcode-pa.googleapis.com/v1internal:generateContent";
-            bodyPayload = {
-                model: modelName,
-                request: {
-                    contents,
-                },
-            };
-        } else {
-            const cleanBaseUrl = this.baseUrl.replace(/\/openai$/, "");
-            targetUrl = `${cleanBaseUrl}/models/${modelName}:generateContent`;
-            if (isApiKey) {
-                targetUrl += `?key=${token}`;
-            }
-            bodyPayload = { contents };
-        }
-
-        const res = await fetch(targetUrl, {
-            method: "POST",
-            headers: this.getHeaders(),
-            body: JSON.stringify(bodyPayload),
-        });
-
-        if (!res.ok) {
-            const errorText = await res.text();
-            throw new Error(`Antigravity Provider Error (${res.status}): ${errorText}`);
-        }
-
-        const data = (await res.json()) as {
-            candidates?: Array<{
-                content?: {
-                    parts?: Array<{ text?: string }>;
-                    role?: string;
-                };
-                finishReason?: string;
-            }>;
-            responses?: Array<{
-                candidates?: Array<{
-                    content?: {
-                        parts?: Array<{ text?: string }>;
-                        role?: string;
-                    };
-                }>;
-            }>;
-            response?: {
-                candidates?: Array<{
-                    content?: {
-                        parts?: Array<{ text?: string }>;
-                        role?: string;
-                    };
-                }>;
-            };
-        };
-
-        const textResponse = data.candidates?.[0]?.content?.parts?.[0]?.text ?? data.responses?.[0]?.candidates?.[0]?.content?.parts?.[0]?.text ?? data.response?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
-
-        return {
-            id: `chatcmpl-${Date.now()}`,
-            object: "chat.completion",
-            created: Math.floor(Date.now() / 1000),
-            model: req.model,
-            choices: [
-                {
-                    index: 0,
-                    message: {
-                        role: "assistant",
-                        content: textResponse,
-                    },
-                    finish_reason: "stop",
-                },
-            ],
-        };
+        return accumulateChunksLocal(chunks, req.model);
     }
 
     async *chatCompletionStream(req: ChatCompletionRequest): AsyncGenerator<ChatCompletionChunk, void, void> {
-        const token = this.accessToken || this.apiKey;
-        const isLocalProxy = /^https?:\/\/127\.0\.0\.1(:\d+)?(\/|$)/.test(this.baseUrl) || /^https?:\/\/localhost(:\d+)?(\/|$)/.test(this.baseUrl);
-        const isApiKey = token.startsWith("AIzaSy");
+        const token = this.getToken();
+        const isLocalProxy = this.isLocalProxy();
+        const isApiKey = this.isApiKey();
 
         if (isLocalProxy || (isApiKey && this.baseUrl.includes("/openai"))) {
             yield* this.openaiFallback.chatCompletionStream(req);
             return;
         }
 
-        const res = await this.chatCompletion(req);
-        const rawContent = res.choices[0]?.message.content;
-        const text = typeof rawContent === "string" ? rawContent : JSON.stringify(rawContent ?? "");
+        const { url, body } = this.buildRequest(req.model, req, true);
+        const streamUrl = url.includes("?") ? url : `${url}?alt=sse`;
+        const res = await this.fetchWithRetry(streamUrl, body);
 
-        yield {
-            id: res.id,
-            object: "chat.completion.chunk",
-            created: res.created,
-            model: req.model,
-            choices: [
-                {
-                    index: 0,
-                    delta: {
-                        role: "assistant",
-                        content: text,
-                    },
-                    finish_reason: "stop",
-                },
-            ],
-        };
+        if (!res.ok) {
+            const errorText = await res.text();
+            throw new Error(`Antigravity Provider Error (${res.status}): ${errorText}`);
+        }
+
+        if (!res.body) {
+            throw new Error("No response body received for streaming");
+        }
+
+        const state = createGeminiStreamState(req.model);
+        for await (const line of streamLines(res.body)) {
+            const jsonStr = parseDataLine(line);
+            if (jsonStr === null) continue;
+            try {
+                const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+                const chunks = geminiStreamToOpenAIChunks(parsed, state);
+                if (chunks) {
+                    for (const chunk of chunks) yield chunk;
+                }
+            } catch {
+                // ignore malformed JSON
+            }
+        }
     }
+
+    /**
+     * Fetch with retry/backoff for transient Antigravity errors.
+     * Port of 9router computeRetryDelay: Retry-After header → error message → transient patterns.
+     */
+    private async fetchWithRetry(url: string, body: Record<string, unknown>): Promise<Response> {
+        const maxAttempts = 3;
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            const res = await fetch(url, {
+                method: "POST",
+                headers: this.getHeaders(),
+                body: JSON.stringify(body),
+            });
+
+            if (res.ok) return res;
+
+            const retryMs = await this.computeRetryDelay(res, attempt);
+            if (!retryMs) return res;
+
+            await new Promise((r) => setTimeout(r, retryMs));
+        }
+        // Last attempt returns as-is
+        return fetch(url, {
+            method: "POST",
+            headers: this.getHeaders(),
+            body: JSON.stringify(body),
+        });
+    }
+
+    private parseRetryHeaders(headers: Headers): number | null {
+        const retryAfter = headers.get("retry-after");
+        if (retryAfter) {
+            const seconds = parseInt(retryAfter, 10);
+            if (!isNaN(seconds) && seconds > 0) return seconds * 1000;
+
+            const date = new Date(retryAfter);
+            if (!isNaN(date.getTime())) {
+                const diff = date.getTime() - Date.now();
+                return diff > 0 ? diff : null;
+            }
+        }
+
+        const resetAfter = headers.get("x-ratelimit-reset-after");
+        if (resetAfter) {
+            const seconds = parseInt(resetAfter, 10);
+            if (!isNaN(seconds) && seconds > 0) return seconds * 1000;
+        }
+
+        const resetTimestamp = headers.get("x-ratelimit-reset");
+        if (resetTimestamp) {
+            const ts = parseInt(resetTimestamp, 10) * 1000;
+            const diff = ts - Date.now();
+            return diff > 0 ? diff : null;
+        }
+
+        return null;
+    }
+
+    private parseRetryFromErrorMessage(errorMessage: string): number | null {
+        if (!errorMessage || typeof errorMessage !== "string") return null;
+        const match = errorMessage.match(/reset after (\d+h)?(\d+m)?(\d+s)?/i);
+        if (!match) return null;
+        let totalMs = 0;
+        if (match[1]) totalMs += parseInt(match[1]) * 3600 * 1000;
+        if (match[2]) totalMs += parseInt(match[2]) * 60 * 1000;
+        if (match[3]) totalMs += parseInt(match[3]) * 1000;
+        return totalMs > 0 ? totalMs : null;
+    }
+
+    private extractErrorMessage(errorJson: unknown, bodyText = ""): string {
+        const parts: string[] = [];
+        const err = errorJson as { error?: { message?: unknown }; message?: unknown } | null;
+        if (err?.error?.message) parts.push(String(err.error.message));
+        if (err?.message) parts.push(String(err.message));
+        if (err?.error) parts.push(typeof err.error === "string" ? err.error : JSON.stringify(err.error));
+        if (bodyText) parts.push(bodyText);
+        return parts.filter(Boolean).join("\n");
+    }
+
+    private isTransientAntigravityError(status: number, message: string): boolean {
+        if (status === 429) return true;
+        if (ANTIGRAVITY_TRANSIENT_STATUSES.has(status)) return true;
+        return ANTIGRAVITY_TRANSIENT_ERROR_PATTERNS.some((pattern) => pattern.test(message || ""));
+    }
+
+    private async computeRetryDelay(response: Response, attempt: number): Promise<number | null> {
+        let bodyText = "";
+        let errorJson: unknown = null;
+        let retryMs = this.parseRetryHeaders(response.headers);
+
+        try {
+            bodyText = await response.clone().text();
+            errorJson = bodyText ? JSON.parse(bodyText) : null;
+        } catch {
+            // ignore parse errors
+        }
+
+        const errorMessage = this.extractErrorMessage(errorJson, bodyText);
+
+        if (!retryMs) {
+            retryMs = this.parseRetryFromErrorMessage(errorMessage);
+        }
+        if (retryMs) return retryMs <= MAX_RETRY_AFTER_MS ? retryMs : null;
+
+        if (!this.isTransientAntigravityError(response.status, errorMessage)) return null;
+
+        const cap = response.status === 429 ? MAX_RETRY_AFTER_MS : ANTIGRAVITY_TRANSIENT_RETRY_MAX_MS;
+        return Math.min(1000 * (2 ** attempt), cap);
+    }
+}
+
+// Accumulate streamed chunks into a non-streaming response
+function accumulateChunksLocal(chunks: ChatCompletionChunk[], model: string): ChatCompletionResponse {
+    let content = "";
+    const toolCallMap = new Map<number, { id: string; name: string; args: string }>();
+
+    for (const chunk of chunks) {
+        const delta = chunk.choices[0]?.delta;
+        if (!delta) continue;
+        if (typeof delta.content === "string") content += delta.content;
+        if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+                const idx = tc.index ?? 0;
+                const entry = toolCallMap.get(idx) || { id: "", name: "", args: "" };
+                if (tc.id) entry.id = tc.id;
+                if (tc.function?.name) entry.name = tc.function.name;
+                if (tc.function?.arguments) entry.args += tc.function.arguments;
+                toolCallMap.set(idx, entry);
+            }
+        }
+    }
+
+    const toolCalls = Array.from(toolCallMap.values()).map((entry) => ({
+        id: entry.id,
+        type: "function" as const,
+        function: { name: entry.name, arguments: entry.args },
+    }));
+
+    const finishReason = chunks.at(-1)?.choices[0]?.finish_reason ?? "stop";
+    const usage = [...chunks].reverse().find((c) => c.usage)?.usage;
+
+    return {
+        id: `chatcmpl-${Date.now()}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [
+            {
+                index: 0,
+                message: {
+                    role: "assistant",
+                    content: content || null,
+                    ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+                },
+                finish_reason: finishReason,
+            },
+        ],
+        ...(usage ? { usage } : {}),
+    };
 }

--- a/packages/translator/src/gemini.ts
+++ b/packages/translator/src/gemini.ts
@@ -1,7 +1,13 @@
-import type { ChatCompletionRequest, ChatCompletionResponse } from "@srouter/types";
+import type { ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse } from "@srouter/types";
+import crypto from "node:crypto";
 
 export interface GeminiContentPart {
     text: string;
+    functionCall?: { name: string; args?: Record<string, unknown>; thoughtSignature?: string };
+    functionResponse?: { name: string; response?: Record<string, unknown> };
+    thought?: boolean;
+    thoughtSignature?: string;
+    inlineData?: { mimeType?: string; data?: string };
 }
 
 export interface GeminiContent {
@@ -100,4 +106,428 @@ export function geminiToOpenAIResponse(data: GeminiRawResponse, requestedModel: 
             },
         ],
     };
+}
+
+// ─── Antigravity IDE envelope helpers (port of 9router executors/antigravity.js) ───
+
+// Official Antigravity IDE Desktop 2.1.1 fingerprint (macOS arm64)
+export const ANTIGRAVITY_IDE_VERSION = "2.1.1";
+export const ANTIGRAVITY_IDE_BASE_URL = "https://daily-cloudcode-pa.googleapis.com";
+export const ANTIGRAVITY_IDE_USER_AGENT = `antigravity/ide/${ANTIGRAVITY_IDE_VERSION} darwin/arm64`;
+
+const MAX_ANTIGRAVITY_OUTPUT_TOKENS = 64000;
+
+export function generateProjectId(): string {
+    const adjectives = ["useful", "bright", "swift", "calm", "bold"];
+    const nouns = ["fuze", "wave", "spark", "flow", "core"];
+    const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
+    const noun = nouns[Math.floor(Math.random() * nouns.length)];
+    return `${adj}-${noun}-${crypto.randomUUID().slice(0, 5)}`;
+}
+
+export function generateSessionId(): string {
+    return crypto.randomUUID() + Date.now().toString();
+}
+
+function uuidFromSeed(seed: string): string {
+    const bytes = crypto.createHash("sha256").update(String(seed || "antigravity")).digest().subarray(0, 16);
+    bytes[6] = (bytes[6] & 0x0f) | 0x50;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = bytes.toString("hex");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+const ANTIGRAVITY_IDE_REQUEST_ID_RE = /^agent\/[^/]+\/\d+\/[^/]+\/\d+$/;
+
+export interface IdeRequestIdArgs {
+    body?: { requestId?: string };
+    request?: { sessionId?: string; contents?: unknown[] };
+    sessionId?: string;
+    model: string;
+    requestType: string;
+}
+
+/**
+ * Build an IDE-format requestId: agent/<conversation>/<timestamp>/<trajectory>/<step>.
+ * Antigravity backend validates this format — requests without it may be rejected.
+ */
+export function buildIdeRequestId({ body, request, sessionId, model, requestType }: IdeRequestIdArgs): string {
+    if (body?.requestId && ANTIGRAVITY_IDE_REQUEST_ID_RE.test(body.requestId)) {
+        return body.requestId;
+    }
+    const sid = request?.sessionId || sessionId || "anonymous";
+    const conversationId = uuidFromSeed(`antigravity:conversation:${sid}`);
+    const trajectoryId = uuidFromSeed(`antigravity:trajectory:${sid}:${model}:${requestType}`);
+    const contentCount = Array.isArray(request?.contents) ? request.contents.length : 1;
+    const step = Math.max(1, contentCount * 2 - 1);
+    return `agent/${conversationId}/${Date.now()}/${trajectoryId}/${step}`;
+}
+
+/**
+ * Build the Antigravity IDE envelope: { project, model, userAgent, requestType, requestId, request }.
+ * The daily-cloudcode host expects this envelope, not a bare generateContent call.
+ */
+export function buildAntigravityEnvelope(args: {
+    projectId: string;
+    model: string;
+    requestType: string;
+    request: Record<string, unknown>;
+    body?: { requestId?: string };
+    sessionId?: string;
+}): Record<string, unknown> {
+    const { projectId, model, requestType, request, body, sessionId } = args;
+    return {
+        project: projectId,
+        model,
+        userAgent: "antigravity",
+        requestType,
+        requestId: buildIdeRequestId({ body, request, sessionId, model, requestType }),
+        request,
+    };
+}
+
+export function buildGeminiStreamUrl(baseUrl: string, modelName: string): string {
+    return `${baseUrl}/v1internal:streamGenerateContent?alt=sse`;
+}
+
+// ─── Gemini JSON Schema cleanup for Antigravity (port of 9router formats/gemini.js) ───
+
+const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
+    "minLength", "maxLength", "exclusiveMinimum", "exclusiveMaximum",
+    "minItems", "maxItems", "format", "multipleOf",
+    "uniqueItems", "contains",
+    "unevaluatedProperties", "unevaluatedItems", "contentSchema",
+    "default", "examples",
+    "$schema", "$defs", "definitions", "const", "$ref", "$comment",
+    "deprecated", "readOnly", "writeOnly",
+    "additionalProperties", "propertyNames", "patternProperties", "enumDescriptions",
+    "anyOf", "oneOf", "allOf", "not",
+    "dependencies", "dependentSchemas", "dependentRequired",
+    "title", "optional", "if", "then", "else", "contentMediaType", "contentEncoding",
+    "cornerRadius", "fillColor", "fontFamily", "fontSize", "fontWeight",
+    "gap", "padding", "strokeColor", "strokeThickness", "textColor",
+];
+
+function removeUnsupportedKeywords(obj: unknown, keywords: string[]): void {
+    if (!obj || typeof obj !== "object") return;
+    if (Array.isArray(obj)) {
+        for (const item of obj) removeUnsupportedKeywords(item, keywords);
+        return;
+    }
+    for (const key of Object.keys(obj as Record<string, unknown>)) {
+        if (keywords.includes(key) || key.startsWith("x-")) {
+            delete (obj as Record<string, unknown>)[key];
+            continue;
+        }
+        const value = (obj as Record<string, unknown>)[key];
+        if (value && typeof value === "object") removeUnsupportedKeywords(value, keywords);
+    }
+}
+
+function convertConstToEnum(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.const !== undefined && !o.enum) {
+        o.enum = [o.const];
+        delete o.const;
+    }
+    for (const value of Object.values(o)) {
+        if (value && typeof value === "object") convertConstToEnum(value);
+    }
+}
+
+function convertEnumValuesToStrings(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.enum && Array.isArray(o.enum)) {
+        o.enum = o.enum.map((v) => String(v));
+        if (!o.type) o.type = "string";
+    }
+    for (const value of Object.values(o)) {
+        if (value && typeof value === "object") convertEnumValuesToStrings(value);
+    }
+}
+
+function mergeAllOf(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.allOf && Array.isArray(o.allOf)) {
+        const merged: Record<string, unknown> = {};
+        for (const item of o.allOf as Record<string, unknown>[]) {
+            if (item.properties) {
+                if (!merged.properties) merged.properties = {};
+                Object.assign(merged.properties as Record<string, unknown>, item.properties);
+            }
+            if (item.required && Array.isArray(item.required)) {
+                if (!merged.required) merged.required = [];
+                for (const req of item.required as string[]) {
+                    if (!(merged.required as string[]).includes(req)) (merged.required as string[]).push(req);
+                }
+            }
+        }
+        delete o.allOf;
+        if (merged.properties) o.properties = { ...(o.properties as Record<string, unknown>), ...(merged.properties as Record<string, unknown>) };
+        if (merged.required) o.required = [...((o.required as string[]) || []), ...(merged.required as string[])];
+    }
+    for (const value of Object.values(o)) {
+        if (value && typeof value === "object") mergeAllOf(value);
+    }
+}
+
+function selectBest(items: Array<Record<string, unknown>>): number {
+    let bestIdx = 0;
+    let bestScore = -1;
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        let score = 0;
+        const type = item.type;
+        if (type === "object" || item.properties) score = 3;
+        else if (type === "array" || item.items) score = 2;
+        else if (type && type !== "null") score = 1;
+        if (score > bestScore) {
+            bestScore = score;
+            bestIdx = i;
+        }
+    }
+    return bestIdx;
+}
+
+function flattenAnyOfOneOf(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.anyOf && Array.isArray(o.anyOf) && o.anyOf.length > 0) {
+        const nonNull = (o.anyOf as Array<Record<string, unknown>>).filter((s) => s && s.type !== "null");
+        if (nonNull.length > 0) {
+            const selected = nonNull[selectBest(nonNull)];
+            delete o.anyOf;
+            Object.assign(o, selected);
+        }
+    }
+    if (o.oneOf && Array.isArray(o.oneOf) && o.oneOf.length > 0) {
+        const nonNull = (o.oneOf as Array<Record<string, unknown>>).filter((s) => s && s.type !== "null");
+        if (nonNull.length > 0) {
+            const selected = nonNull[selectBest(nonNull)];
+            delete o.oneOf;
+            Object.assign(o, selected);
+        }
+    }
+    for (const value of Object.values(o)) {
+        if (value && typeof value === "object") flattenAnyOfOneOf(value);
+    }
+}
+
+function flattenTypeArrays(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.type && Array.isArray(o.type)) {
+        const nonNullTypes = (o.type as string[]).filter((t) => t !== "null");
+        o.type = nonNullTypes.length > 0 ? nonNullTypes[0] : "string";
+    }
+    for (const value of Object.values(o)) {
+        if (value && typeof value === "object") flattenTypeArrays(value);
+    }
+}
+
+function ensureObjectType(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.properties && !o.type) o.type = "object";
+    for (const v of Object.values(o)) if (v && typeof v === "object") ensureObjectType(v);
+}
+
+function cleanupRequired(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (o.required && Array.isArray(o.required) && o.properties) {
+        const props = o.properties as Record<string, unknown>;
+        const valid = (o.required as string[]).filter((f) => Object.prototype.hasOwnProperty.call(props, f));
+        if (valid.length === 0) delete o.required;
+        else o.required = valid;
+    }
+    for (const value of Object.values(o)) {
+        if (value && typeof value === "object") cleanupRequired(value);
+    }
+}
+
+function addPlaceholders(obj: unknown): void {
+    if (!obj || typeof obj !== "object") return;
+    const o = obj as Record<string, unknown>;
+    if (Object.keys(o).length === 0) {
+        o.type = "object";
+        o.properties = { reason: { type: "string", description: "Brief explanation of why you are calling this tool" } };
+        o.required = ["reason"];
+        return;
+    }
+    if (o.type === "object") {
+        if (!o.properties || Object.keys(o.properties as Record<string, unknown>).length === 0) {
+            o.properties = { reason: { type: "string", description: "Brief explanation of why you are calling this tool" } };
+            o.required = ["reason"];
+        }
+    }
+    for (const value of Object.values(o)) {
+        if (value && typeof value === "object") addPlaceholders(value);
+    }
+}
+
+/**
+ * Clean a JSON Schema for Antigravity API compatibility — removes unsupported
+ * keywords recursively (port of 9router cleanJSONSchemaForAntigravity).
+ */
+export function cleanJSONSchemaForAntigravity(schema: unknown): unknown {
+    if (!schema || typeof schema !== "object") return schema;
+    const cleaned = schema as Record<string, unknown>;
+    convertConstToEnum(cleaned);
+    convertEnumValuesToStrings(cleaned);
+    mergeAllOf(cleaned);
+    flattenAnyOfOneOf(cleaned);
+    flattenTypeArrays(cleaned);
+    ensureObjectType(cleaned);
+    removeUnsupportedKeywords(cleaned, UNSUPPORTED_SCHEMA_CONSTRAINTS);
+    cleanupRequired(cleaned);
+    addPlaceholders(cleaned);
+    return cleaned;
+}
+
+/**
+ * Sanitize a function name for Gemini: [a-zA-Z_][a-zA-Z0-9_.:\-]{0,63}.
+ */
+export function sanitizeFunctionName(name: string): string {
+    if (!name) return "_unknown";
+    let s = name.replace(/[^a-zA-Z0-9_.:\-]/g, "_");
+    if (!/^[a-zA-Z_]/.test(s)) s = "_" + s;
+    return s.substring(0, 64);
+}
+
+// ─── Gemini SSE stream → OpenAI chunks (port of 9router response/gemini-to-openai.js) ───
+
+export interface GeminiStreamState {
+    messageId?: string;
+    model: string;
+    functionIndex: number;
+    geminiToolCallCount: number;
+    finishReason?: string;
+    usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+    toolNameMap?: Map<string, string> | null;
+}
+
+export function createGeminiStreamState(model: string, toolNameMap?: Map<string, string> | null): GeminiStreamState {
+    return { model, functionIndex: 0, geminiToolCallCount: 0, toolNameMap };
+}
+
+function geminiChunkMeta(state: GeminiStreamState) {
+    return { id: `chatcmpl-${state.messageId || Date.now()}`, created: Math.floor(Date.now() / 1000), model: state.model };
+}
+
+function buildGeminiChunk(state: GeminiStreamState, delta: Record<string, unknown>, finishReason: string | null): ChatCompletionChunk {
+    return {
+        id: `chatcmpl-${state.messageId || Date.now()}`,
+        object: "chat.completion.chunk",
+        created: Math.floor(Date.now() / 1000),
+        model: state.model,
+        choices: [
+            {
+                index: 0,
+                delta: delta as ChatCompletionChunk["choices"][0]["delta"],
+                finish_reason: finishReason as ChatCompletionChunk["choices"][0]["finish_reason"],
+            },
+        ],
+    };
+}
+
+function emitGeminiFunctionCall(functionCall: { name: string; args?: Record<string, unknown> }, state: GeminiStreamState): ChatCompletionChunk {
+    const rawName = functionCall.name;
+    const fcName = state.toolNameMap?.get(rawName) || rawName;
+    const fcArgs = functionCall.args || {};
+    const toolCallIndex = state.functionIndex++;
+    state.geminiToolCallCount++;
+    return buildGeminiChunk(state, {
+        tool_calls: [{
+            index: toolCallIndex,
+            id: `${fcName}-${Date.now()}-${toolCallIndex}`,
+            type: "function",
+            function: { name: fcName, arguments: JSON.stringify(fcArgs) },
+        }],
+    }, null);
+}
+
+/**
+ * Convert a Gemini/Antigravity SSE chunk into OpenAI ChatCompletionChunk(s).
+ * Returns null when the chunk produces no output.
+ */
+export function geminiStreamToOpenAIChunks(chunk: Record<string, unknown>, state: GeminiStreamState): ChatCompletionChunk[] | null {
+    if (!chunk) return null;
+
+    const response = (chunk.response as Record<string, unknown>) || chunk;
+    const candidates = response.candidates as Array<Record<string, unknown>> | undefined;
+    if (!candidates?.[0]) return null;
+
+    const results: ChatCompletionChunk[] = [];
+    const candidate = candidates[0];
+    const content = candidate.content as { parts?: GeminiContentPart[] } | undefined;
+
+    if (!state.messageId) {
+        state.messageId = (response.responseId as string) || `msg_${Date.now()}`;
+        state.model = (response.modelVersion as string) || state.model;
+        state.functionIndex = 0;
+        state.geminiToolCallCount = 0;
+        results.push(buildGeminiChunk(state, { role: "assistant" }, null));
+    }
+
+    if (content?.parts) {
+        for (const part of content.parts) {
+            const partAny = part as unknown as Record<string, unknown>;
+            const hasThoughtSig = part.thoughtSignature || partAny.thought_signature;
+            const isThought = part.thought === true;
+
+            if (hasThoughtSig) {
+                const hasTextContent = part.text !== undefined && part.text !== "";
+                const hasFunctionCall = !!part.functionCall;
+                if (hasTextContent) {
+                    results.push(buildGeminiChunk(state, isThought ? { reasoning_content: part.text } : { content: part.text }, null));
+                }
+                if (hasFunctionCall && part.functionCall) {
+                    results.push(emitGeminiFunctionCall(part.functionCall, state));
+                }
+                continue;
+            }
+
+            if (part.text !== undefined && part.text !== "") {
+                results.push(buildGeminiChunk(state, isThought ? { reasoning_content: part.text } : { content: part.text }, null));
+            }
+
+            if (part.functionCall) {
+                results.push(emitGeminiFunctionCall(part.functionCall, state));
+            }
+
+            const inlineData = part.inlineData || (part as unknown as Record<string, unknown>).inline_data;
+            if (inlineData && (inlineData as Record<string, unknown>).data) {
+                const id = inlineData as Record<string, unknown>;
+                const mimeType = id.mimeType || id.mime_type || "image/png";
+                results.push(buildGeminiChunk(state, {
+                    images: [{ type: "image_url", image_url: { url: `data:${mimeType};base64,${id.data}` } }],
+                }, null));
+            }
+        }
+    }
+
+    // Usage metadata
+    const usageMeta = (response.usageMetadata as Record<string, unknown>) || (chunk.usageMetadata as Record<string, unknown>);
+    if (usageMeta) {
+        const promptTokens = Number(usageMeta.promptTokenCount ?? 0);
+        const completionTokens = Number(usageMeta.candidatesTokenCount ?? usageMeta.candidates_tokens_count ?? 0);
+        const total = promptTokens + completionTokens;
+        state.usage = { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: total };
+    }
+
+    // Finish reason
+    if (candidate.finishReason) {
+        let finishReason = String(candidate.finishReason) === "STOP" ? "stop" : String(candidate.finishReason).toLowerCase();
+        if (finishReason === "stop" && state.geminiToolCallCount > 0) finishReason = "tool_calls";
+        const finalChunk = buildGeminiChunk(state, {}, finishReason);
+        if (state.usage) finalChunk.usage = state.usage;
+        results.push(finalChunk);
+        state.finishReason = finishReason;
+    }
+
+    return results.length > 0 ? results : null;
 }


### PR DESCRIPTION
## Summary

- Upgrade Antigravity executor dari 9Router: IDE envelope (project/requestId/sessionId/userAgent) ke `daily-cloudcode-pa.googleapis.com`
- Native SSE streaming (`streamGenerateContent?alt=sse`) → OpenAI chunks
- Retry/backoff (Retry-After, error message parse, transient patterns)
- Tools sanitization (function name + JSON schema clean)

## Motivation

SRouter antigravity sebelumnya cuma support Gemini public endpoint (generateContent biasa), stream-nya fake (non-stream di-emit sekali). 9Router punya executor lengkap dengan IDE envelope + native streaming yang dibutuhin backend Antigravity (daily-cloudcode-pa nolak request tanpa envelope).

## Changes

- **`packages/translator/src/gemini.ts`**: helpers baru — `buildAntigravityEnvelope`, `buildIdeRequestId` (format `agent/<conv>/<ts>/<traj>/<step>`), `generateProjectId`/`generateSessionId`, `cleanJSONSchemaForAntigravity` (unsupported keyword stripping, anyOf/oneOf flatten, const→enum, placeholder), `sanitizeFunctionName`, `geminiStreamToOpenAIChunks` (text/reasoning/function-call/image/usage/finish)
- **`packages/executors/src/antigravity.ts`**: rewrite — IDE envelope + `v1internal:streamGenerateContent?alt=sse`, retry/backoff, tools sanitize, model id asli dipertahankan (drop mapping lama gemini-3.6-flash → gemini-2.5-flash)
- **`apps/api/src/logic/auth.logic.ts`**: OAuth callback & token import pake IDE base URL (bukan generativelanguage)

## Test Plan

- [x] Unit test translator: envelope, requestId, schema clean, SSE→chunks (30+ assertions)
- [x] Unit test executor: stream URL, envelope, contents, tools (mock fetch)
- [x] Live OAuth Google login → callback → 2 akun antigravity ke DB (ya29 + refresh)
- [x] Live listModels: 30 model (gemini-3.6-flash, claude-opus-4-6-thinking, gpt-oss, image)
- [x] Live chat non-streaming: "Halo, ada yang bisa saya bantu hari ini?"
- [x] Live chat streaming (SSE): delta chunks + usage + [DONE]

## Notes for Reviewers

- Fix `c36f743`: base URL lama (generativelanguage/v1beta/openai) nolak IDE envelope dengan 404 — di-switch ke daily-cloudcode-pa
- Image generation path dipertahankan (non-streaming generateContent + imageConfig), belum di-test live
- Cloak tools (anti-ban `_ide` suffix + decoy) dari 9Router belum di-port