### PR TITLE
feat(claude): add Claude Code OAuth support + upgrade Anthropic executor

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import {
     anthropicAuthHandler,
     antigravityAuthHandler,
     bluesMindsAuthHandler,
+    claudeAuthHandler,
     commandCodeAuthHandler,
     goRouterAuthHandler,
     openaiCodexAuthHandler,
@@ -251,6 +252,23 @@ export class AuthController {
             (b) => AuthLogic.processAnthropicTokenImport(b),
             c
         );
+    }
+
+    // Claude Code OAuth
+    public static loginClaude(c: Context): Response {
+        return loginFor(claudeAuthHandler, (p) => AuthLogic.initiateClaudeOAuthPKCE(p), c, false);
+    }
+
+    public static async handleClaudeOAuthCallback(c: Context): Promise<Response> {
+        return handleOAuthCallbackFor(
+            claudeAuthHandler,
+            (code, state) => AuthLogic.processClaudeOAuthCallback(code, state),
+            c
+        );
+    }
+
+    public static async importClaudeToken(c: Context): Promise<Response> {
+        return importTokenFor(claudeAuthHandler, (b) => AuthLogic.processClaudeTokenImport(b), c);
     }
 
     // GoRouter Provider (API key)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { Hono } from "hono";
 import {
     authRoute,
     handleAntigravityOAuthCallback,
+    handleClaudeOAuthCallback,
     handleOAuthCallback,
     handleQoderOAuthCallback
 } from "@/routes/v1/auth.js";
@@ -93,6 +94,8 @@ oauthApp.get("/auth/callback", (c) => handleOAuthCallback(c));
 oauthApp.post("/auth/callback", (c) => handleOAuthCallback(c));
 oauthApp.get("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
 oauthApp.post("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
+oauthApp.get("/auth/claude/callback", (c) => handleClaudeOAuthCallback(c));
+oauthApp.post("/auth/claude/callback", (c) => handleClaudeOAuthCallback(c));
 oauthApp.get("/auth/qoder/callback", (c) => handleQoderOAuthCallback(c));
 oauthApp.post("/auth/qoder/callback", (c) => handleQoderOAuthCallback(c));
 oauthApp.route("/v1", messagesRoute);
@@ -110,7 +113,7 @@ try {
         },
         (info) => {
             console.log(
-                `🔑 OAuth Callback Server running at http://localhost:${info.port}/auth/callback & /auth/antigravity/callback`
+                `🔑 OAuth Callback Server running at http://localhost:${info.port}/auth/callback & /auth/antigravity/callback & /auth/claude/callback`
             );
         }
     );

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -13,6 +13,7 @@ import {
     anthropicAuthHandler,
     antigravityAuthHandler,
     bluesMindsAuthHandler,
+    claudeAuthHandler,
     commandCodeAuthHandler,
     goRouterAuthHandler,
     openaiCodexAuthHandler,
@@ -128,6 +129,7 @@ async function processOAuthCallbackFor(
         accessToken: tokens.accessToken,
         refreshToken: tokens.refreshToken,
         accountId: tokens.accountId,
+        organizationId: tokens.organizationId,
         tokenExpiresAt: tokens.expiresIn ? Date.now() + tokens.expiresIn * 1000 : undefined,
         lastRefreshedAt: Date.now(),
         enabled: true,
@@ -138,6 +140,7 @@ async function processOAuthCallbackFor(
         id: accountId,
         name: accountName,
         accountId: tokens.accountId,
+        organizationId: tokens.organizationId,
         baseUrl,
         accessToken: tokens.accessToken,
         refreshToken: tokens.refreshToken
@@ -173,6 +176,7 @@ function processTokenImportFor(
         accessToken: mapping.accessToken,
         refreshToken: mapping.refreshToken,
         accountId: mapping.accountId,
+        organizationId: mapping.organizationId,
         enabled: true,
         createdAt: timestamp
     });
@@ -181,6 +185,7 @@ function processTokenImportFor(
         id: accountId,
         name: providerName,
         accountId: mapping.accountId,
+        organizationId: mapping.organizationId,
         baseUrl: mapping.baseUrl ?? baseUrl,
         apiKey: mapping.apiKey,
         accessToken: mapping.accessToken,
@@ -231,6 +236,22 @@ export class AuthLogic {
     // Anthropic (API key)
     public static processAnthropicTokenImport(params: TokenImportParams): ProviderConfig {
         return processTokenImportFor(anthropicAuthHandler, params);
+    }
+
+    // Claude Code (OAuth)
+    public static initiateClaudeOAuthPKCE(params: OAuthLoginParams): OAuthLoginResult {
+        return initiatePKCEFor(claudeAuthHandler, params);
+    }
+
+    public static async processClaudeOAuthCallback(
+        code: string,
+        state: string
+    ): Promise<ProviderConfig> {
+        return processOAuthCallbackFor(claudeAuthHandler, code, state);
+    }
+
+    public static processClaudeTokenImport(params: TokenImportParams): ProviderConfig {
+        return processTokenImportFor(claudeAuthHandler, params);
     }
 
     // GoRouter (API key)

--- a/apps/api/src/logic/auth.providers.ts
+++ b/apps/api/src/logic/auth.providers.ts
@@ -22,7 +22,7 @@ import {
     SeekAIExecutor,
     TabiTokenExecutor
 } from "@srouter/executors";
-import { AntigravityOAuth, OpenAICodexOAuth, QoderOAuth } from "@srouter/providers";
+import { AntigravityOAuth, ClaudeOAuth, OpenAICodexOAuth, QoderOAuth } from "@srouter/providers";
 import type { AIProvider, ProviderCategory, ProviderProtocol } from "@srouter/types";
 
 export interface OAuthLoginParams {
@@ -55,6 +55,7 @@ export interface OAuthTokens {
     accessToken: string;
     refreshToken?: string;
     accountId?: string;
+    organizationId?: string;
     expiresIn?: number;
 }
 
@@ -67,6 +68,7 @@ export type ExecutorFactory = (args: {
     id: string;
     name: string;
     accountId?: string;
+    organizationId?: string;
     baseUrl?: string;
     apiKey?: string;
     accessToken?: string;
@@ -92,6 +94,7 @@ export interface ImportTokenMapping {
     accessToken?: string;
     refreshToken?: string;
     accountId?: string;
+    organizationId?: string;
     baseUrl?: string;
     apiKey?: string;
 }
@@ -117,6 +120,7 @@ export interface AuthProviderHandler {
         accessToken: string;
         refreshToken?: string;
         accountId?: string;
+        organizationId?: string;
         expiresIn?: number;
         baseUrl?: string;
     };
@@ -216,6 +220,31 @@ export const anthropicAuthHandler: AuthProviderHandler = {
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new AnthropicExecutor({ id, name, baseUrl, apiKey })
+};
+
+export const claudeAuthHandler: AuthProviderHandler = {
+    providerId: "claude",
+    displayName: "Claude Code",
+    category: "oauth",
+    protocol: "anthropic",
+    idPrefix: "claude",
+    clientId: () => process.env.CLAUDE_OAUTH_CLIENT_ID || "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+    defaultRedirectUri: "http://localhost:1455/auth/claude/callback",
+    oauthSuccessMessage: "Login Claude Code OAuth Berhasil!",
+    tokenImportMessage: "Claude Code OAuth token registered and saved directly to SQLite database!",
+    oauthClass: ClaudeOAuth,
+    mapOAuthTokens: (tokens) => ({
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        organizationId: tokens.organizationId,
+        expiresIn: tokens.expiresIn
+    }),
+    mapImportTokens: (params) => ({
+        accessToken: params.accessToken,
+        refreshToken: params.refreshToken
+    }),
+    buildExecutor: ({ id, name, accessToken, refreshToken, organizationId }) =>
+        new AnthropicExecutor({ id, name, accessToken, refreshToken, organizationId })
 };
 
 export const qoderAuthHandler: AuthProviderHandler = {
@@ -321,6 +350,7 @@ export const authProviderHandlers: Record<string, AuthProviderHandler> = {
     antigravity: antigravityAuthHandler,
     commandcode: commandCodeAuthHandler,
     anthropic: anthropicAuthHandler,
+    claude: claudeAuthHandler,
     qoder: qoderAuthHandler,
     gorouter: goRouterAuthHandler,
     bluesminds: bluesMindsAuthHandler,

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -6,6 +6,7 @@ export const authRoute = new Hono();
 
 export const handleOAuthCallback = AuthController.handleOAuthCallback;
 export const handleAntigravityOAuthCallback = AuthController.handleAntigravityOAuthCallback;
+export const handleClaudeOAuthCallback = AuthController.handleClaudeOAuthCallback;
 export const handleCommandCodeTokenImport = AuthController.importCommandCodeToken;
 export const handleQoderOAuthCallback = AuthController.handleQoderOAuthCallback;
 
@@ -42,6 +43,18 @@ authRoute.post("/auth/commandcode/import-token", adminAuth, AuthController.impor
 // 1. POST /v1/auth/anthropic/token & POST /v1/auth/anthropic/import-token
 authRoute.post("/auth/anthropic/token", adminAuth, AuthController.importAnthropicToken);
 authRoute.post("/auth/anthropic/import-token", adminAuth, AuthController.importAnthropicToken);
+
+// --- Claude Code OAuth ---
+// 1. GET /v1/auth/claude/login - Initiate Claude Code OAuth PKCE Login Flow
+authRoute.get("/auth/claude/login", adminAuth, AuthController.loginClaude);
+
+// 2. GET & POST /v1/auth/claude/callback - OAuth Callback Receiver
+authRoute.get("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
+authRoute.post("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
+
+// 3. POST /v1/auth/claude/token & POST /v1/auth/claude/import-token
+authRoute.post("/auth/claude/token", adminAuth, AuthController.importClaudeToken);
+authRoute.post("/auth/claude/import-token", adminAuth, AuthController.importClaudeToken);
 
 // --- GoRouter Provider (API key) ---
 // 1. POST /v1/auth/gorouter/token & POST /v1/auth/gorouter/import-token

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -209,6 +209,19 @@ export function loadSavedProvidersFromDB(): void {
                     })
                 );
                 break;
+            case isProviderBaseId(p.id, "claude") || providerType === "claude":
+                registry.registerProvider(
+                    new AnthropicExecutor({
+                        id: p.id || p.providerId,
+                        name: p.name,
+                        baseUrl,
+                        apiKey: p.apiKey,
+                        accessToken: p.accessToken,
+                        refreshToken: p.refreshToken,
+                        organizationId: p.organizationId
+                    })
+                );
+                break;
             case p.protocol === "anthropic" ||
                 providerType === "anthropic" ||
                 providerType === "custom_anthropic":

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -78,6 +78,13 @@ export function initDatabase(): void {
         // column already exists
     }
 
+    // Ensure organization_id column exists (e.g. Claude OAuth organization binding)
+    try {
+        db.exec("ALTER TABLE providers ADD COLUMN organization_id TEXT;");
+    } catch {
+        // column already exists
+    }
+
     // 2. Table for Client API Keys / Endpoint Keys
     db.exec(`
         CREATE TABLE IF NOT EXISTS api_keys (

--- a/packages/db/src/providers.ts
+++ b/packages/db/src/providers.ts
@@ -16,6 +16,7 @@ export function getAllProvidersDB(): ProviderConfig[] {
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
         accountId: row.account_id ? String(row.account_id) : undefined,
+        organizationId: row.organization_id ? String(row.organization_id) : undefined,
         tokenExpiresAt: row.token_expires_at ? Number(row.token_expires_at) : undefined,
         lastRefreshedAt: row.last_refreshed_at ? Number(row.last_refreshed_at) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
@@ -44,6 +45,7 @@ export function getProviderByIdDB(id: string): ProviderConfig | null {
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
         accountId: row.account_id ? String(row.account_id) : undefined,
+        organizationId: row.organization_id ? String(row.organization_id) : undefined,
         tokenExpiresAt: row.token_expires_at ? Number(row.token_expires_at) : undefined,
         lastRefreshedAt: row.last_refreshed_at ? Number(row.last_refreshed_at) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,
@@ -59,8 +61,13 @@ export function upsertProviderDB(
     config: ProviderConfig & { category: string; protocol: string }
 ): ProviderConfig {
     const query = db.prepare(`
-        INSERT INTO providers (id, provider_id, name, category, protocol, base_url, api_key, access_token, refresh_token, account_id, token_expires_at, last_refreshed_at, custom_headers, provider_specific_data, enabled, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO providers (
+            id, provider_id, name, category, protocol, base_url, api_key,
+            access_token, refresh_token, account_id, organization_id,
+            token_expires_at, last_refreshed_at, custom_headers,
+            provider_specific_data, enabled, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             provider_id = excluded.provider_id,
             name = excluded.name,
@@ -71,6 +78,7 @@ export function upsertProviderDB(
             access_token = excluded.access_token,
             refresh_token = excluded.refresh_token,
             account_id = excluded.account_id,
+            organization_id = excluded.organization_id,
             token_expires_at = excluded.token_expires_at,
             last_refreshed_at = excluded.last_refreshed_at,
             custom_headers = excluded.custom_headers,
@@ -90,6 +98,7 @@ export function upsertProviderDB(
         config.accessToken ?? null,
         config.refreshToken ?? null,
         config.accountId ?? null,
+        config.organizationId ?? null,
         config.tokenExpiresAt ?? null,
         config.lastRefreshedAt ?? null,
         config.customHeaders ? JSON.stringify(config.customHeaders) : null,
@@ -159,6 +168,7 @@ export function getConnectionsByProviderIdDB(providerId: string): ProviderConfig
         accessToken: row.access_token ? String(row.access_token) : undefined,
         refreshToken: row.refresh_token ? String(row.refresh_token) : undefined,
         accountId: row.account_id ? String(row.account_id) : undefined,
+        organizationId: row.organization_id ? String(row.organization_id) : undefined,
         tokenExpiresAt: row.token_expires_at ? Number(row.token_expires_at) : undefined,
         lastRefreshedAt: row.last_refreshed_at ? Number(row.last_refreshed_at) : undefined,
         customHeaders: row.custom_headers ? JSON.parse(String(row.custom_headers)) : undefined,

--- a/packages/executors/src/anthropic.ts
+++ b/packages/executors/src/anthropic.ts
@@ -20,35 +20,99 @@ export interface AnthropicExecutorOptions {
     baseUrl?: string;
     apiKey?: string;
     accessToken?: string;
+    refreshToken?: string;
+    organizationId?: string;
 }
+
+// Anthropic-Beta flags — base for all models, heavy-agent flags gated to opus/sonnet
+// (port of 9router providers/shared.js selectAnthropicBeta)
+const ANTHROPIC_BETA_BASE = [
+    "claude-code-20250219",
+    "oauth-2025-04-20",
+    "interleaved-thinking-2025-05-14",
+    "context-management-2025-06-27",
+    "prompt-caching-scope-2026-01-05",
+    "structured-outputs-2025-12-15",
+    "fast-mode-2026-02-01",
+    "redact-thinking-2026-02-12",
+    "token-efficient-tools-2026-03-28"
+];
+const ANTHROPIC_BETA_HEAVY_AGENT = ["advanced-tool-use-2025-11-20", "effort-2025-11-24"];
+
+export function selectAnthropicBeta(model = ""): string {
+    const flags = [...ANTHROPIC_BETA_BASE];
+    if (/^claude-(opus|sonnet)/.test(model)) flags.push(...ANTHROPIC_BETA_HEAVY_AGENT);
+    return flags.join(",");
+}
+
+// Full Claude CLI fingerprint — required by providers that gate on client identity
+const CLAUDE_CLI_SPOOF_HEADERS: Record<string, string> = {
+    "Anthropic-Dangerous-Direct-Browser-Access": "true",
+    "User-Agent": "claude-cli/2.1.92 (external, sdk-cli)",
+    "X-App": "cli",
+    "X-Stainless-Helper-Method": "stream",
+    "X-Stainless-Retry-Count": "0",
+    "X-Stainless-Runtime-Version": "v24.14.0",
+    "X-Stainless-Package-Version": "0.80.0",
+    "X-Stainless-Runtime": "node",
+    "X-Stainless-Lang": "js",
+    "X-Stainless-Arch": "arm64",
+    "X-Stainless-Os": "MacOS",
+    "X-Stainless-Timeout": "600"
+};
 
 export class AnthropicExecutor implements AIProvider {
     id: string;
     name: string;
-    category: "api_key" = "api_key";
+    category: "api_key" | "oauth" = "api_key";
     protocol: "anthropic" = "anthropic";
     private baseUrl: string;
     private apiKey: string;
     private accessToken: string;
+    private refreshToken?: string;
+    private organizationId?: string;
 
     constructor(options: AnthropicExecutorOptions = {}) {
         this.id = options.id ?? "anthropic";
         this.name = options.name ?? "Anthropic Provider";
         this.baseUrl = (options.baseUrl ?? ANTHROPIC_BASE_URL).replace(/\/$/, "");
-        this.apiKey = options.apiKey ?? "";
-        this.accessToken = options.accessToken ?? "";
+        this.apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY ?? "";
+        this.accessToken = options.accessToken ?? process.env.ANTHROPIC_ACCESS_TOKEN ?? "";
+        this.refreshToken = options.refreshToken;
+        this.organizationId = options.organizationId;
+        if (this.accessToken) {
+            this.category = "oauth";
+        }
     }
 
-    private getHeaders(): Record<string, string> {
+    updateToken(accessToken: string, refreshToken?: string): void {
+        this.accessToken = accessToken;
+        if (refreshToken) this.refreshToken = refreshToken;
+    }
+
+    private getHeaders(model?: string, stream = false): Record<string, string> {
         const headers: Record<string, string> = {
             "Content-Type": "application/json",
-            "anthropic-version": "2023-06-01"
+            "anthropic-version": "2023-06-01",
+            "Anthropic-Beta": selectAnthropicBeta(model || "")
         };
-        const token = this.accessToken || this.apiKey;
-        if (token) {
-            headers["x-api-key"] = token;
-            headers["Authorization"] = `Bearer ${token}`;
+
+        if (this.accessToken) {
+            // OAuth account — Bearer token + CLI identity headers
+            headers["Authorization"] = `Bearer ${this.accessToken}`;
+            Object.assign(headers, CLAUDE_CLI_SPOOF_HEADERS);
+            if (this.organizationId) {
+                headers["anthropic-organization-id"] = this.organizationId;
+            }
+        } else if (this.apiKey) {
+            headers["x-api-key"] = this.apiKey;
+            headers["Authorization"] = `Bearer ${this.apiKey}`;
         }
+
+        if (stream) {
+            headers["Accept"] = "text/event-stream";
+        }
+
         return headers;
     }
 
@@ -94,10 +158,14 @@ export class AnthropicExecutor implements AIProvider {
     async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
         const anthropicReq = openAIToAnthropicRequest(req);
         anthropicReq.stream = false;
+        const targetModel = req.model.includes("/")
+            ? (req.model.split("/")[1] ?? req.model)
+            : req.model;
+        anthropicReq.model = targetModel;
 
         const res = await fetch(`${this.baseUrl}/messages`, {
             method: "POST",
-            headers: this.getHeaders(),
+            headers: this.getHeaders(targetModel, false),
             body: JSON.stringify(anthropicReq)
         });
 
@@ -115,10 +183,14 @@ export class AnthropicExecutor implements AIProvider {
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const anthropicReq = openAIToAnthropicRequest(req);
         anthropicReq.stream = true;
+        const targetModel = req.model.includes("/")
+            ? (req.model.split("/")[1] ?? req.model)
+            : req.model;
+        anthropicReq.model = targetModel;
 
         const res = await fetch(`${this.baseUrl}/messages`, {
             method: "POST",
-            headers: this.getHeaders(),
+            headers: this.getHeaders(targetModel, true),
             body: JSON.stringify(anthropicReq)
         });
 

--- a/packages/providers/src/oauth/base.ts
+++ b/packages/providers/src/oauth/base.ts
@@ -8,6 +8,8 @@ export interface OAuthTokenResponse {
     tokenType: string;
     /** Optional ChatGPT/OpenAI account identifier (for multi-account binding) */
     accountId?: string;
+    /** Optional organization id (e.g. Claude OAuth) */
+    organizationId?: string;
 }
 
 export interface PKCEPair {

--- a/packages/providers/src/oauth/claude.ts
+++ b/packages/providers/src/oauth/claude.ts
@@ -1,0 +1,143 @@
+import type { OAuthTokenResponse, PKCEPair } from "./base.js";
+
+export interface ClaudeOAuthOptions {
+    clientId?: string;
+    redirectUri?: string;
+    scope?: string;
+    authorizeUrl?: string;
+    tokenUrl?: string;
+    prompt?: string;
+}
+
+/**
+ * Claude Code OAuth (port of 9router providers/registry/claude.js).
+ * Allows a Claude subscription (claude.ai account) to be used via Claude Code OAuth
+ * tokens — not just a raw API key.
+ */
+export class ClaudeOAuth {
+    private clientId: string;
+    private redirectUri: string;
+    private scope: string;
+    private authorizeUrl: string;
+    private tokenUrl: string;
+    private prompt?: string;
+
+    constructor(options: ClaudeOAuthOptions = {}) {
+        // Official Claude Code OAuth public client ID (mirrors claude-code CLI)
+        this.clientId = options.clientId ?? process.env.CLAUDE_OAUTH_CLIENT_ID ?? "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+        this.redirectUri = options.redirectUri ?? process.env.CLAUDE_OAUTH_REDIRECT_URI ?? "http://localhost:1455/auth/claude/callback";
+        this.scope = options.scope ?? process.env.CLAUDE_OAUTH_SCOPE ?? "org:create_api_key user:profile user:inference";
+        this.authorizeUrl = options.authorizeUrl ?? process.env.CLAUDE_OAUTH_AUTHORIZE_URL ?? "https://claude.ai/oauth/authorize";
+        this.tokenUrl = options.tokenUrl ?? process.env.CLAUDE_OAUTH_TOKEN_URL ?? "https://api.anthropic.com/v1/oauth/token";
+        this.prompt = options.prompt ?? process.env.CLAUDE_OAUTH_PROMPT;
+    }
+
+    /**
+     * Generates PKCE parameters and returns authorization URL
+     */
+    getAuthorizationUrl(pkce: PKCEPair): string {
+        const params: Record<string, string> = {
+            response_type: "code",
+            client_id: this.clientId,
+            redirect_uri: this.redirectUri,
+            scope: this.scope,
+            code_challenge: pkce.codeChallenge,
+            code_challenge_method: "S256",
+            state: pkce.state,
+        };
+
+        if (this.prompt) {
+            params.prompt = this.prompt;
+        }
+
+        const queryString = Object.entries(params)
+            .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+            .join("&");
+
+        return `${this.authorizeUrl}?${queryString}`;
+    }
+
+    /**
+     * Exchanges authorization code and code_verifier for Access Token.
+     * Claude OAuth uses a JSON body (not form-encoded) with client_id only.
+     */
+    async exchangeCodeForTokens(code: string, codeVerifier: string): Promise<OAuthTokenResponse> {
+        const res = await fetch(this.tokenUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                grant_type: "authorization_code",
+                client_id: this.clientId,
+                code,
+                code_verifier: codeVerifier,
+                redirect_uri: this.redirectUri,
+            }),
+        });
+
+        if (!res.ok) {
+            const errorText = await res.text();
+            throw new Error(`Claude OAuth Exchange Failed (${res.status}): ${errorText}`);
+        }
+
+        const data = (await res.json()) as {
+            access_token: string;
+            refresh_token?: string;
+            id_token?: string;
+            expires_in?: number;
+            token_type?: string;
+            organization_id?: string;
+        };
+
+        return {
+            accessToken: data.access_token,
+            refreshToken: data.refresh_token,
+            idToken: data.id_token,
+            expiresIn: data.expires_in,
+            tokenType: data.token_type ?? "Bearer",
+            organizationId: data.organization_id,
+        };
+    }
+
+    /**
+     * Refreshes an expired access token using refresh_token.
+     * Claude OAuth: JSON body, client_id only, no client_secret.
+     */
+    async refreshTokens(refreshToken: string): Promise<OAuthTokenResponse> {
+        const res = await fetch(this.tokenUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                grant_type: "refresh_token",
+                client_id: this.clientId,
+                refresh_token: refreshToken,
+            }),
+        });
+
+        if (!res.ok) {
+            const errorText = await res.text();
+            throw new Error(`Claude OAuth Refresh Failed (${res.status}): ${errorText}`);
+        }
+
+        const data = (await res.json()) as {
+            access_token: string;
+            refresh_token?: string;
+            id_token?: string;
+            expires_in?: number;
+            token_type?: string;
+            organization_id?: string;
+        };
+
+        return {
+            accessToken: data.access_token,
+            refreshToken: data.refresh_token ?? refreshToken,
+            idToken: data.id_token,
+            expiresIn: data.expires_in,
+            tokenType: data.token_type ?? "Bearer",
+            organizationId: data.organization_id,
+        };
+    }
+}

--- a/packages/providers/src/oauth/index.ts
+++ b/packages/providers/src/oauth/index.ts
@@ -1,4 +1,5 @@
 export * from "./antigravity.js";
 export * from "./base.js";
+export * from "./claude.js";
 export * from "./openai.js";
 export * from "./qoder.js";

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -49,6 +49,7 @@ export interface ProviderConfig {
     accountId?: string;
     tokenExpiresAt?: number;
     lastRefreshedAt?: number;
+    organizationId?: string;
     customHeaders?: Record<string, string>;
     providerSpecificData?: Record<string, string>;
     enabled: boolean;


### PR DESCRIPTION
## Summary

- Tambah **Claude Code OAuth** (provider `claude`, alias `cc`): login pake akun Claude subscription via claude.ai (bukan cuma API key)
- Upgrade `AnthropicExecutor`: dynamic beta headers, Claude CLI spoof headers, Bearer auth buat OAuth, org binding
- Port dari 9Router `providers/registry/claude.js` + `shared.js`

## ⚠️ DRAFT — JANGAN MERGE DULU

PR ini **draft**: belum live-tested end-to-end (gue nggak punya akun Claude). Revert dari PR #3 yang keburu ke-merge.

## Changes

- **`packages/providers/src/oauth/claude.ts`** (baru): `ClaudeOAuth` — PKCE S256, authorize URL, exchange code (JSON body, client_id only), refresh token, parse `organization_id`
- **`packages/executors/src/anthropic.ts`**: `selectAnthropicBeta(model)` — base flags + heavy-agent gated ke opus/sonnet; Claude CLI spoof headers; Bearer auth + `anthropic-organization-id` buat OAuth; `Accept: text/event-stream` streaming
- **Auth**: `/v1/auth/claude/login`, `/auth/claude/callback` (port 1455), `/v1/auth/claude/import-token`
- **Registry**: catalog `claude` + load case sebelum generic anthropic
- **DB**: kolom `organization_id`

## Test Plan

- [x] Unit test (20+ assertions): beta gating, OAuth/API-key headers, PKCE authorize URL
- [x] Build + tsc (sisa error pre-existing)
- [x] Live: login route redirect claude.ai bener, callback invalid state error, catalog nampilin claude
- [ ] ⏳ **Login end-to-end + chat: butuh akun Claude (belum)**

## Notes for Reviewers

> **Catatan**: PR ini = cherry-pick `e75d6de` di atas main yang udah di-revert (`737b717`). Jangan squash-merge pake cara biasa kalau mau — merge harus hati-hati biar revert nggak double.