### PR TITLE
feat(claude): add Claude Code OAuth support + upgrade Anthropic executor

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -294,4 +294,100 @@ export class AuthController {
             201,
         );
     }
+
+    // --- Claude Code OAuth Handlers ---
+    public static loginClaude(c: Context): Response {
+        const customClientId = c.req.query("client_id") || undefined;
+        const redirectUri = c.req.query("redirect_uri") || undefined;
+        const prompt = c.req.query("prompt") || undefined;
+
+        try {
+            const result = AuthLogic.initiateClaudeOAuthPKCE({
+                clientId: customClientId,
+                redirectUri,
+                prompt,
+            });
+
+            if (c.req.query("format") === "json") {
+                return ok(c, result);
+            }
+
+            return c.redirect(result.authorizeUrl);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return err(c, errorMessage, 400, { type: "invalid_request_error" });
+        }
+    }
+
+    public static async handleClaudeOAuthCallback(c: Context): Promise<Response> {
+        let code = c.req.query("code") || undefined;
+        let state = c.req.query("state") || undefined;
+
+        if ((!code || !state) && c.req.method === "POST") {
+            try {
+                const body = await c.req.json<OAuthCallbackBody>();
+                if (body.callbackUrl) {
+                    try {
+                        const parsedUrl = new URL(body.callbackUrl);
+                        code = code || parsedUrl.searchParams.get("code") || undefined;
+                        state = state || parsedUrl.searchParams.get("state") || undefined;
+                    } catch {
+                        // Ignore invalid URL string
+                    }
+                }
+                code = code || body.code;
+                state = state || body.state;
+            } catch {
+                // Ignore JSON parse error
+            }
+        }
+
+        if (!code || !state) {
+            return err(c, "Missing required 'code' or 'state' parameters in OAuth callback", 400, {
+                type: "invalid_request_error",
+            });
+        }
+
+        try {
+            const providerConfig = await AuthLogic.processClaudeOAuthCallback(code, state);
+
+            if (c.req.method === "POST" || c.req.header("accept")?.includes("application/json")) {
+                return ok(c, {
+                    success: true,
+                    message: "Login Claude Code OAuth Berhasil!",
+                    provider: providerConfig,
+                });
+            }
+
+            return renderOAuthSuccessHTML(providerConfig.name);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return err(c, errorMessage, 500);
+        }
+    }
+
+    public static async importClaudeToken(c: Context): Promise<Response> {
+        let body: TokenImportBody;
+        try {
+            body = await c.req.json<TokenImportBody>();
+        } catch {
+            return err(c, "Invalid JSON body", 400, { type: "invalid_request_error" });
+        }
+
+        if (!body.accessToken) {
+            return err(c, "Field 'accessToken' is required", 400, { type: "invalid_request_error" });
+        }
+
+        const providerConfig = AuthLogic.processClaudeTokenImport(body);
+
+        return ok(
+            c,
+            {
+                success: true,
+                message: "Claude Code OAuth token registered and saved directly to SQLite database!",
+                provider: providerConfig,
+            },
+            201,
+        );
+    }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
-import { authRoute, handleAntigravityOAuthCallback, handleOAuthCallback } from "@/routes/v1/auth.js";
+import { authRoute, handleAntigravityOAuthCallback, handleClaudeOAuthCallback, handleOAuthCallback } from "@/routes/v1/auth.js";
 import { chatRoute } from "@/routes/v1/chat.js";
 import { logsRoute } from "@/routes/v1/logs.js";
 import { modelsRoute } from "@/routes/v1/models.js";
@@ -64,6 +64,8 @@ oauthApp.get("/auth/callback", (c) => handleOAuthCallback(c));
 oauthApp.post("/auth/callback", (c) => handleOAuthCallback(c));
 oauthApp.get("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
 oauthApp.post("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
+oauthApp.get("/auth/claude/callback", (c) => handleClaudeOAuthCallback(c));
+oauthApp.post("/auth/claude/callback", (c) => handleClaudeOAuthCallback(c));
 
 const oauthPort = Number(process.env.OAUTH_PORT) || 1455;
 

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -6,7 +6,7 @@ import {
     upsertProviderDB,
 } from "@srouter/db";
 import { AntigravityExecutor, AnthropicExecutor, CodexExecutor, CommandCodeExecutor, OpenAIExecutor } from "@srouter/executors";
-import { AntigravityOAuth, OpenAICodexOAuth, generatePKCE, type PKCEPair } from "@srouter/providers";
+import { AntigravityOAuth, ClaudeOAuth, OpenAICodexOAuth, generatePKCE, type PKCEPair } from "@srouter/providers";
 import type { ProviderConfig } from "@srouter/types";
 import { registry } from "@/services/registry.js";
 
@@ -312,6 +312,110 @@ export class AuthLogic {
             name: providerName,
             baseUrl,
             apiKey: params.accessToken,
+        });
+        registry.registerProvider(providerInstance);
+
+        return providerConfig;
+    }
+
+    // --- Claude Code OAuth ---
+    public static initiateClaudeOAuthPKCE(params: OAuthLoginParams): OAuthLoginResult {
+        cleanupExpiredSessions();
+        const clientId = params.clientId || process.env.CLAUDE_OAUTH_CLIENT_ID || "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+        const redirectUri = params.redirectUri || "http://localhost:1455/auth/claude/callback";
+        const prompt = params.prompt;
+
+        const oauthInstance = new ClaudeOAuth({
+            clientId,
+            redirectUri,
+            prompt,
+        });
+
+        const pkce: PKCEPair = generatePKCE();
+        saveOAuthSessionDB({
+            state: pkce.state,
+            codeVerifier: pkce.codeVerifier,
+            clientId,
+            redirectUri,
+            createdAt: Date.now(),
+        });
+
+        const authorizeUrl = oauthInstance.getAuthorizationUrl(pkce);
+
+        return {
+            authorizeUrl,
+            state: pkce.state,
+            codeVerifier: pkce.codeVerifier,
+            redirectUri,
+        };
+    }
+
+    public static async processClaudeOAuthCallback(code: string, state: string): Promise<ProviderConfig> {
+        cleanupExpiredSessions();
+
+        const session = getOAuthSessionDB(state);
+        if (!session) {
+            throw new Error("Invalid or expired OAuth state parameter");
+        }
+
+        deleteOAuthSessionDB(state);
+
+        const oauthInstance = new ClaudeOAuth({
+            clientId: session.clientId,
+            redirectUri: session.redirectUri,
+        });
+
+        const tokens = await oauthInstance.exchangeCodeForTokens(code, session.codeVerifier);
+        const timestamp = Date.now();
+        const accountId = `claude_${timestamp}`;
+        const accountName = `Claude Code (Account #${timestamp.toString().slice(-4)})`;
+
+        const providerConfig = upsertProviderDB({
+            id: accountId,
+            providerId: "claude",
+            name: accountName,
+            category: "oauth",
+            protocol: "anthropic",
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            enabled: true,
+            createdAt: timestamp,
+        });
+
+        const providerInstance = new AnthropicExecutor({
+            id: accountId,
+            name: accountName,
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            organizationId: tokens.organizationId,
+        });
+        registry.registerProvider(providerInstance);
+
+        return providerConfig;
+    }
+
+    public static processClaudeTokenImport(params: TokenImportParams): ProviderConfig {
+        const timestamp = Date.now();
+        const accountId = params.id || `claude_${timestamp}`;
+        const providerName = params.name || `Claude Code (Account #${timestamp.toString().slice(-4)})`;
+
+        const providerConfig = upsertProviderDB({
+            id: accountId,
+            providerId: "claude",
+            name: providerName,
+            category: "oauth",
+            protocol: "anthropic",
+            accessToken: params.accessToken,
+            refreshToken: params.refreshToken,
+            enabled: true,
+            createdAt: timestamp,
+        });
+
+        const providerInstance = new AnthropicExecutor({
+            id: accountId,
+            name: providerName,
+            accessToken: params.accessToken,
+            refreshToken: params.refreshToken,
         });
         registry.registerProvider(providerInstance);
 

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -5,6 +5,7 @@ export const authRoute = new Hono();
 
 export const handleOAuthCallback = AuthController.handleOAuthCallback;
 export const handleAntigravityOAuthCallback = AuthController.handleAntigravityOAuthCallback;
+export const handleClaudeOAuthCallback = AuthController.handleClaudeOAuthCallback;
 export const handleCommandCodeTokenImport = AuthController.importCommandCodeToken;
 
 // --- OpenAI OAuth ---
@@ -40,3 +41,15 @@ authRoute.post("/auth/commandcode/import-token", AuthController.importCommandCod
 // 1. POST /v1/auth/anthropic/token & POST /v1/auth/anthropic/import-token
 authRoute.post("/auth/anthropic/token", AuthController.importAnthropicToken);
 authRoute.post("/auth/anthropic/import-token", AuthController.importAnthropicToken);
+
+// --- Claude Code OAuth ---
+// 1. GET /v1/auth/claude/login - Initiate Claude Code OAuth PKCE Login Flow
+authRoute.get("/auth/claude/login", AuthController.loginClaude);
+
+// 2. GET & POST /v1/auth/claude/callback - OAuth Callback Receiver
+authRoute.get("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
+authRoute.post("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
+
+// 3. POST /v1/auth/claude/token & POST /v1/auth/claude/import-token
+authRoute.post("/auth/claude/token", AuthController.importClaudeToken);
+authRoute.post("/auth/claude/import-token", AuthController.importClaudeToken);

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -87,6 +87,19 @@ export function loadSavedProvidersFromDB(): void {
                     }),
                 );
                 break;
+            case providerType === "claude" || p.id.startsWith("claude"):
+                registry.registerProvider(
+                    new AnthropicExecutor({
+                        id: p.id || p.providerId,
+                        name: p.name,
+                        baseUrl,
+                        apiKey: p.apiKey,
+                        accessToken: p.accessToken,
+                        refreshToken: p.refreshToken,
+                        organizationId: p.organizationId,
+                    }),
+                );
+                break;
             case p.protocol === "anthropic" || providerType === "anthropic" || providerType === "custom_anthropic":
                 registry.registerProvider(
                     new AnthropicExecutor({

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -59,6 +59,13 @@ export function initDatabase(): void {
         // column already exists
     }
 
+    // Ensure organization_id column exists (e.g. Claude OAuth organization binding)
+    try {
+        db.exec("ALTER TABLE providers ADD COLUMN organization_id TEXT;");
+    } catch {
+        // column already exists
+    }
+
     // 2. Table for Client API Keys / Endpoint Keys
     db.exec(`
         CREATE TABLE IF NOT EXISTS api_keys (

--- a/packages/db/src/providers.ts
+++ b/packages/db/src/providers.ts
@@ -16,6 +16,7 @@ export function getAllProvidersDB(): ProviderConfig[] {
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
         accountId: row.account_id ? String(row.account_id) : undefined,
+        organizationId: row.organization_id ? String(row.organization_id) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
         enabled: Boolean(row.enabled),
         createdAt: Number(row.created_at ?? 0),
@@ -39,6 +40,7 @@ export function getProviderByIdDB(id: string): ProviderConfig | null {
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
         accountId: row.account_id ? String(row.account_id) : undefined,
+        organizationId: row.organization_id ? String(row.organization_id) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
         enabled: Boolean(row.enabled),
         createdAt: Number(row.created_at ?? 0),
@@ -47,8 +49,8 @@ export function getProviderByIdDB(id: string): ProviderConfig | null {
 
 export function upsertProviderDB(config: ProviderConfig & { category: string; protocol: string }): ProviderConfig {
     const query = db.prepare(`
-        INSERT INTO providers (id, provider_id, name, category, protocol, base_url, api_key, access_token, refresh_token, account_id, custom_headers, enabled, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO providers (id, provider_id, name, category, protocol, base_url, api_key, access_token, refresh_token, account_id, organization_id, custom_headers, enabled, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             provider_id = excluded.provider_id,
             name = excluded.name,
@@ -59,12 +61,13 @@ export function upsertProviderDB(config: ProviderConfig & { category: string; pr
             access_token = excluded.access_token,
             refresh_token = excluded.refresh_token,
             account_id = excluded.account_id,
+            organization_id = excluded.organization_id,
             custom_headers = excluded.custom_headers,
             enabled = excluded.enabled,
             created_at = excluded.created_at;
     `);
 
-    query.run(config.id, config.providerId, config.name, config.category, config.protocol, config.baseUrl ?? null, config.apiKey ?? null, config.accessToken ?? null, config.refreshToken ?? null, config.accountId ?? null, config.customHeaders ? JSON.stringify(config.customHeaders) : null, config.enabled ? 1 : 0, config.createdAt);
+    query.run(config.id, config.providerId, config.name, config.category, config.protocol, config.baseUrl ?? null, config.apiKey ?? null, config.accessToken ?? null, config.refreshToken ?? null, config.accountId ?? null, config.organizationId ?? null, config.customHeaders ? JSON.stringify(config.customHeaders) : null, config.enabled ? 1 : 0, config.createdAt);
 
     return config;
 }
@@ -97,6 +100,7 @@ export function getConnectionsByProviderIdDB(providerId: string): ProviderConfig
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
         accountId: row.account_id ? String(row.account_id) : undefined,
+        organizationId: row.organization_id ? String(row.organization_id) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
         enabled: Boolean(row.enabled),
         createdAt: Number(row.created_at ?? 0),

--- a/packages/executors/src/anthropic.ts
+++ b/packages/executors/src/anthropic.ts
@@ -8,16 +8,57 @@ export interface AnthropicExecutorOptions {
     baseUrl?: string;
     apiKey?: string;
     accessToken?: string;
+    refreshToken?: string;
+    organizationId?: string;
 }
+
+// Anthropic-Beta flags — base for all models, heavy-agent flags gated to opus/sonnet
+// (port of 9router providers/shared.js selectAnthropicBeta)
+const ANTHROPIC_BETA_BASE = [
+    "claude-code-20250219",
+    "oauth-2025-04-20",
+    "interleaved-thinking-2025-05-14",
+    "context-management-2025-06-27",
+    "prompt-caching-scope-2026-01-05",
+    "structured-outputs-2025-12-15",
+    "fast-mode-2026-02-01",
+    "redact-thinking-2026-02-12",
+    "token-efficient-tools-2026-03-28",
+];
+const ANTHROPIC_BETA_HEAVY_AGENT = ["advanced-tool-use-2025-11-20", "effort-2025-11-24"];
+
+export function selectAnthropicBeta(model = ""): string {
+    const flags = [...ANTHROPIC_BETA_BASE];
+    if (/^claude-(opus|sonnet)/.test(model)) flags.push(...ANTHROPIC_BETA_HEAVY_AGENT);
+    return flags.join(",");
+}
+
+// Full Claude CLI fingerprint — required by providers that gate on client identity
+const CLAUDE_CLI_SPOOF_HEADERS: Record<string, string> = {
+    "Anthropic-Dangerous-Direct-Browser-Access": "true",
+    "User-Agent": "claude-cli/2.1.92 (external, sdk-cli)",
+    "X-App": "cli",
+    "X-Stainless-Helper-Method": "stream",
+    "X-Stainless-Retry-Count": "0",
+    "X-Stainless-Runtime-Version": "v24.14.0",
+    "X-Stainless-Package-Version": "0.80.0",
+    "X-Stainless-Runtime": "node",
+    "X-Stainless-Lang": "js",
+    "X-Stainless-Arch": "arm64",
+    "X-Stainless-Os": "MacOS",
+    "X-Stainless-Timeout": "600",
+};
 
 export class AnthropicExecutor implements AIProvider {
     id: string;
     name: string;
-    category: "api_key" = "api_key";
+    category: "api_key" | "oauth" = "api_key";
     protocol: "anthropic" = "anthropic";
     private baseUrl: string;
     private apiKey: string;
     private accessToken: string;
+    private refreshToken?: string;
+    private organizationId?: string;
 
     constructor(options: AnthropicExecutorOptions = {}) {
         this.id = options.id ?? "anthropic";
@@ -25,18 +66,36 @@ export class AnthropicExecutor implements AIProvider {
         this.baseUrl = (options.baseUrl ?? "https://api.anthropic.com/v1").replace(/\/$/, "");
         this.apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY ?? "";
         this.accessToken = options.accessToken ?? process.env.ANTHROPIC_ACCESS_TOKEN ?? "";
+        this.refreshToken = options.refreshToken;
+        this.organizationId = options.organizationId;
+        if (this.accessToken) {
+            this.category = "oauth";
+        }
     }
 
-    private getHeaders(): Record<string, string> {
+    private getHeaders(model?: string, stream = false): Record<string, string> {
         const headers: Record<string, string> = {
             "Content-Type": "application/json",
             "anthropic-version": "2023-06-01",
+            "Anthropic-Beta": selectAnthropicBeta(model || ""),
         };
-        const token = this.accessToken || this.apiKey;
-        if (token) {
-            headers["x-api-key"] = token;
-            headers["Authorization"] = `Bearer ${token}`;
+
+        if (this.accessToken) {
+            // OAuth account — Bearer token + CLI identity headers
+            headers["Authorization"] = `Bearer ${this.accessToken}`;
+            Object.assign(headers, CLAUDE_CLI_SPOOF_HEADERS);
+            if (this.organizationId) {
+                headers["anthropic-organization-id"] = this.organizationId;
+            }
+        } else if (this.apiKey) {
+            headers["x-api-key"] = this.apiKey;
+            headers["Authorization"] = `Bearer ${this.apiKey}`;
         }
+
+        if (stream) {
+            headers["Accept"] = "text/event-stream";
+        }
+
         return headers;
     }
 
@@ -80,10 +139,12 @@ export class AnthropicExecutor implements AIProvider {
     async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
         const anthropicReq = openAIToAnthropicRequest(req);
         anthropicReq.stream = false;
+        const targetModel = req.model.includes("/") ? (req.model.split("/")[1] ?? req.model) : req.model;
+        anthropicReq.model = targetModel;
 
         const res = await fetch(`${this.baseUrl}/messages`, {
             method: "POST",
-            headers: this.getHeaders(),
+            headers: this.getHeaders(targetModel, false),
             body: JSON.stringify(anthropicReq),
         });
 
@@ -99,10 +160,12 @@ export class AnthropicExecutor implements AIProvider {
     async *chatCompletionStream(req: ChatCompletionRequest): AsyncGenerator<ChatCompletionChunk, void, void> {
         const anthropicReq = openAIToAnthropicRequest(req);
         anthropicReq.stream = true;
+        const targetModel = req.model.includes("/") ? (req.model.split("/")[1] ?? req.model) : req.model;
+        anthropicReq.model = targetModel;
 
         const res = await fetch(`${this.baseUrl}/messages`, {
             method: "POST",
-            headers: this.getHeaders(),
+            headers: this.getHeaders(targetModel, true),
             body: JSON.stringify(anthropicReq),
         });
 

--- a/packages/providers/src/oauth/base.ts
+++ b/packages/providers/src/oauth/base.ts
@@ -8,6 +8,8 @@ export interface OAuthTokenResponse {
     tokenType: string;
     /** Optional ChatGPT/OpenAI account identifier (for multi-account binding) */
     accountId?: string;
+    /** Optional organization id (e.g. Claude OAuth) */
+    organizationId?: string;
 }
 
 export interface PKCEPair {

--- a/packages/providers/src/oauth/claude.ts
+++ b/packages/providers/src/oauth/claude.ts
@@ -1,0 +1,143 @@
+import type { OAuthTokenResponse, PKCEPair } from "./base.js";
+
+export interface ClaudeOAuthOptions {
+    clientId?: string;
+    redirectUri?: string;
+    scope?: string;
+    authorizeUrl?: string;
+    tokenUrl?: string;
+    prompt?: string;
+}
+
+/**
+ * Claude Code OAuth (port of 9router providers/registry/claude.js).
+ * Allows a Claude subscription (claude.ai account) to be used via Claude Code OAuth
+ * tokens — not just a raw API key.
+ */
+export class ClaudeOAuth {
+    private clientId: string;
+    private redirectUri: string;
+    private scope: string;
+    private authorizeUrl: string;
+    private tokenUrl: string;
+    private prompt?: string;
+
+    constructor(options: ClaudeOAuthOptions = {}) {
+        // Official Claude Code OAuth public client ID (mirrors claude-code CLI)
+        this.clientId = options.clientId ?? process.env.CLAUDE_OAUTH_CLIENT_ID ?? "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+        this.redirectUri = options.redirectUri ?? process.env.CLAUDE_OAUTH_REDIRECT_URI ?? "http://localhost:1455/auth/claude/callback";
+        this.scope = options.scope ?? process.env.CLAUDE_OAUTH_SCOPE ?? "org:create_api_key user:profile user:inference";
+        this.authorizeUrl = options.authorizeUrl ?? process.env.CLAUDE_OAUTH_AUTHORIZE_URL ?? "https://claude.ai/oauth/authorize";
+        this.tokenUrl = options.tokenUrl ?? process.env.CLAUDE_OAUTH_TOKEN_URL ?? "https://api.anthropic.com/v1/oauth/token";
+        this.prompt = options.prompt ?? process.env.CLAUDE_OAUTH_PROMPT;
+    }
+
+    /**
+     * Generates PKCE parameters and returns authorization URL
+     */
+    getAuthorizationUrl(pkce: PKCEPair): string {
+        const params: Record<string, string> = {
+            response_type: "code",
+            client_id: this.clientId,
+            redirect_uri: this.redirectUri,
+            scope: this.scope,
+            code_challenge: pkce.codeChallenge,
+            code_challenge_method: "S256",
+            state: pkce.state,
+        };
+
+        if (this.prompt) {
+            params.prompt = this.prompt;
+        }
+
+        const queryString = Object.entries(params)
+            .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+            .join("&");
+
+        return `${this.authorizeUrl}?${queryString}`;
+    }
+
+    /**
+     * Exchanges authorization code and code_verifier for Access Token.
+     * Claude OAuth uses a JSON body (not form-encoded) with client_id only.
+     */
+    async exchangeCodeForTokens(code: string, codeVerifier: string): Promise<OAuthTokenResponse> {
+        const res = await fetch(this.tokenUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                grant_type: "authorization_code",
+                client_id: this.clientId,
+                code,
+                code_verifier: codeVerifier,
+                redirect_uri: this.redirectUri,
+            }),
+        });
+
+        if (!res.ok) {
+            const errorText = await res.text();
+            throw new Error(`Claude OAuth Exchange Failed (${res.status}): ${errorText}`);
+        }
+
+        const data = (await res.json()) as {
+            access_token: string;
+            refresh_token?: string;
+            id_token?: string;
+            expires_in?: number;
+            token_type?: string;
+            organization_id?: string;
+        };
+
+        return {
+            accessToken: data.access_token,
+            refreshToken: data.refresh_token,
+            idToken: data.id_token,
+            expiresIn: data.expires_in,
+            tokenType: data.token_type ?? "Bearer",
+            organizationId: data.organization_id,
+        };
+    }
+
+    /**
+     * Refreshes an expired access token using refresh_token.
+     * Claude OAuth: JSON body, client_id only, no client_secret.
+     */
+    async refreshTokens(refreshToken: string): Promise<OAuthTokenResponse> {
+        const res = await fetch(this.tokenUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                grant_type: "refresh_token",
+                client_id: this.clientId,
+                refresh_token: refreshToken,
+            }),
+        });
+
+        if (!res.ok) {
+            const errorText = await res.text();
+            throw new Error(`Claude OAuth Refresh Failed (${res.status}): ${errorText}`);
+        }
+
+        const data = (await res.json()) as {
+            access_token: string;
+            refresh_token?: string;
+            id_token?: string;
+            expires_in?: number;
+            token_type?: string;
+            organization_id?: string;
+        };
+
+        return {
+            accessToken: data.access_token,
+            refreshToken: data.refresh_token ?? refreshToken,
+            idToken: data.id_token,
+            expiresIn: data.expires_in,
+            tokenType: data.token_type ?? "Bearer",
+            organizationId: data.organization_id,
+        };
+    }
+}

--- a/packages/providers/src/oauth/index.ts
+++ b/packages/providers/src/oauth/index.ts
@@ -1,3 +1,4 @@
 export * from "./antigravity.js";
 export * from "./base.js";
+export * from "./claude.js";
 export * from "./openai.js";

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -129,6 +129,22 @@ export const DEFAULT_CATALOG: ProviderDefinition[] = [
             { id: "claude-3-5-sonnet-20241022", object: "model", owned_by: "anthropic" },
         ],
     },
+    {
+        id: "claude",
+        name: "Claude Code (OAuth)",
+        category: "oauth",
+        protocol: "anthropic",
+        description: "Claude Code OAuth driver — pakai akun Claude subscription via claude.ai.",
+        icon: "🧠",
+        requiresApiKey: false,
+        requiresOAuth: true,
+        status: { state: "disconnected", message: "OAuth token missing" },
+        models: [
+            { id: "claude-sonnet-4-20250514", object: "model", owned_by: "anthropic" },
+            { id: "claude-opus-4-20250514", object: "model", owned_by: "anthropic" },
+            { id: "claude-3-5-sonnet-20241022", object: "model", owned_by: "anthropic" },
+        ],
+    },
 ];
 
 export class ProviderRegistry {

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -40,6 +40,7 @@ export interface ProviderConfig {
     accessToken?: string;
     refreshToken?: string;
     accountId?: string;
+    organizationId?: string;
     customHeaders?: Record<string, string>;
     enabled: boolean;
     createdAt: number;


### PR DESCRIPTION
## Summary

- Tambah **Claude Code OAuth** (provider `claude`, alias `cc`): login pake akun Claude subscription via claude.ai (bukan cuma API key)
- Upgrade `AnthropicExecutor`: dynamic beta headers, Claude CLI spoof headers, Bearer auth buat OAuth, org binding
- Port dari 9Router `providers/registry/claude.js` + `shared.js`

## Motivation

SRouter sebelumnya cuma support Anthropic API key. 9Router punya Claude Code OAuth (`cc` alias) yang bikin akun Claude subscription bisa dipake via OAuth token — client ID public `9d1c250a-e61b-44d9-88ed-5944d1962f5e`, authorize di claude.ai, token di api.anthropic.com/v1/oauth/token.

## Changes

- **`packages/providers/src/oauth/claude.ts`** (baru): `ClaudeOAuth` — PKCE S256, authorize URL, exchange code (JSON body, client_id only tanpa secret), refresh token, parse `organization_id`
- **`packages/executors/src/anthropic.ts`**: `selectAnthropicBeta(model)` — base flags + heavy-agent (`advanced-tool-use`, `effort`) gated ke opus/sonnet; Claude CLI spoof headers (X-Stainless-*, User-Agent claude-cli/2.1.92, X-App); Bearer auth + `anthropic-organization-id` buat OAuth accounts; `Accept: text/event-stream` buat streaming; strip model prefix (`claude/...`)
- **Auth**: `/v1/auth/claude/login` (redirect claude.ai), `/auth/claude/callback` (port 1455), `/v1/auth/claude/import-token` + AuthLogic methods
- **Registry**: catalog `claude` (Claude Code OAuth, disconnected default) + load case sebelum generic anthropic protocol match
- **DB**: kolom `organization_id` baru

## Test Plan

- [x] Unit test (20+ assertions): selectAnthropicBeta gating, OAuth headers (Bearer/spoof/org), API key headers, authorize URL PKCE
- [x] Build semua package + tsc (sisa error cuma pre-existing di providers.controller.ts/providers.logic.ts)
- [x] Live: `/v1/auth/claude/login` → redirect claude.ai bener (client ID + scopes + PKCE)
- [x] Live: callback invalid state → error handling bener
- [x] Live: catalog `/v1/providers` nampilin `claude` baru
- [ ] ⏳ Login end-to-end: **belum di-test** (gue nggak punya akun Claude) — butuh user login manual

## Notes for Reviewers

- **Belum live-tested end-to-end** — butuh akun Claude subscription buat OAuth login. Unit test + route test udah pass, tapi token exchange & chat belum diverifikasi live.
- Refresh token flow disimpan di DB tapi belum ada auto-refresh scheduler (konsisten sama codex/antigravity).