### PR TITLE
feat(freebuff): add native FreeBuff provider

### DIFF
--- a/apps/api/src/controllers/providers.controller.ts
+++ b/apps/api/src/controllers/providers.controller.ts
@@ -1,8 +1,8 @@
 import type { Context } from "hono";
 import type { CreateProviderPayload } from "@/logic/providers.logic.js";
 import { ProvidersLogic } from "@/logic/providers.logic.js";
-import { deleteProviderDB } from "@srouter/db";
-import { loadSavedProvidersFromDB } from "@/services/registry.js";
+import { deleteProviderDB, getProviderByIdDB } from "@srouter/db";
+import { freebuffExecutor, loadSavedProvidersFromDB } from "@/services/registry.js";
 import { ok } from "@/utils/response.js";
 
 export class ProvidersController {
@@ -20,7 +20,7 @@ export class ProvidersController {
     }
 
     public static async getProvider(c: Context): Promise<Response> {
-        const providerId = c.req.param("providerId");
+        const providerId = c.req.param("providerId") ?? "";
         const provider = await ProvidersLogic.getProviderById(providerId);
         if (!provider) {
             return c.json({ error: { message: `Provider '${providerId}' not found` } }, 404);
@@ -37,8 +37,16 @@ export class ProvidersController {
         return ok(c, created);
     }
 
-    public static deleteProvider(c: Context): Response {
-        const id = c.req.param("id");
+    public static async deleteProvider(c: Context): Promise<Response> {
+        const id = c.req.param("id") ?? "";
+        const saved = getProviderByIdDB(id);
+        if (saved === null) {
+            return c.json({ error: { message: `Connection '${id}' not found` } }, 404);
+        }
+        const existing = saved.providerId === "freebuff" || id.startsWith("freebuff_") || id.startsWith("freebuff-")
+            ? freebuffExecutor.unregister(id)
+            : Promise.resolve();
+        await existing;
         const deleted = deleteProviderDB(id);
         if (!deleted) {
             return c.json({ error: { message: `Connection '${id}' not found` } }, 404);

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -109,7 +109,7 @@ export class ProvidersLogic {
             name: config.name,
             protocol: config.protocol,
             category: config.category,
-            baseUrl: config.baseUrl,
+            requiresApiKey: false,
             models: [],
             status: { state: "connected" },
         };

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -21,6 +21,7 @@ export interface CreateProviderPayload {
     protocol: ProviderProtocol;
     baseUrl?: string;
     apiKey?: string;
+    accessToken?: string;
 }
 
 export class ProvidersLogic {
@@ -88,6 +89,8 @@ export class ProvidersLogic {
         const protocol = payload.protocol;
         const baseUrl = payload.baseUrl?.trim();
         const apiKey = payload.apiKey?.trim();
+        const accessToken = payload.accessToken?.trim() ||
+            (id === "freebuff" || id.startsWith("freebuff_") || id.startsWith("freebuff-") ? apiKey : undefined);
 
         const config = {
             id,
@@ -97,6 +100,7 @@ export class ProvidersLogic {
             protocol,
             baseUrl,
             apiKey,
+            accessToken,
             enabled: true,
             createdAt: Date.now(),
         };

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -55,10 +55,10 @@ export function loadSavedProvidersFromDB(): void {
 
         switch (true) {
             case providerType === "freebuff" || p.id.startsWith("freebuff_") || p.id.startsWith("freebuff-"):
-                if (p.accessToken) {
+                if (p.accessToken || p.apiKey) {
                     freebuffConnections.push({
                         id: p.id,
-                        accessToken: p.accessToken,
+                        accessToken: p.accessToken || p.apiKey || "",
                         baseUrl: baseUrl || process.env.FREEBUFF_BASE_URL || "https://www.codebuff.com",
                         enabled: true,
                     });

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -1,9 +1,16 @@
 import { getAllProvidersDB } from "@srouter/db";
-import { AntigravityExecutor, AnthropicExecutor, CodexExecutor, CommandCodeExecutor, OpenAIExecutor } from "@srouter/executors";
+import { AntigravityExecutor, AnthropicExecutor, CodexExecutor, CommandCodeExecutor, FreebuffExecutor, OpenAIExecutor } from "@srouter/executors";
 import { ProviderRegistry } from "@srouter/providers";
 
 // Create a global ProviderRegistry instance
 export const registry = new ProviderRegistry();
+
+// All persisted FreeBuff tokens share one coordinator; each DB row remains a
+// separate runtime connection for pooling and failover.
+export const freebuffExecutor = new FreebuffExecutor({
+    id: "freebuff",
+    name: "FreeBuff",
+});
 
 // 1. Register env-configured OpenAI Provider if present
 if (process.env.OPENAI_API_KEY) {
@@ -34,6 +41,12 @@ if (process.env.ANTHROPIC_API_KEY) {
  */
 export function loadSavedProvidersFromDB(): void {
     const savedProviders = getAllProvidersDB();
+    const freebuffConnections = [] as {
+        id: string;
+        accessToken: string;
+        baseUrl: string;
+        enabled: boolean;
+    }[];
     for (const p of savedProviders) {
         if (!p.enabled) continue;
 
@@ -41,6 +54,16 @@ export function loadSavedProvidersFromDB(): void {
         const baseUrl = p.baseUrl || (providerType === "antigravity" || p.id.startsWith("antigravity") ? process.env.ANTIGRAVITY_BASE_URL : undefined);
 
         switch (true) {
+            case providerType === "freebuff" || p.id.startsWith("freebuff_") || p.id.startsWith("freebuff-"):
+                if (p.accessToken) {
+                    freebuffConnections.push({
+                        id: p.id,
+                        accessToken: p.accessToken,
+                        baseUrl: baseUrl || process.env.FREEBUFF_BASE_URL || "https://www.codebuff.com",
+                        enabled: true,
+                    });
+                }
+                break;
             case providerType === "commandcode" || p.id.startsWith("commandcode"):
                 registry.registerProvider(
                     new CommandCodeExecutor({
@@ -103,6 +126,9 @@ export function loadSavedProvidersFromDB(): void {
                 break;
         }
     }
+    freebuffExecutor.replaceConnections(freebuffConnections);
+    if (freebuffConnections.length > 0) registry.registerProvider(freebuffExecutor);
+    else registry.unregisterProvider("freebuff");
 }
 
 // Auto load saved DB providers

--- a/docs/superpowers/plans/2026-08-12-freebuff-native.md
+++ b/docs/superpowers/plans/2026-08-12-freebuff-native.md
@@ -1,0 +1,289 @@
+# FreeBuff Native Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the behavior of `trefeon/freebuff-proxy` into a native, pure Node.js/TypeScript FreeBuff provider inside SRouter, with one FreeBuff token per persisted connection and no sidecar proxy.
+
+**Architecture:** `FreebuffExecutor` implements the existing `AIProvider` contract and delegates to a shared `FreebuffCoordinator`. The coordinator owns one connection state machine per enabled token; each connection owns an upstream client, session manager, and agent-run manager. A shared model registry resolves model IDs to FreeBuff agent IDs and refreshes its state without fabricating live results.
+
+**Tech Stack:** TypeScript ESM, Node.js built-ins (`fetch`, `http`, `https`, `AbortController`, `crypto`), `@srouter/types`, `@srouter/translator`, `@srouter/db`, `@srouter/providers`, Hono API, SQLite, `node:test`/existing package test conventions. No uTLS or JA3 spoofing dependency; browser-like headers/User-Agent are best-effort only.
+
+## Global Constraints
+
+- Full native integration; do not run or embed the Go `freebuff-proxy` binary.
+- One FreeBuff token maps to one SRouter provider connection.
+- Public IDs preserve nested upstream model IDs: `freebuff/deepseek/deepseek-v4-flash` -> upstream `deepseek/deepseek-v4-flash`.
+- Upstream chat is forced to streaming; non-stream callers receive an accumulated OpenAI response.
+- Never log, dump, return, or include FreeBuff tokens in error messages.
+- `listModels()` uses live verified data; failures return no fabricated live list and preserve the previous valid registry state where applicable.
+- No `any` or `unknown` in `@srouter/types`, `@srouter/providers`, `@srouter/db`, or `apps/api`.
+- Do not use `rejectUnauthorized=false` as a TLS workaround.
+- Every background timer uses `.unref()` and has an explicit shutdown path.
+- Follow SRouter workspace build order: types -> db -> providers -> translator -> executors -> api.
+- Do not commit or push automatically; the repository rule requires explicit user instruction.
+
+---
+
+## File Map
+
+### New files
+
+- `packages/executors/src/freebuff/types.ts` — concrete wire payloads, parsed upstream responses, connection snapshots, leases, and typed configuration.
+- `packages/executors/src/freebuff/errors.ts` — typed errors and safe upstream error parsing.
+- `packages/executors/src/freebuff/profiles.ts` — rotating User-Agent/browser-like request headers.
+- `packages/executors/src/freebuff/convert.ts` — request normalization, schema normalization, SSE sanitization, and completion accumulator.
+- `packages/executors/src/freebuff/upstream.ts` — Codebuff HTTP client, envelope injection, compression handling, proxy support, and endpoint calls.
+- `packages/executors/src/freebuff/session.ts` — per-token session cache, single-flight refresh, queue polling, invalidation, and end.
+- `packages/executors/src/freebuff/runs.ts` — per-token agent-run state, leases, rotation, finish drain, cooldown, and shutdown.
+- `packages/executors/src/freebuff/registry.ts` — source fetch, TypeScript constant parsing, model-to-agent map, fallback/degraded state, and refresh timer.
+- `packages/executors/src/freebuff/coordinator.ts` — multi-connection round-robin/failover and lifecycle orchestration.
+- `packages/executors/src/freebuff/executor.ts` — `AIProvider` facade and model prefix handling.
+- `packages/executors/src/freebuff/*.test.ts` — focused unit/mock tests, split by module as implementation stabilizes.
+
+### Modified files
+
+- `packages/executors/src/index.ts` — export `FreebuffExecutor` and public types if needed.
+- `packages/executors/package.json` — only add a dependency if Node built-ins cannot cover the wire behavior; default is zero new runtime dependencies.
+- `packages/providers/src/registry.ts` — add `freebuff` catalog definition and status/model metadata.
+- `apps/api/src/services/registry.ts` — specific `freebuff` executor case before generic OpenAI fallback; share one coordinator across FreeBuff connections.
+- `apps/api/src/logic/providers.logic.ts` — validate/add FreeBuff token connections and provider-specific defaults.
+- `apps/api/src/controllers/providers.controller.ts` — ensure delete/disable unregisters runtime state before/with DB deletion.
+- `apps/api/src/routes/v1/providers.ts` — add only a route if the existing generic provider payload cannot configure a FreeBuff token.
+- `apps/api/src/logic/auth.logic.ts` / `apps/api/src/controllers/auth.controller.ts` / `apps/api/src/routes/v1/auth.ts` — add token import only if existing provider configuration route cannot persist/register one FreeBuff token; no OAuth flow.
+- `packages/db/src/providers.ts` — modify only if runtime metadata or enabled-update support is missing; update every row mapper and persistence query consistently.
+- `packages/types/src/provider.ts` — add a typed provider-specific config field only if existing fields are insufficient; avoid `any`/`unknown`.
+
+---
+
+## Task 1: Define typed FreeBuff domain and error contracts
+
+**Files:**
+- Create: `packages/executors/src/freebuff/types.ts`
+- Create: `packages/executors/src/freebuff/errors.ts`
+- Test: `packages/executors/src/freebuff/errors.test.ts`
+
+**Interfaces:**
+- `FreebuffExecutor` and coordinator tasks consume `FreebuffConfig`, `FreebuffConnectionConfig`, `FreebuffModelRegistryState`, `FreebuffLease`, and `FreebuffError` types.
+- `parseUpstreamError(status, body, headers): FreebuffError` returns a token-safe typed error.
+
+- [ ] **Step 1: Write failing tests** for 401 auth rejection, 429 reset/retry parsing, banned 403, waiting-room 503, session-invalid, run-invalid, unknown upstream error truncation, and credential redaction.
+- [ ] **Step 2: Run the focused test** with the package's existing test command; confirm missing types/functions fail.
+- [ ] **Step 3: Implement concrete interfaces and error classes** with `Error.cause`, `unwrap`-equivalent predicates, bounded body text, and no token fields in messages.
+- [ ] **Step 4: Run focused tests** and confirm all error cases pass.
+- [ ] **Step 5: Verify no `any`/`unknown`** in the new files with a targeted search.
+
+## Task 2: Port pure request/SSE conversion first
+
+**Files:**
+- Create: `packages/executors/src/freebuff/convert.ts`
+- Create: `packages/executors/src/freebuff/convert.test.ts`
+- Read/reference: `/tmp/freebuff-proxy/internal/convert/convert.go`
+
+**Interfaces:**
+- `normalizeRequest(req): FreebuffUpstreamChatRequest`.
+- `sanitizeSseLine(line): ChatCompletionChunk | null`.
+- `createAccumulator(): FreebuffAccumulator`.
+- `accumulateChunk(accumulator, chunk): void`.
+- `finishAccumulator(accumulator, model): ChatCompletionResponse`.
+
+- [ ] **Step 1: Write failing tests** for allowlisted fields, dropped unknown fields, `developer` role conversion, nested `$ref`/nullable schema normalization, malformed SSE dropping, reasoning preservation, `[DONE]`, tool-call fragment stitching, usage, and finish reason.
+- [ ] **Step 2: Run the focused tests** and confirm they fail before implementation.
+- [ ] **Step 3: Port the Go behavior** without copying untyped JSON maps; define recursive JSON value/schema types that satisfy SRouter's no-`any`/no-`unknown` rule.
+- [ ] **Step 4: Add model prefix helpers** that remove exactly `freebuff/` and retain all remaining slash-separated segments.
+- [ ] **Step 5: Run focused tests** and inspect serialized request/chunk fixtures.
+
+## Task 3: Implement upstream HTTP wire client
+
+**Files:**
+- Create: `packages/executors/src/freebuff/upstream.ts`
+- Create: `packages/executors/src/freebuff/profiles.ts`
+- Create: `packages/executors/src/freebuff/upstream.test.ts`
+- Read/reference: `/tmp/freebuff-proxy/internal/upstream/client.go`, `internal/stealth/headers.go`, `internal/stealth/profiles.go`
+
+**Interfaces:**
+- `FreebuffUpstreamClient` exposes `createSession`, `getSession`, `endSession`, `startRun`, `finishRun`, and `chatCompletions`.
+- `buildChatEnvelope(req, options): FreebuffUpstreamChatRequest` is pure and testable.
+- `createFreebuffTransport(config): FreebuffTransport` uses standard Node fetch/dispatcher capabilities only.
+
+- [ ] **Step 1: Write mock-server tests** asserting exact endpoint paths, Bearer auth, `x-freebuff-model`, optional instance header, envelope metadata, forced stream, provider deny, stop sentinel, content type, and model nested-ID preservation.
+- [ ] **Step 2: Add response-body decompression tests** for gzip/deflate/br only if supported by the selected Node API; otherwise document reliance on Node fetch decompression and test the actual runtime behavior.
+- [ ] **Step 3: Implement endpoint methods** with `AbortSignal`, per-call timeout, bounded error reads, status classification, redirect policy, and safe logging.
+- [ ] **Step 4: Implement HTTP/SOCKS proxy configuration** using a typed adapter; reject malformed proxy URLs and preserve TLS verification.
+- [ ] **Step 5: Implement rotating User-Agent/browser-like headers** with no JA3 claim.
+- [ ] **Step 6: Run the mock upstream test** and verify all request captures and response classifications.
+
+## Task 4: Implement per-token session manager
+
+**Files:**
+- Create: `packages/executors/src/freebuff/session.ts`
+- Create: `packages/executors/src/freebuff/session.test.ts`
+- Consume: `FreebuffUpstreamClient`, Task 1 types/errors
+
+**Interfaces:**
+- `FreebuffSessionManager.ensureSession(signal): Promise<FreebuffSessionLease>`.
+- `invalidate(): void`.
+- `end(signal): Promise<void>`.
+- `snapshot(): FreebuffSessionSnapshot`.
+
+- [ ] **Step 1: Write failing tests** for active cache reuse, expiry-margin refresh, concurrent single-flight, queued retry timing, ended/superseded recreation, invalidation, disabled sessions, and end cleanup.
+- [ ] **Step 2: Implement state machine** with mutex/single-flight promise ownership and bounded refresh iterations.
+- [ ] **Step 3: Preserve queue position/depth/retry metadata** for coordinator error selection.
+- [ ] **Step 4: Run focused tests plus a race-like concurrent stress test** with many simultaneous ensure calls.
+
+## Task 5: Implement per-token agent-run manager
+
+**Files:**
+- Create: `packages/executors/src/freebuff/runs.ts`
+- Create: `packages/executors/src/freebuff/runs.test.ts`
+- Read/reference: `/tmp/freebuff-proxy/internal/runs/runs.go`
+
+**Interfaces:**
+- `acquireRun(agentId, signal): Promise<FreebuffRunLease>`.
+- `releaseRun(lease): void`.
+- `invalidateRun(agentId): void`.
+- `maintain(signal): Promise<void>`.
+- `prewarm(agentIds, signal): Promise<void>`.
+- `shutdown(signal): Promise<void>`.
+- cooldown methods and `snapshot(): FreebuffRunSnapshot`.
+
+- [ ] **Step 1: Write failing tests** for lazy START, concurrent START convergence, inflight accounting, interval rotation, draining FINISH, retry after FINISH failure, auth/rate-limit/ban cooldown, invalidate, prewarm, and shutdown deadline.
+- [ ] **Step 2: Implement mutex-protected active/draining maps** without holding locks across upstream calls.
+- [ ] **Step 3: Add an unref'd maintain scheduler** only at coordinator level; keep manager methods deterministic for tests.
+- [ ] **Step 4: Run focused tests and inspect that no lease remains inflight after release/shutdown.**
+
+## Task 6: Implement live model registry
+
+**Files:**
+- Create: `packages/executors/src/freebuff/registry.ts`
+- Create: `packages/executors/src/freebuff/registry.test.ts`
+- Read/reference: `/tmp/freebuff-proxy/internal/registry/registry.go`, `internal/registry/parse.go`, `internal/registry/testdata/registry-fixture.ts`
+
+**Interfaces:**
+- `FreebuffModelRegistry.refresh(signal): Promise<void>`.
+- `models(): ModelObject[]`.
+- `agentForModel(modelId): string | null`.
+- `agentIds(): string[]`.
+- `start(signal): void` and `stop(): void`.
+
+- [ ] **Step 1: Write fixture tests** for direct agent maps, free-mode model blocks, constants/aliases, duplicate model precedence, sorting, malformed sources, HTTP failure retention, and empty-result rejection.
+- [ ] **Step 2: Port the parser** using concrete token/AST-like types; do not use a permissive regex that silently maps arbitrary strings.
+- [ ] **Step 3: Implement parallel source fetch with timeout and atomic state replacement.**
+- [ ] **Step 4: Implement fallback/degraded boot state and unref'd refresh timer.**
+- [ ] **Step 5: Run fixture and failure-retention tests; verify no fabricated model output after failed refresh.**
+
+## Task 7: Implement multi-connection coordinator
+
+**Files:**
+- Create: `packages/executors/src/freebuff/coordinator.ts`
+- Create: `packages/executors/src/freebuff/coordinator.test.ts`
+- Consume: Tasks 1, 3, 4, 5, and 6
+
+**Interfaces:**
+- `FreebuffCoordinator.register(config): void`.
+- `unregister(connectionId, signal): Promise<void>`.
+- `update(config): Promise<void>`.
+- `listModels(): Promise<ModelObject[]>`.
+- `chatCompletion(req): Promise<ChatCompletionResponse>`.
+- `chatCompletionStream(req): AsyncGenerator<ChatCompletionChunk, void, void>`.
+- `start(signal): Promise<void>` and `shutdown(signal): Promise<void>`.
+- `snapshot(): FreebuffCoordinatorSnapshot`.
+
+- [ ] **Step 1: Write failing tests** for one/two-token round-robin, disabled connection filtering, auth failover, all-token cooldown, waiting-room best-position selection, retry-once session/run invalidation, and unregister drain.
+- [ ] **Step 2: Implement connection registration and lifecycle** with a shared registry and no stale deleted providers.
+- [ ] **Step 3: Implement chat lease flow**: resolve model→agent, acquire run/session, call upstream, retry once on invalid state, release lease in `finally`.
+- [ ] **Step 4: Map typed FreeBuff errors to SRouter-compatible errors/status metadata** without leaking credentials.
+- [ ] **Step 5: Run coordinator tests under concurrent requests** and verify token distribution/failover.
+
+## Task 8: Add the `FreebuffExecutor` facade and exports
+
+**Files:**
+- Create: `packages/executors/src/freebuff/executor.ts`
+- Modify: `packages/executors/src/index.ts`
+- Modify: `packages/executors/package.json` only if required
+- Create: `packages/executors/src/freebuff/executor.test.ts`
+
+**Interfaces:**
+- `new FreebuffExecutor(options)` implements `AIProvider`.
+- `listModels()` delegates to coordinator and returns public `freebuff/<nested-id>` IDs.
+- `chatCompletion(req)` and `chatCompletionStream(req)` delegate while preserving request model and stream semantics.
+- `updateToken`/`shutdown` are exposed for SRouter lifecycle integration.
+
+- [ ] **Step 1: Write facade tests** for model prefixing, nested model stripping, streaming delegation, non-stream delegation, and token update.
+- [ ] **Step 2: Implement the facade and exports.**
+- [ ] **Step 3: Build `@srouter/executors` only after translator/types dependencies are available.**
+- [ ] **Step 4: Run all executor tests.**
+
+## Task 9: Wire catalog, DB configuration, registry, and runtime deletion
+
+**Files:**
+- Modify: `packages/providers/src/registry.ts`
+- Modify: `apps/api/src/services/registry.ts`
+- Modify: `apps/api/src/logic/providers.logic.ts`
+- Modify: `apps/api/src/controllers/providers.controller.ts`
+- Modify: `apps/api/src/routes/v1/providers.ts` only if needed
+- Modify: `apps/api/src/logic/auth.logic.ts` / auth controller/routes only if generic token import cannot support FreeBuff
+- Modify: `packages/db/src/providers.ts` / `packages/types/src/provider.ts` only if a concrete metadata gap is found
+- Tests: corresponding `apps/api` and providers/db tests
+
+**Interfaces:**
+- Provider ID is `freebuff`; saved connection IDs are unique `freebuff_<timestamp>` or existing explicit IDs.
+- `loadSavedProvidersFromDB()` routes FreeBuff before generic OpenAI.
+- Add/enable registers the connection with the shared coordinator immediately.
+- Delete/disable unregisters and drains runtime state before returning success.
+
+- [ ] **Step 1: Add failing wiring tests** for catalog presence, generic OpenAI non-capture, DB reload, one-token-per-connection persistence, and delete/unregister.
+- [ ] **Step 2: Add the catalog definition** without hardcoded live models; use coordinator live models for connected state.
+- [ ] **Step 3: Add the specific registry case** before `p.protocol === "openai"`.
+- [ ] **Step 4: Extend provider add/config flow** with FreeBuff defaults and token validation, preserving the existing generic provider path.
+- [ ] **Step 5: Add runtime unregister/update support** and wire deletion/disable to it; verify deleted providers disappear from `/v1/models` and cannot receive traffic.
+- [ ] **Step 6: Run API/provider/db focused tests and targeted type checks.**
+
+## Task 10: Add end-to-end mock smoke coverage and operational docs
+
+**Files:**
+- Create: `packages/executors/src/freebuff/smoke-test.mjs` or use the repository's existing test location
+- Modify: `README.md` or provider docs only with verified setup instructions
+- Tests: API route smoke fixture if existing test harness supports it
+
+- [ ] **Step 1: Start an ephemeral mock Codebuff server** with session, agent-run, models-source, and SSE endpoints; assert captured envelope and lifecycle ordering.
+- [ ] **Step 2: Register two FreeBuff connections in an isolated test registry** and exercise `/v1/models`, non-stream chat, stream chat, waiting room, auth failover, delete, and shutdown.
+- [ ] **Step 3: Verify model IDs retain nested slashes end-to-end.**
+- [ ] **Step 4: Document only behavior actually verified; explicitly note pure-Node TLS limitation and secure token configuration.**
+- [ ] **Step 5: Remove temporary smoke artifacts if they are not part of the permanent test suite.**
+
+## Task 11: Full verification and review gate
+
+**Files:**
+- No new implementation files; inspect all changed files.
+
+- [ ] **Step 1: Run the required workspace build order:**
+
+```bash
+pnpm --filter @srouter/types build
+pnpm --filter @srouter/db build
+pnpm --filter @srouter/providers build
+pnpm --filter @srouter/translator build
+pnpm --filter @srouter/executors build
+pnpm --filter api exec tsc --noEmit
+```
+
+- [ ] **Step 2: Run focused tests for converter, upstream, session, runs, registry, coordinator, facade, DB, and API wiring.**
+- [ ] **Step 3: Run `git diff --check` and targeted searches for `any`, `unknown`, credential logging, `rejectUnauthorized: false`, and unref'd timers in changed protected areas.**
+- [ ] **Step 4: Inspect `git diff --stat` and `git status --short`; confirm no tokens, dumps, generated `dist`, or unrelated files are included.**
+- [ ] **Step 5: Perform a whole-branch review against the approved spec before asking for user review/merge.**
+
+---
+
+## Implementation Notes
+
+- Use `/tmp/freebuff-proxy` as the behavior reference, not as a runtime dependency. Re-check relevant Go tests/fixtures while porting each module.
+- Keep the implementation modular, but do not create a new package until executor-local boundaries become a proven dependency problem.
+- Preserve existing SRouter provider behavior; the FreeBuff-specific registry case must precede generic protocol fallbacks.
+- No real-token live verification belongs in CI. Perform it manually only when Seaavey supplies a token through a secure environment mechanism.
+- This plan deliberately leaves commits/pushes to explicit user instruction because `.agents/AGENTS.md` forbids automatic git side effects.
+
+---
+
+## Plan Acceptance
+
+Plan derived from `docs/superpowers/specs/2026-08-12-freebuff-native-design.md`. Implementation has not started in this planning document.

--- a/docs/superpowers/specs/2026-08-12-freebuff-native-design.md
+++ b/docs/superpowers/specs/2026-08-12-freebuff-native-design.md
@@ -1,0 +1,170 @@
+# FreeBuff Native Provider — Design Spec
+
+## Status
+
+- **Status:** Draft — desain disetujui Seaavey untuk ditulis sebagai spec
+- **Scope:** Full parity native di SRouter; tidak menjalankan `freebuff-proxy` sebagai service terpisah
+- **Constraint:** Pure Node.js/TypeScript. TLS JA3 spoofing asli tidak ditargetkan; browser-like headers/User-Agent hanya best-effort.
+
+## Tujuan
+
+Menambahkan FreeBuff sebagai provider native di SRouter sehingga SRouter langsung berbicara dengan endpoint Codebuff/FreeBuff dan mempertahankan lifecycle yang dibutuhkan upstream: free session, agent run, CLI request envelope, model registry, multi-token failover, streaming, non-streaming, dan typed error handling.
+
+Satu token FreeBuff direpresentasikan sebagai satu koneksi provider di dashboard/database. Seluruh koneksi FreeBuff dikoordinasikan oleh satu coordinator runtime agar pooling dan failover tetap konsisten.
+
+## Non-goals
+
+- Menjalankan binary Go `freebuff-proxy`.
+- Menyediakan JA3/TLS ClientHello impersonation setara uTLS.
+- Mengubah provider executor lain atau routing umum lebih dari yang diperlukan.
+- Menambahkan hardcoded model yang terlihat sebagai model live; fallback registry hanya boleh dipakai sesuai parity upstream dan harus dibedakan dari hasil live.
+- Menambahkan OAuth FreeBuff sebelum mekanisme token import/configuration native disepakati.
+
+## Arsitektur
+
+```text
+SRouter API
+  -> ProviderRegistry
+  -> FreebuffExecutor facade
+  -> FreebuffCoordinator
+      -> FreebuffConnection[token A]
+          -> session manager
+          -> run manager
+          -> upstream client
+      -> FreebuffConnection[token B]
+          -> session manager
+          -> run manager
+          -> upstream client
+      -> model registry
+```
+
+Komponen provider berada di `packages/executors/src/freebuff/`:
+
+- `executor.ts`: implementasi `AIProvider`; facade chat/model.
+- `coordinator.ts`: round-robin, failover, cooldown, waiting-room selection, lease release.
+- `upstream.ts`: HTTP wire protocol Codebuff/FreeBuff, auth, envelope, headers, compression, optional HTTP/SOCKS proxy.
+- `session.ts`: create/poll/cache/invalidate/end dengan single-flight per token.
+- `runs.ts`: START/FINISH, prewarm, rotasi, inflight drain, shutdown.
+- `registry.ts`: fetch dan parse source TypeScript Codebuff menjadi mapping model→agent; refresh periodik dan previous-state retention.
+- `convert.ts`: request whitelist, `developer`→`system`, tool-schema normalization, SSE sanitization, accumulator non-stream.
+- `errors.ts`: typed errors dan mapping ke contract SRouter.
+- `profiles.ts`: User-Agent dan browser-like header profiles tanpa klaim JA3 spoof.
+
+Jika ukuran file atau coupling berkembang, komponen lifecycle boleh dipindahkan ke package internal khusus, tetapi boundary `AIProvider` tetap di executor.
+
+## Request dan model contract
+
+Public model ID memakai prefix provider SRouter dan mempertahankan nested ID upstream, misalnya:
+
+```text
+freebuff/deepseek/deepseek-v4-flash
+```
+
+Saat request dikirim upstream, hanya prefix `freebuff/` yang dihapus sehingga model menjadi:
+
+```text
+deepseek/deepseek-v4-flash
+```
+
+`listModels()` wajib live-fetch registry ketika sumber upstream tersedia. Jika refresh gagal, registry mempertahankan mapping valid sebelumnya; saat boot pertama, fallback parity boleh dipakai sebagai degraded/offline state dan tidak boleh mengarang model di luar catalog yang diketahui.
+
+Chat harus mendukung:
+
+- request streaming SSE dengan chunk yang valid dan terminator `[DONE]`;
+- request non-streaming dengan akumulasi content, reasoning, tool calls, finish reason, dan usage;
+- whitelist parameter agar field yang tidak didukung upstream tidak diteruskan;
+- cancellation saat client disconnect.
+
+## Upstream envelope
+
+Setiap chat upstream harus mempertahankan field/header parity berikut:
+
+- `x-freebuff-model`;
+- `x-freebuff-instance-id` jika session aktif;
+- `codebuff_metadata` berisi `run_id`, generated `client_id`, dan instance id/session metadata;
+- `provider.data_collection = deny`;
+- `stream = true` ke upstream;
+- stop sentinel `cb_easp` bila client tidak memberi stop sendiri;
+- rotating User-Agent/browser headers best-effort.
+
+Token upstream hanya boleh berasal dari konfigurasi provider/database dan tidak boleh masuk log, error body, dump, atau response.
+
+## Session dan run lifecycle
+
+Per koneksi/token:
+
+- session dibuat lazy atau diprewarm sesuai parity yang aman terhadap quota;
+- session active dipakai sampai expiry margin;
+- queued session menghasilkan waiting-room error dengan retry delay;
+- ended/superseded/expired/session-invalid di-invalidate dan dibuat ulang;
+- concurrent refresh dibuat single-flight;
+- agent run di-START saat diperlukan, dipelihara, dirotasi sesuai interval, lalu di-FINISH setelah inflight lease selesai;
+- shutdown menghentikan scheduler, menolak pekerjaan baru, FINISH run, END session, dan memakai deadline terbatas;
+- timer background harus `.unref()` agar tidak menahan proses test/shutdown.
+
+## Pooling dan error handling
+
+Coordinator memilih koneksi enabled secara round-robin dan failover linear.
+
+- `401`: cooldown token 30 menit, lanjut token berikutnya.
+- `429` quota: cooldown sampai `retryAfter/resetAt`, lalu surfacing 429 bila seluruh token exhausted.
+- temporary ban: cooldown sampai `resumesAt`, surfacing 403 bila seluruh token banned.
+- waiting room: coba token lain; jika semuanya queued, pilih posisi terbaik dan surfacing 503 + Retry-After.
+- session/run invalid: invalidate komponen terkait dan retry maksimal sekali.
+- error lain: lanjut failover; jika seluruh token gagal, surfacing error upstream yang aman.
+
+## Persistence dan wiring SRouter
+
+Provider config memakai `providerId = "freebuff"`, `protocol = "openai"`, dan satu `accessToken` per koneksi. `baseUrl` default mengarah ke upstream Codebuff/FreeBuff yang digunakan client native, bukan localhost proxy.
+
+Perubahan wiring yang dibutuhkan:
+
+1. export `FreebuffExecutor` dari `packages/executors/src/index.ts`;
+2. tambah case spesifik `freebuff` sebelum generic `protocol === "openai"` di `apps/api/src/services/registry.ts`;
+3. tambah token-import/config path FreeBuff yang menyimpan satu token per koneksi dan langsung mendaftarkan runtime instance;
+4. tambah catalog/provider definition serta model filtering dengan public `freebuff/<nested-id>`;
+5. pastikan delete/disable membersihkan runtime coordinator, bukan hanya row SQLite;
+6. jika metadata runtime/config tambahan dibutuhkan, gunakan field persisted khusus yang sudah disediakan codebase, bukan menyamarkan auth mode di `customHeaders`;
+7. jangan memakai `any` atau `unknown` di area yang dilindungi `.agents/AGENTS.md`.
+
+Tidak ada perubahan database yang dibutuhkan bila satu token dapat direpresentasikan oleh kolom `access_token`, `base_url`, dan metadata provider yang sudah ada. Migration hanya ditambahkan bila implementasi menemukan kebutuhan persisted yang konkret.
+
+## Security dan operasional
+
+- Default listen/API behavior SRouter tetap berlaku.
+- FreeBuff token tidak boleh dikirim sebagai client API key ke upstream secara salah; executor menambahkan Bearer token hanya pada outbound Codebuff request.
+- Debug dump harus opt-in, directory-bound, dan redacted.
+- Base URL harus divalidasi agar tidak mengarah ke target yang tidak diinginkan oleh konfigurasi user.
+- TLS best-effort tidak boleh menggunakan `rejectUnauthorized=false` sebagai shortcut.
+- Error yang dikembalikan ke client harus menghapus credential dan membatasi ukuran body upstream.
+
+## Verification criteria
+
+- TypeScript compile bersih pada package yang berubah dan `apps/api`.
+- Unit test converter: whitelist, role, schema, SSE, tool call accumulator.
+- Unit test session: single-flight, queued, expiry, invalidate, end.
+- Unit test runs: concurrent acquire, rotation, release/drain, cooldown, shutdown.
+- Unit test coordinator: round-robin, auth failover, waiting-room best selection, all-token error.
+- Mock upstream test memverifikasi URL, method, headers, envelope, model nested, dan stream.
+- `listModels()` healthy mengembalikan hasil live; failure tidak mengembalikan fabricated live list.
+- Smoke test SRouter `/v1/models`, non-stream chat, stream chat, disable/delete koneksi, dan shutdown.
+- Live verification dengan token FreeBuff asli dilakukan hanya setelah user menyediakan credential secara aman; credential tidak ditulis ke repository.
+
+## Risiko dan mitigasi
+
+- **Upstream undocumented berubah:** typed classifier + previous registry state + fixture tests; live test wajib setelah implementasi.
+- **Quota/session admission terbakar oleh prewarm:** prewarm dibuat best-effort dan tidak melakukan POST session berkala tanpa kebutuhan.
+- **Nested model ID salah dipotong:** helper prefix stripping diuji eksplisit.
+- **State runtime tertinggal setelah delete/disable:** coordinator memiliki register/unregister/update lifecycle dan diuji dari DB sampai registry.
+- **TLS JA3 berbeda dari Go proxy:** dokumentasikan sebagai batasan pure Node, gunakan header/profile best-effort, jangan klaim parity penuh pada fingerprint layer.
+- **Timer menggantungkan test:** semua scheduler/timer memakai `.unref()` dan shutdown eksplisit.
+
+## Keputusan terbuka yang bukan blocker desain
+
+- Nama route UI/token import final mengikuti pola provider existing.
+- Interval refresh/rotation dapat diekspos sebagai konfigurasi provider setelah baseline parity lulus.
+- Apakah fallback model boot ditampilkan di UI atau hanya dipakai internal ditentukan saat implementation plan berdasarkan contract `listModels()` SRouter.
+
+## Acceptance
+
+Desain ini disetujui Seaavey pada 2026-08-12 untuk dilanjutkan ke implementation plan. Implementasi belum dimulai pada spec ini.

--- a/packages/executors/src/freebuff.ts
+++ b/packages/executors/src/freebuff.ts
@@ -1,0 +1,3 @@
+/** Public FreeBuff executor entrypoint. */
+export { FreebuffExecutor } from "./freebuff/executor.js";
+export type { FreebuffExecutorOptions } from "./freebuff/executor.js";

--- a/packages/executors/src/freebuff/convert.test.ts
+++ b/packages/executors/src/freebuff/convert.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ChatCompletionChunk } from "@srouter/types";
+import {
+    accumulateChunk,
+    createAccumulator,
+    finishAccumulator,
+    normalizeRequest,
+    removeFreebuffModelPrefix,
+    sanitizeSseLine,
+    withFreebuffModelPrefix,
+    type FreebuffRequestInput,
+} from "./convert.js";
+
+type ChatMessageWithReasoning = { reasoning_content?: string };
+
+test("normalizes allowlisted request fields and developer role", () => {
+    const input: FreebuffRequestInput = {
+        model: "freebuff/deepseek/deepseek-v4-flash",
+        messages: [{ role: "developer", content: "be concise" }, { role: "user", content: "hi" }],
+        temperature: 0.2,
+        max_tokens: 20,
+        stream: true,
+        n: 2,
+        bogus: "drop me",
+    };
+    const output = normalizeRequest(input);
+    assert.equal(output.model, input.model);
+    assert.equal(output.temperature, 0.2);
+    assert.equal(output.max_tokens, 20);
+    assert.equal("stream" in output, false);
+    assert.equal("n" in output, false);
+    assert.equal("bogus" in output, false);
+    assert.equal(output.messages[0]?.role, "system");
+});
+
+test("resolves nested refs and removes nullable schema noise", () => {
+    const input: FreebuffRequestInput = {
+        model: "m",
+        messages: [],
+        tools: [{
+            type: "function",
+            function: {
+                name: "lookup",
+                parameters: {
+                    type: "object",
+                    properties: { value: { $ref: "#/$defs/Value" } },
+                    $defs: { Value: { anyOf: [{ type: "string" }, { type: "null" }], nullable: true } },
+                },
+            },
+        }],
+    };
+    const normalized = normalizeRequest(input);
+    const tools = normalized.tools;
+    assert.ok(Array.isArray(tools));
+    const tool = tools[0];
+    assert.ok(tool && typeof tool === "object" && !Array.isArray(tool));
+    const functionValue = tool.function;
+    assert.ok(functionValue && typeof functionValue === "object" && !Array.isArray(functionValue));
+    const parameters = functionValue.parameters;
+    assert.deepEqual(parameters, { type: "object", properties: { value: { type: "string" } } });
+});
+
+test("drops malformed SSE and preserves reasoning and usage", () => {
+    assert.equal(sanitizeSseLine("data: {bad"), null);
+    assert.equal(sanitizeSseLine("event: message"), null);
+    const chunk = sanitizeSseLine('data: {"id":"c1","choices":[{"index":0,"delta":{"content":"x","reasoning_content":"think"},"finish_reason":null}]}');
+    assert.equal(chunk?.choices[0]?.delta.content, "x");
+    assert.equal(chunk?.choices[0]?.delta.reasoning_content, "think");
+    const usage = sanitizeSseLine('data: {"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}');
+    assert.deepEqual(usage?.usage, { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 });
+    const toolChunk = sanitizeSseLine('data: {"system_fingerprint":"fp","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{\\"q\\":\\""}}]}}]}');
+    assert.equal(toolChunk?.system_fingerprint, "fp");
+    assert.deepEqual(toolChunk?.choices[0]?.delta.tool_calls?.[0]?.function, { name: "search", arguments: '{"q":"' });
+    assert.equal(sanitizeSseLine("data: [DONE]"), null);
+});
+
+test("accumulates non-stream content, reasoning, tool fragments, usage, and finish reason", () => {
+    const accumulator = createAccumulator();
+    const chunks: ChatCompletionChunk[] = [
+        { id: "c1", object: "chat.completion.chunk", created: 10, model: "upstream", choices: [{ index: 0, delta: { content: "Hello", reasoning_content: "think " }, finish_reason: null }] },
+        { id: "c1", object: "chat.completion.chunk", created: 10, model: "upstream", choices: [{ index: 0, delta: { content: " world", reasoning_content: "step", tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "search", arguments: "{\"q\":\"" } }] }, finish_reason: null }] },
+        { id: "c1", object: "chat.completion.chunk", created: 10, model: "upstream", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: "x\"}" } }] }, finish_reason: "tool_calls" }] },
+        { id: "c1", object: "chat.completion.chunk", created: 10, model: "upstream", choices: [], usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 } },
+    ];
+    for (const chunk of chunks) accumulateChunk(accumulator, chunk);
+    const response = finishAccumulator(accumulator, "freebuff/deepseek/deepseek-v4-flash");
+    assert.equal(response.model, "freebuff/deepseek/deepseek-v4-flash");
+    assert.equal(response.choices[0]?.message.content, "Hello world");
+    assert.equal((response.choices[0]?.message as ChatMessageWithReasoning).reasoning_content, "think step");
+    assert.equal(response.choices[0]?.finish_reason, "tool_calls");
+    assert.deepEqual(response.choices[0]?.message.tool_calls?.[0]?.function, { name: "search", arguments: '{"q":"x"}' });
+    assert.deepEqual(response.usage, { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 });
+});
+
+test("preserves nested model IDs while changing only exact prefix", () => {
+    assert.equal(removeFreebuffModelPrefix("freebuff/deepseek/deepseek-v4-flash"), "deepseek/deepseek-v4-flash");
+    assert.equal(removeFreebuffModelPrefix("other/freebuff/model"), "other/freebuff/model");
+    assert.equal(withFreebuffModelPrefix("deepseek/deepseek-v4-flash"), "freebuff/deepseek/deepseek-v4-flash");
+});
+
+test("preserves a non-standard legacy finish reason at the SRouter response boundary", () => {
+    const chunk = sanitizeSseLine('data: {"choices":[{"delta":{},"finish_reason":"legacy_complete"}]}');
+    assert.equal(chunk?.choices[0]?.finish_reason, "legacy_complete");
+    const accumulator = createAccumulator();
+    if (chunk) accumulateChunk(accumulator, chunk);
+    const response = finishAccumulator(accumulator, "m");
+    assert.equal(response.choices[0]?.finish_reason, null);
+    assert.equal(response.choices[0]?.legacy_finish_reason, "legacy_complete");
+});
+
+test("returns zero usage and stop for an empty accumulator", () => {
+    const response = finishAccumulator(createAccumulator(), "m");
+    assert.equal(response.choices[0]?.finish_reason, "stop");
+    assert.deepEqual(response.usage, { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+});

--- a/packages/executors/src/freebuff/convert.ts
+++ b/packages/executors/src/freebuff/convert.ts
@@ -1,0 +1,286 @@
+import { randomUUID } from "node:crypto";
+import type {
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionChunkDeltaToolCall,
+    ChatCompletionResponse,
+    ChatMessage,
+
+    ChatMessageRole,
+    FinishReason,
+    ToolCall,
+    UsageInfo,
+} from "@srouter/types";
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export interface FreebuffMessageInput {
+    role: string;
+    content: JsonValue;
+    [key: string]: JsonValue;
+}
+
+export interface FreebuffToolInput {
+    type: string;
+    function: JsonObject;
+    [key: string]: JsonValue;
+}
+
+export interface FreebuffRequestInput {
+    model: string;
+    messages: readonly FreebuffMessageInput[];
+    [key: string]: JsonValue | readonly FreebuffMessageInput[] | readonly FreebuffToolInput[];
+}
+
+export interface FreebuffUpstreamChatRequest {
+    model: string;
+    messages: FreebuffMessageInput[];
+    [key: string]: JsonValue | FreebuffMessageInput[];
+}
+
+type FreebuffFinishReason = FinishReason | string;
+interface FreebuffLogprobEntry {
+    token: string;
+    logprob: number;
+    bytes?: number[];
+    top_logprobs?: FreebuffLogprobEntry[];
+}
+interface FreebuffChoiceLogprobs {
+    content?: FreebuffLogprobEntry[];
+    refusal?: FreebuffLogprobEntry[];
+}
+interface FreebuffChunkChoice extends Omit<ChatCompletionChunkChoice, "finish_reason"> {
+    finish_reason: FreebuffFinishReason;
+    logprobs?: FreebuffChoiceLogprobs;
+}
+export type FreebuffSanitizedChunk = Omit<ChatCompletionChunk, "choices"> & {
+    choices: FreebuffChunkChoice[];
+    system_fingerprint?: string;
+};
+interface FreebuffCompletionChoice extends Omit<ChatCompletionResponse["choices"][number], "finish_reason"> {
+    finish_reason: FinishReason;
+    legacy_finish_reason?: string;
+}
+export type FreebuffCompletionResponse = Omit<ChatCompletionResponse, "choices"> & {
+    choices: FreebuffCompletionChoice[];
+};
+
+type ToolCallState = { id: string; type: "function"; name: string; arguments: string };
+export interface FreebuffAccumulator {
+    id: string;
+    created: number;
+    upstreamModel: string;
+    content: string[];
+    reasoning: string[];
+    finishReason: FreebuffFinishReason;
+    usage: UsageInfo | undefined;
+    systemFingerprint: string | undefined;
+    toolCalls: Map<number, ToolCallState>;
+}
+
+const ALLOWED_FIELDS = new Set([
+    "frequency_penalty", "logit_bias", "logprobs", "max_completion_tokens", "max_tokens", "metadata",
+    "modalities", "parallel_tool_calls", "presence_penalty", "reasoning_effort", "response_format", "seed",
+    "service_tier", "stop", "store", "stream_options", "temperature", "tool_choice", "tools", "top_logprobs", "top_p", "user",
+]);
+const MAX_SCHEMA_DEPTH = 12;
+
+function isObject(value: JsonValue): value is JsonObject { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function clone(value: JsonValue): JsonValue {
+    if (Array.isArray(value)) return value.map(clone);
+    if (isObject(value)) { const output: JsonObject = {}; for (const [key, child] of Object.entries(value)) output[key] = clone(child); return output; }
+    return value;
+}
+function definitions(node: JsonObject): JsonObject | undefined {
+    const output: JsonObject = {};
+    let found = false;
+    for (const key of ["definitions", "$defs"]) { const value = node[key]; if (isObject(value)) { found = true; Object.assign(output, value); } }
+    return found ? output : undefined;
+}
+function mergeDefinitions(parent: JsonObject | undefined, local: JsonObject | undefined): JsonObject | undefined {
+    if (!parent) return local;
+    if (!local) return parent;
+    return { ...parent, ...local };
+}
+function nullSchema(node: JsonObject): boolean {
+    if (node.type === "null" || node.const === null) return true;
+    return Array.isArray(node.enum) && node.enum.length === 1 && node.enum[0] === null;
+}
+function resolveRef(node: JsonObject, defs: JsonObject | undefined): JsonValue | undefined {
+    if (!defs || Object.keys(node).length !== 1 || typeof node.$ref !== "string") return undefined;
+    const prefix = node.$ref.startsWith("#/definitions/") ? "#/definitions/" : "#/$defs/";
+    if (!node.$ref.startsWith(prefix)) return undefined;
+    const target = defs[node.$ref.slice(prefix.length)];
+    return target === undefined ? undefined : clone(target);
+}
+function normalizeSchema(node: JsonObject, inherited: JsonObject | undefined, depth: number): JsonObject {
+    if (depth <= 0) return node;
+    const defs = mergeDefinitions(inherited, definitions(node));
+    const resolved = resolveRef(node, defs);
+    if (resolved !== undefined && isObject(resolved)) return normalizeSchema(resolved, defs, depth - 1);
+    const output: JsonObject = {};
+    for (const [key, value] of Object.entries(node)) {
+        if (key !== "definitions" && key !== "$defs" && key !== "nullable") output[key] = normalizeSchemaValue(value, defs, depth - 1);
+    }
+    for (const key of ["anyOf", "oneOf"]) {
+        const value = output[key];
+        if (!Array.isArray(value)) continue;
+        const filtered = value.filter((entry) => !isObject(entry) || !nullSchema(entry));
+        if (filtered.length === 0) delete output[key];
+        else if (filtered.length === 1 && isObject(filtered[0])) { delete output[key]; Object.assign(output, filtered[0]); }
+        else output[key] = filtered;
+    }
+    if (Array.isArray(output.type)) {
+        const type = output.type.find((entry): entry is string => typeof entry === "string" && entry.trim() !== "" && entry !== "null");
+        if (type) output.type = type; else delete output.type;
+    }
+    if (Array.isArray(output.enum)) {
+        const seen = new Set<string>();
+        const values = output.enum.filter((entry) => { if (entry === null) return false; const key = JSON.stringify(entry); if (seen.has(key)) return false; seen.add(key); return true; });
+        if (values.length) output.enum = values; else delete output.enum;
+    }
+    if (output.const === null) delete output.const;
+    return output;
+}
+function normalizeSchemaValue(value: JsonValue, defs: JsonObject | undefined, depth: number): JsonValue {
+    if (Array.isArray(value)) return value.map((entry) => normalizeSchemaValue(entry, defs, depth));
+    return isObject(value) ? normalizeSchema(value, defs, depth) : value;
+}
+function isFreebuffToolInput(value: JsonValue): value is FreebuffToolInput {
+    return isObject(value) && typeof value.type === "string" && isObject(value.function);
+}
+function normalizeTools(tools: readonly JsonValue[]): JsonValue[] {
+    return tools.map((tool) => {
+        if (!isFreebuffToolInput(tool)) return clone(tool);
+        const copy: FreebuffToolInput = { ...tool, function: { ...tool.function } };
+        const params = copy.function.parameters;
+        if (isObject(params)) copy.function.parameters = normalizeSchema(params, definitions(params), MAX_SCHEMA_DEPTH);
+        return copy;
+    });
+}
+
+export function normalizeRequest(req: FreebuffRequestInput): FreebuffUpstreamChatRequest {
+    const output: FreebuffUpstreamChatRequest = { model: req.model, messages: req.messages.map((message) => ({ ...message, role: message.role === "developer" ? "system" : message.role })) };
+    for (const [key, value] of Object.entries(req)) {
+        if (ALLOWED_FIELDS.has(key) && value !== null) output[key] = key === "tools" && Array.isArray(value) ? normalizeTools(value) : value as JsonValue;
+    }
+    return output;
+}
+
+function integer(value: JsonValue, fallback: number): number { return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : fallback; }
+function createdSeconds(value: JsonValue): number {
+    const created = integer(value, 0);
+    return created > 0 ? created : Math.floor(Date.now() / 1000);
+}
+function fallbackChatId(): string { return `chatcmpl-${randomUUID()}`; }
+function fallbackToolCallId(): string { return `call_${randomUUID()}`; }
+function parseLine(line: string): JsonValue | null {
+    const text = line.trim();
+    if (!text || text.startsWith(":") || /^(event|id|retry):/.test(text)) return null;
+    const payload = text.startsWith("data:") ? text.slice(5).trim() : text;
+    if (!payload || payload === "[DONE]" || !payload.startsWith("{")) return null;
+    try { const value: JsonValue = JSON.parse(payload) as JsonValue; return isObject(value) ? value : null; } catch { return null; }
+}
+function usage(value: JsonValue): UsageInfo | undefined {
+    if (!isObject(value) || typeof value.prompt_tokens !== "number" || typeof value.completion_tokens !== "number" || typeof value.total_tokens !== "number") return undefined;
+    const result: UsageInfo = { prompt_tokens: value.prompt_tokens, completion_tokens: value.completion_tokens, total_tokens: value.total_tokens };
+    if (isObject(value.prompt_tokens_details) && typeof value.prompt_tokens_details.cached_tokens === "number") {
+        result.prompt_tokens_details = { cached_tokens: value.prompt_tokens_details.cached_tokens };
+    }
+    if (isObject(value.completion_tokens_details) && typeof value.completion_tokens_details.reasoning_tokens === "number") {
+        result.completion_tokens_details = { reasoning_tokens: value.completion_tokens_details.reasoning_tokens };
+    }
+    return result;
+}
+function role(value: JsonValue): ChatMessageRole | undefined { return value === "system" || value === "user" || value === "assistant" || value === "tool" || value === "function" ? value : undefined; }
+function finish(value: JsonValue): FreebuffFinishReason { return value === null ? null : typeof value === "string" ? value : null; }
+function isSrouterFinishReason(value: FreebuffFinishReason): value is FinishReason {
+    return value === null || value === "stop" || value === "length" || value === "tool_calls" || value === "content_filter";
+}
+function logprobEntries(value: JsonValue): FreebuffLogprobEntry[] | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const entries: FreebuffLogprobEntry[] = [];
+    for (const item of value) {
+        if (!isObject(item) || typeof item.token !== "string" || typeof item.logprob !== "number" || !Number.isFinite(item.logprob)) continue;
+        const entry: FreebuffLogprobEntry = { token: item.token, logprob: item.logprob };
+        if (Array.isArray(item.bytes)) {
+            const bytes = item.bytes.filter((byte): byte is number => typeof byte === "number" && Number.isInteger(byte));
+            if (bytes.length === item.bytes.length) entry.bytes = bytes;
+        }
+        const topLogprobs = logprobEntries(item.top_logprobs);
+        if (topLogprobs) entry.top_logprobs = topLogprobs;
+        entries.push(entry);
+    }
+    return entries;
+}
+function choiceLogprobs(value: JsonValue): FreebuffChoiceLogprobs | undefined {
+    if (!isObject(value)) return undefined;
+    const output: FreebuffChoiceLogprobs = {};
+    const content = logprobEntries(value.content);
+    const refusal = logprobEntries(value.refusal);
+    if (content) output.content = content;
+    if (refusal) output.refusal = refusal;
+    return content || refusal ? output : undefined;
+}
+function toolCallFragments(value: JsonValue): ChatCompletionChunkDeltaToolCall[] | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const fragments: ChatCompletionChunkDeltaToolCall[] = [];
+    for (const entry of value) {
+        if (!isObject(entry) || typeof entry.index !== "number") continue;
+        const fragment: ChatCompletionChunkDeltaToolCall = { index: Math.trunc(entry.index) };
+        if (typeof entry.id === "string") fragment.id = entry.id;
+        if (entry.type === "function") fragment.type = "function";
+        if (isObject(entry.function)) {
+            const functionFragment: { name?: string; arguments?: string } = {};
+            if (typeof entry.function.name === "string") functionFragment.name = entry.function.name;
+            if (typeof entry.function.arguments === "string") functionFragment.arguments = entry.function.arguments;
+            if (functionFragment.name !== undefined || functionFragment.arguments !== undefined) fragment.function = functionFragment;
+        }
+        fragments.push(fragment);
+    }
+    return fragments;
+}
+
+export function sanitizeSseLine(line: string): FreebuffSanitizedChunk | null {
+    const raw = parseLine(line); if (!raw || !isObject(raw)) return null;
+    const rawChoices = Array.isArray(raw.choices) ? raw.choices : [];
+    const choices: FreebuffChunkChoice[] = [];
+    for (const value of rawChoices) {
+        if (!isObject(value)) continue;
+        const rawDelta = isObject(value.delta) ? value.delta : {};
+        const toolCalls = toolCallFragments(rawDelta.tool_calls);
+        const delta = { ...(typeof rawDelta.content === "string" ? { content: rawDelta.content } : {}), ...(typeof rawDelta.reasoning_content === "string" ? { reasoning_content: rawDelta.reasoning_content } : {}), ...(role(rawDelta.role) ? { role: role(rawDelta.role) } : {}), ...(toolCalls ? { tool_calls: toolCalls } : {}) };
+        const choice: FreebuffChunkChoice = { index: integer(value.index, 0), delta, finish_reason: finish(value.finish_reason ?? null) };
+        const parsedLogprobs = choiceLogprobs(value.logprobs);
+        if (parsedLogprobs) choice.logprobs = parsedLogprobs;
+        choices.push(choice);
+    }
+    const parsedUsage = usage(raw.usage);
+    if (!choices.length && !parsedUsage) return null;
+    return { id: typeof raw.id === "string" && raw.id ? raw.id : fallbackChatId(), object: "chat.completion.chunk", created: createdSeconds(raw.created), model: typeof raw.model === "string" ? raw.model : "", choices, ...(parsedUsage ? { usage: parsedUsage } : {}), ...(typeof raw.system_fingerprint === "string" ? { system_fingerprint: raw.system_fingerprint } : {}) };
+}
+
+export function createAccumulator(): FreebuffAccumulator { return { id: fallbackChatId(), created: Math.floor(Date.now() / 1000), upstreamModel: "", content: [], reasoning: [], finishReason: null, usage: undefined, systemFingerprint: undefined, toolCalls: new Map() }; }
+export function accumulateChunk(accumulator: FreebuffAccumulator, chunk: FreebuffSanitizedChunk): void {
+    accumulator.id = chunk.id || accumulator.id; if (chunk.created > 0) accumulator.created = chunk.created; accumulator.upstreamModel = chunk.model || accumulator.upstreamModel; if (chunk.usage) accumulator.usage = chunk.usage; if (chunk.system_fingerprint) accumulator.systemFingerprint = chunk.system_fingerprint;
+    for (const choice of chunk.choices) { if (choice.finish_reason !== null) accumulator.finishReason = choice.finish_reason; if (choice.delta.content) accumulator.content.push(choice.delta.content); if (choice.delta.reasoning_content) accumulator.reasoning.push(choice.delta.reasoning_content); for (const fragment of choice.delta.tool_calls ?? []) { const current = accumulator.toolCalls.get(fragment.index) ?? { id: fallbackToolCallId(), type: "function" as const, name: "", arguments: "" }; if (fragment.id) current.id = fragment.id; if (fragment.function?.name) current.name = fragment.function.name; if (fragment.function?.arguments) current.arguments += fragment.function.arguments; accumulator.toolCalls.set(fragment.index, current); } }
+}
+export function finishAccumulator(accumulator: FreebuffAccumulator, model: string): FreebuffCompletionResponse {
+    const message: ChatMessage & { reasoning_content?: string } = { role: "assistant", content: accumulator.content.join("") };
+    const calls: ToolCall[] = [...accumulator.toolCalls.entries()].sort(([a], [b]) => a - b).map(([, call]) => ({ id: call.id, type: "function", function: { name: call.name, arguments: call.arguments } }));
+    if (calls.length) message.tool_calls = calls;
+    if (accumulator.reasoning.join("")) message.reasoning_content = accumulator.reasoning.join("");
+    const upstreamFinishReason = accumulator.finishReason ?? "stop";
+    const completionChoice: FreebuffCompletionChoice = {
+        index: 0,
+        message,
+        // Keep the public SRouter field narrow; retain an upstream-only reason in the extension below.
+        finish_reason: isSrouterFinishReason(upstreamFinishReason) ? upstreamFinishReason : null,
+        ...(isSrouterFinishReason(upstreamFinishReason) ? {} : { legacy_finish_reason: upstreamFinishReason }),
+    };
+    return { id: accumulator.id, object: "chat.completion", created: accumulator.created, model, choices: [completionChoice], usage: accumulator.usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }, ...(accumulator.systemFingerprint ? { system_fingerprint: accumulator.systemFingerprint } : {}) };
+}
+export function removeFreebuffModelPrefix(model: string): string { return model.startsWith("freebuff/") ? model.slice("freebuff/".length) : model; }
+export function withFreebuffModelPrefix(model: string): string { return model.startsWith("freebuff/") ? model : `freebuff/${model}`; }

--- a/packages/executors/src/freebuff/coordinator.test.ts
+++ b/packages/executors/src/freebuff/coordinator.test.ts
@@ -1,0 +1,149 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ChatCompletionRequest } from "@srouter/types";
+import type {
+    FreebuffChatRequest,
+    FreebuffRequestOptions,
+    FreebuffSessionResponse,
+    FreebuffUpstreamClientContract,
+} from "./upstream.js";
+import { FreebuffCoordinator } from "./coordinator.js";
+import { FreebuffRunManager } from "./runs.js";
+import { FreebuffSessionManager } from "./session.js";
+
+const request: ChatCompletionRequest = {
+    model: "freebuff/deepseek/deepseek-v4-flash",
+    messages: [{ role: "user", content: "hello" }],
+    stream: true,
+};
+
+class FakeUpstream implements FreebuffUpstreamClientContract {
+    public readonly token: string;
+    public readonly chatCalls: number[] = [];
+    public readonly finishedRuns: string[] = [];
+    public startRunCalls = 0;
+    public sessionEnds = 0;
+    public pendingStart: Promise<string> | undefined;
+    public resolvePendingStart: ((runId: string) => void) | undefined;
+    public pendingSession: Promise<FreebuffSessionResponse> | undefined;
+    public resolvePendingSession: ((response: FreebuffSessionResponse) => void) | undefined;
+
+    public constructor(token: string) {
+        this.token = token;
+    }
+
+    public createSession(): Promise<FreebuffSessionResponse> {
+        if (this.pendingSession !== undefined) return this.pendingSession;
+        return Promise.resolve({ status: "active", instanceId: `instance-${this.token}` });
+    }
+
+    public getSession(): Promise<FreebuffSessionResponse> {
+        return Promise.resolve({ status: "active", instanceId: `instance-${this.token}` });
+    }
+
+    public endSession(): Promise<void> {
+        this.sessionEnds += 1;
+        return Promise.resolve();
+    }
+
+    public startRun(): Promise<string> {
+        this.startRunCalls += 1;
+        if (this.token !== "slow") return Promise.resolve(`run-${this.token}`);
+        this.pendingStart = new Promise<string>((resolve) => {
+            this.resolvePendingStart = resolve;
+        });
+        return this.pendingStart;
+    }
+
+    public finishRun(runId: string): Promise<void> {
+        this.finishedRuns.push(runId);
+        return Promise.resolve();
+    }
+
+    public chatCompletions(): Promise<Response> {
+        this.chatCalls.push(Date.now());
+        if (this.token === "first") {
+            let failed = false;
+            const body = new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode('data: {"id":"first","model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}]}\n'));
+                },
+                pull(controller) {
+                    if (!failed) {
+                        failed = true;
+                        controller.error(new Error("connection dropped after partial output"));
+                    }
+                },
+            });
+            return Promise.resolve(new Response(body, { status: 200 }));
+        }
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode('data: {"id":"second","model":"deepseek/deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"replacement"},"finish_reason":"stop"}]}\n'));
+                controller.close();
+            },
+        });
+        return Promise.resolve(new Response(body, { status: 200 }));
+    }
+}
+
+function config(id: string, token: string) {
+    return { id, accessToken: token, baseUrl: "https://example.test", enabled: true } as const;
+}
+
+test("does not fail over after a partial SSE response", async () => {
+    const upstreams: FakeUpstream[] = [];
+    const coordinator = new FreebuffCoordinator({
+        createUpstream(connection) {
+            const upstream = new FakeUpstream(connection.accessToken);
+            upstreams.push(upstream);
+            return upstream;
+        },
+    });
+    coordinator.register(config("first", "first"));
+    coordinator.register(config("second", "second"));
+
+    const chunks: unknown[] = [];
+    await assert.rejects(
+        (async () => {
+            for await (const chunk of coordinator.chatCompletionStream(request)) chunks.push(chunk);
+        })(),
+        /connection dropped after partial output/,
+    );
+
+    assert.equal(chunks.length, 1);
+    assert.deepEqual(upstreams.map((upstream) => upstream.chatCalls.length), [1, 0]);
+});
+
+test("does not resurrect a run whose START resolves after shutdown", async () => {
+    let upstream: FakeUpstream | undefined;
+    const manager = new FreebuffRunManager(
+        (upstream = new FakeUpstream("slow")),
+        { shutdownTimeoutMs: 100 },
+    );
+    const acquire = manager.acquireRun("base2-free-deepseek");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const shutdown = manager.shutdown();
+    upstream.resolvePendingStart?.("late-run");
+
+    await shutdown;
+    await assert.rejects(acquire, /shutdown/i);
+    assert.equal(manager.snapshot().activeRuns, 0);
+    assert.deepEqual(upstream.finishedRuns, ["late-run"]);
+});
+
+test("does not return a session lease after end invalidates an in-flight refresh", async () => {
+    const upstream = new FakeUpstream("session");
+    upstream.pendingSession = new Promise<FreebuffSessionResponse>((resolve) => {
+        upstream.resolvePendingSession = resolve;
+    });
+    const manager = new FreebuffSessionManager(upstream);
+    const ensure = manager.ensureSession();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const ending = manager.end();
+    upstream.resolvePendingSession?.({ status: "active", instanceId: "late-instance" });
+
+    await ending;
+    await assert.rejects(ensure, /invalidated|ended|lifecycle/i);
+    assert.equal(upstream.sessionEnds, 1);
+});

--- a/packages/executors/src/freebuff/coordinator.ts
+++ b/packages/executors/src/freebuff/coordinator.ts
@@ -62,7 +62,7 @@ interface RuntimeConnection {
 }
 
 const AUTH_COOLDOWN_MS = 30 * 60 * 1_000;
-const DEFAULT_BASE_URL = "https://freebuff.ai";
+const DEFAULT_BASE_URL = "https://www.codebuff.com";
 
 function requestInput(request: ChatCompletionRequest): FreebuffRequestInput {
     return JSON.parse(JSON.stringify(request)) as FreebuffRequestInput;
@@ -229,12 +229,17 @@ export class FreebuffCoordinator {
         let lastError: Error | undefined;
         let bestWaiting: FreebuffWaitingRoomError | undefined;
         for (const connection of candidates) {
+            let emitted = false;
             try {
-                yield* this.streamFromConnection(connection, agentId, request);
+                for await (const chunk of this.streamFromConnection(connection, agentId, request)) {
+                    emitted = true;
+                    yield chunk;
+                }
                 return;
             } catch (error) {
                 const caught = error instanceof Error ? error : new Error("FreeBuff request failed");
                 lastError = caught;
+                if (emitted) throw caught;
                 if (caught instanceof FreebuffWaitingRoomError) {
                     if (bestWaiting === undefined || (caught.position ?? Number.MAX_SAFE_INTEGER) < (bestWaiting.position ?? Number.MAX_SAFE_INTEGER)) bestWaiting = caught;
                     continue;

--- a/packages/executors/src/freebuff/coordinator.ts
+++ b/packages/executors/src/freebuff/coordinator.ts
@@ -1,0 +1,328 @@
+import { randomUUID } from "node:crypto";
+import type {
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    FinishReason,
+    ModelObject,
+} from "@srouter/types";
+import {
+    accumulateChunk,
+    createAccumulator,
+    finishAccumulator,
+    normalizeRequest,
+    removeFreebuffModelPrefix,
+    sanitizeSseLine,
+    type FreebuffRequestInput,
+    type FreebuffSanitizedChunk,
+} from "./convert.js";
+import { isFreebuffError } from "./errors.js";
+import type { FreebuffError } from "./types.js";
+import { FreebuffModelRegistry } from "./registry.js";
+import { FreebuffRunManager, type FreebuffRunLease } from "./runs.js";
+import { FreebuffSessionManager, type FreebuffSessionLease, FreebuffWaitingRoomError } from "./session.js";
+import {
+    createFreebuffTransport,
+    FreebuffUpstreamClient,
+    type FreebuffChatRequest,
+    type FreebuffRequestOptions,
+    type FreebuffTransportConfig,
+    type FreebuffUpstreamClientContract,
+} from "./upstream.js";
+import type { FreebuffConnectionConfig } from "./types.js";
+
+export interface FreebuffCoordinatorOptions {
+    readonly registry?: FreebuffModelRegistry;
+    readonly createUpstream?: (config: FreebuffConnectionConfig) => FreebuffUpstreamClientContract;
+    readonly sessionExpiryMarginMs?: number;
+    readonly runRotationIntervalMs?: number;
+    readonly requestTimeoutMs?: number;
+}
+
+export interface FreebuffCoordinatorSnapshot {
+    readonly connections: readonly FreebuffConnectionSnapshot[];
+    readonly registry: ReturnType<FreebuffModelRegistry["snapshot"]>;
+}
+
+export interface FreebuffConnectionSnapshot {
+    readonly id: string;
+    readonly enabled: boolean;
+    readonly cooldownUntil?: number;
+    readonly session: ReturnType<FreebuffSessionManager["snapshot"]>;
+    readonly runs: ReturnType<FreebuffRunManager["snapshot"]>;
+}
+
+interface RuntimeConnection {
+    readonly config: FreebuffConnectionConfig;
+    readonly upstream: FreebuffUpstreamClientContract;
+    readonly session: FreebuffSessionManager;
+    readonly runs: FreebuffRunManager;
+    enabled: boolean;
+    cooldownUntil: number;
+}
+
+const AUTH_COOLDOWN_MS = 30 * 60 * 1_000;
+const DEFAULT_BASE_URL = "https://freebuff.ai";
+
+function requestInput(request: ChatCompletionRequest): FreebuffRequestInput {
+    return JSON.parse(JSON.stringify(request)) as FreebuffRequestInput;
+}
+
+function upstreamRequest(request: ChatCompletionRequest): FreebuffChatRequest {
+    const normalized = normalizeRequest(requestInput(request));
+    return {
+        ...normalized,
+        model: removeFreebuffModelPrefix(normalized.model),
+        messages: normalized.messages,
+    };
+}
+
+function retryAfterMs(error: FreebuffError): number {
+    const retrySeconds = error.details.retryAfterSeconds;
+    if (retrySeconds !== undefined) return Math.max(0, retrySeconds * 1_000);
+    const resetAt = error.details.resetAt;
+    if (resetAt !== undefined) return Math.max(0, resetAt - Date.now());
+    const resumesAt = error.details.resumesAt;
+    if (resumesAt !== undefined) return Math.max(0, resumesAt - Date.now());
+    return 0;
+}
+
+function publicFinishReason(reason: string | null): FinishReason {
+    return reason === null || reason === "stop" || reason === "length" || reason === "tool_calls" || reason === "content_filter" ? reason : null;
+}
+
+async function* responseLines(body: ReadableStream<Uint8Array>): AsyncGenerator<string, void, void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+        while (true) {
+            const item = await reader.read();
+            if (item.done) break;
+            buffer += decoder.decode(item.value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+            for (const line of lines) if (line.trim() !== "") yield line.trim();
+        }
+        buffer += decoder.decode();
+        if (buffer.trim() !== "") yield buffer.trim();
+    } finally {
+        await reader.cancel().catch(() => undefined);
+    }
+}
+
+export class FreebuffCoordinator {
+    public readonly id = "freebuff";
+    private readonly registry: FreebuffModelRegistry;
+    private readonly createUpstream: (config: FreebuffConnectionConfig) => FreebuffUpstreamClientContract;
+    private readonly sessionExpiryMarginMs: number | undefined;
+    private readonly runRotationIntervalMs: number | undefined;
+    private readonly requestTimeoutMs: number | undefined;
+    private readonly connections = new Map<string, RuntimeConnection>();
+    private cursor = 0;
+    private started = false;
+
+    public constructor(options: FreebuffCoordinatorOptions = {}) {
+        this.registry = options.registry ?? new FreebuffModelRegistry();
+        this.createUpstream = options.createUpstream ?? ((config) => {
+            const transportConfig: FreebuffTransportConfig = {
+                baseUrl: config.baseUrl || DEFAULT_BASE_URL,
+                accessToken: config.accessToken,
+                ...(this.requestTimeoutMs === undefined ? {} : { timeoutMs: this.requestTimeoutMs }),
+            };
+            return new FreebuffUpstreamClient(createFreebuffTransport(transportConfig));
+        });
+        this.sessionExpiryMarginMs = options.sessionExpiryMarginMs;
+        this.runRotationIntervalMs = options.runRotationIntervalMs;
+        this.requestTimeoutMs = options.requestTimeoutMs;
+    }
+
+    public register(config: FreebuffConnectionConfig): void {
+        if (config.id.trim() === "") throw new TypeError("FreeBuff connection id must not be empty");
+        if (config.accessToken.trim() === "") throw new TypeError("FreeBuff access token must not be empty");
+        const previous = this.connections.get(config.id);
+        if (previous !== undefined) void this.closeConnection(previous);
+        const upstream = this.createUpstream(config);
+        const session = new FreebuffSessionManager(upstream, {
+            ...(this.sessionExpiryMarginMs === undefined ? {} : { expiryMarginMs: this.sessionExpiryMarginMs }),
+        });
+        const runs = new FreebuffRunManager(upstream, {
+            ...(this.runRotationIntervalMs === undefined ? {} : { rotationIntervalMs: this.runRotationIntervalMs }),
+        });
+        this.connections.set(config.id, {
+            config,
+            upstream,
+            session,
+            runs,
+            enabled: config.enabled,
+            cooldownUntil: 0,
+        });
+    }
+
+    /** Replace the runtime pool with the currently persisted enabled connections. */
+    public replaceConnections(configs: readonly FreebuffConnectionConfig[]): void {
+        const nextIds = new Set(configs.map((config) => config.id));
+        for (const connectionId of this.connections.keys()) {
+            if (!nextIds.has(connectionId)) void this.unregister(connectionId).catch(() => undefined);
+        }
+        for (const config of configs) this.register(config);
+    }
+
+    public async update(config: FreebuffConnectionConfig): Promise<void> {
+        await this.unregister(config.id);
+        this.register(config);
+    }
+
+    public updateToken(connectionId: string, accessToken: string): void {
+        const current = this.connections.get(connectionId);
+        if (current === undefined) return;
+        this.register({ ...current.config, accessToken });
+    }
+
+    public async unregister(connectionId: string): Promise<void> {
+        const current = this.connections.get(connectionId);
+        if (current === undefined) return;
+        this.connections.delete(connectionId);
+        await this.closeConnection(current);
+    }
+
+    public setEnabled(connectionId: string, enabled: boolean): void {
+        const current = this.connections.get(connectionId);
+        if (current !== undefined) current.enabled = enabled;
+    }
+
+    public async listModels(): Promise<ModelObject[]> {
+        try {
+            await this.registry.refresh();
+        } catch {
+            // The registry intentionally retains its prior verified/degraded state.
+        }
+        return this.registry.models();
+    }
+
+    public async chatCompletion(request: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+        const accumulator = createAccumulator();
+        for await (const chunk of this.streamWithFailover(request)) {
+            accumulateChunk(accumulator, chunk);
+        }
+        return finishAccumulator(accumulator, request.model);
+    }
+
+    public async *chatCompletionStream(request: ChatCompletionRequest): AsyncGenerator<ChatCompletionChunk, void, void> {
+        for await (const chunk of this.streamWithFailover(request)) {
+            yield {
+                ...chunk,
+                model: request.model,
+                choices: chunk.choices.map((choice) => ({
+                    ...choice,
+                    finish_reason: publicFinishReason(choice.finish_reason),
+                })),
+            };
+        }
+    }
+
+    private async *streamWithFailover(request: ChatCompletionRequest): AsyncGenerator<FreebuffSanitizedChunk, void, void> {
+        const agentId = this.registry.agentForModel(request.model);
+        if (agentId === null) throw new Error(`FreeBuff model is not available: ${request.model}`);
+        const candidates = this.candidateConnections();
+        if (candidates.length === 0) throw new Error("No enabled FreeBuff connections are available");
+        let lastError: Error | undefined;
+        let bestWaiting: FreebuffWaitingRoomError | undefined;
+        for (const connection of candidates) {
+            try {
+                yield* this.streamFromConnection(connection, agentId, request);
+                return;
+            } catch (error) {
+                const caught = error instanceof Error ? error : new Error("FreeBuff request failed");
+                lastError = caught;
+                if (caught instanceof FreebuffWaitingRoomError) {
+                    if (bestWaiting === undefined || (caught.position ?? Number.MAX_SAFE_INTEGER) < (bestWaiting.position ?? Number.MAX_SAFE_INTEGER)) bestWaiting = caught;
+                    continue;
+                }
+                if (isFreebuffError(caught, "SESSION_INVALID") || isFreebuffError(caught, "RUN_INVALID")) {
+                    connection.session.invalidate();
+                    connection.runs.invalidateRun(agentId);
+                    try {
+                        yield* this.streamFromConnection(connection, agentId, request);
+                        return;
+                    } catch (retryError) {
+                        lastError = retryError instanceof Error ? retryError : new Error("FreeBuff retry failed");
+                    }
+                }
+                this.applyCooldown(connection, caught);
+            }
+        }
+        if (bestWaiting !== undefined) throw bestWaiting;
+        throw lastError ?? new Error("All FreeBuff connections failed");
+    }
+
+    public async start(signal?: AbortSignal): Promise<void> {
+        if (this.started) return;
+        this.started = true;
+        this.registry.start(signal);
+    }
+
+    public async shutdown(options: FreebuffRequestOptions = {}): Promise<void> {
+        this.started = false;
+        this.registry.stop();
+        const current = [...this.connections.values()];
+        this.connections.clear();
+        await Promise.all(current.map((connection) => this.closeConnection(connection, options)));
+    }
+
+    public snapshot(): FreebuffCoordinatorSnapshot {
+        return {
+            connections: [...this.connections.values()].map((connection) => ({
+                id: connection.config.id,
+                enabled: connection.enabled,
+                ...(connection.cooldownUntil > Date.now() ? { cooldownUntil: connection.cooldownUntil } : {}),
+                session: connection.session.snapshot(),
+                runs: connection.runs.snapshot(),
+            })),
+            registry: this.registry.snapshot(),
+        };
+    }
+
+    private candidateConnections(): RuntimeConnection[] {
+        const now = Date.now();
+        const enabled = [...this.connections.values()].filter((connection) => connection.enabled && connection.cooldownUntil <= now);
+        if (enabled.length === 0) return [];
+        const offset = this.cursor % enabled.length;
+        this.cursor += 1;
+        return [...enabled.slice(offset), ...enabled.slice(0, offset)];
+    }
+
+    private async *streamFromConnection(connection: RuntimeConnection, agentId: string, request: ChatCompletionRequest): AsyncGenerator<FreebuffSanitizedChunk, void, void> {
+        const session: FreebuffSessionLease = await connection.session.ensureSession({ timeoutMs: this.requestTimeoutMs });
+        if (session.status !== "active") throw new Error("FreeBuff session is disabled");
+        const run: FreebuffRunLease = await connection.runs.acquireRun(agentId, { timeoutMs: this.requestTimeoutMs });
+        try {
+            const response = await connection.upstream.chatCompletions(upstreamRequest(request), {
+                model: removeFreebuffModelPrefix(request.model),
+                runId: run.runId,
+                clientId: randomUUID(),
+                ...(session.instanceId === undefined ? {} : { instanceId: session.instanceId }),
+                timeoutMs: this.requestTimeoutMs,
+            });
+            if (!response.body) throw new Error("FreeBuff response did not contain a stream body");
+            for await (const line of responseLines(response.body)) {
+                const chunk = sanitizeSseLine(line);
+                if (chunk === null) continue;
+                yield chunk;
+            }
+        } finally {
+            connection.runs.releaseRun(run);
+        }
+    }
+
+    private applyCooldown(connection: RuntimeConnection, error: Error): void {
+        if (!isFreebuffError(error)) return;
+        if (error.code === "AUTH_REJECTED") connection.cooldownUntil = Date.now() + AUTH_COOLDOWN_MS;
+        else if (error.code === "RATE_LIMITED" || error.code === "BANNED") connection.cooldownUntil = Date.now() + retryAfterMs(error);
+    }
+
+    private async closeConnection(connection: RuntimeConnection, options: FreebuffRequestOptions = {}): Promise<void> {
+        await connection.runs.shutdown(options).catch(() => undefined);
+        await connection.session.end(options).catch(() => undefined);
+    }
+}

--- a/packages/executors/src/freebuff/errors.test.ts
+++ b/packages/executors/src/freebuff/errors.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FreebuffAuthError, FreebuffRateLimitError, FreebuffUpstreamError, parseUpstreamError } from "./errors.js";
+
+test("maps authentication rejection without exposing credentials", () => {
+    const token = "freebuff-auth-token";
+    const authorization = ["Bearer", token].join(" ");
+    const error = parseUpstreamError(401, `token=${token}`, { authorization });
+    assert.ok(error instanceof FreebuffAuthError);
+    assert.equal(error.code, "AUTH_REJECTED");
+    assert.equal(error.message.includes(token), false);
+});
+
+test("parses quota reset and retry-after values", () => {
+    const error = parseUpstreamError(429, '{"message":"quota exceeded"}', { "retry-after": "12", "x-ratelimit-reset": "1700000012" });
+    assert.ok(error instanceof FreebuffRateLimitError);
+    assert.equal(error.retryAfterSeconds, 12);
+    assert.equal(error.resetAt, 1700000012000);
+});
+
+test("maps bans, waiting rooms, invalid sessions, and invalid runs", () => {
+    assert.equal(parseUpstreamError(403, '{"error":"banned","resumesAt":1700000012}', {}).code, "BANNED");
+    assert.equal(parseUpstreamError(503, '{"error":"waiting room","position":4}', {}).code, "WAITING_ROOM");
+    assert.equal(parseUpstreamError(400, '{"error":"session-invalid"}', {}).code, "SESSION_INVALID");
+    assert.equal(parseUpstreamError(400, '{"error":"run-invalid"}', {}).code, "RUN_INVALID");
+});
+
+test("bounds and redacts opaque upstream body text", () => {
+    const token = "freebuff-secret-token";
+    const authorization = ["Bearer", token].join(" ");
+    const error = parseUpstreamError(500, `${token} ${"x".repeat(5000)}`, { authorization });
+    assert.ok(error instanceof FreebuffUpstreamError);
+    assert.equal(error.body.length <= 2048, true);
+    assert.equal(error.message.includes(token), false);
+    assert.equal(error.message.includes("x".repeat(100)), true);
+});
+
+test("supports Error.cause and unwrap-equivalent predicates", () => {
+    const cause = new Error("transport failed");
+    const error = parseUpstreamError(502, "bad gateway", {}, cause);
+    assert.equal(error.cause, cause);
+    assert.equal(error.is("UPSTREAM"), true);
+    assert.equal(error.is("AUTH_REJECTED"), false);
+});

--- a/packages/executors/src/freebuff/errors.ts
+++ b/packages/executors/src/freebuff/errors.ts
@@ -1,0 +1,116 @@
+import type { FreebuffError, FreebuffErrorCode, FreebuffErrorDetails } from "./types.js";
+
+const MAX_BODY_LENGTH = 2048;
+const SENSITIVE_HEADER = /^(authorization|proxy-authorization|cookie|set-cookie)$/i;
+const SECRET_PATTERN = /\b(?:sk-[A-Za-z0-9_-]+|freebuff-[A-Za-z0-9_-]+|Bearer\s+[A-Za-z0-9._~-]+)\b/gi;
+
+type ErrorCause = Error | undefined;
+type HeaderInput = Readonly<Record<string, string>>;
+type MutableFreebuffErrorDetails = {
+    -readonly [Key in keyof FreebuffErrorDetails]: FreebuffErrorDetails[Key];
+};
+
+function safeBody(body: string): string {
+    return body.replace(SECRET_PATTERN, "[redacted]").slice(0, MAX_BODY_LENGTH);
+}
+
+function safeHeaders(headers: HeaderInput): Readonly<Record<string, string>> {
+    const result: Record<string, string> = {};
+    for (const [name, value] of Object.entries(headers)) {
+        if (!SENSITIVE_HEADER.test(name)) result[name.toLowerCase()] = safeBody(value);
+    }
+    return result;
+}
+
+function parseJson(body: string): Record<string, string | number> {
+    try {
+        const parsed = JSON.parse(body) as Record<string, string | number | boolean | null>;
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+        const result: Record<string, string | number> = {};
+        for (const [key, value] of Object.entries(parsed)) {
+            if (typeof value === "string" || typeof value === "number") result[key] = value;
+        }
+        return result;
+    } catch {
+        return {};
+    }
+}
+
+function numberValue(payload: Record<string, string | number>, keys: readonly string[]): number | undefined {
+    for (const key of keys) {
+        const value = payload[key];
+        if (typeof value === "number" && Number.isFinite(value)) return value;
+        if (typeof value === "string" && /^\d+(?:\.\d+)?$/.test(value)) return Number(value);
+    }
+    return undefined;
+}
+
+export class FreebuffUpstreamError extends Error implements FreebuffError {
+    readonly name = "FreebuffError" as const;
+    readonly code: FreebuffErrorCode;
+    readonly status: number;
+    readonly details: FreebuffErrorDetails;
+
+    constructor(code: FreebuffErrorCode, status: number, details: FreebuffErrorDetails, cause?: ErrorCause) {
+        super(`FreeBuff upstream error (${status}): ${code}${details.body ? ` — ${details.body}` : ""}`, { cause });
+        this.code = code;
+        this.status = status;
+        this.details = details;
+    }
+
+    is(code: FreebuffErrorCode): boolean {
+        return this.code === code;
+    }
+
+    get body(): string {
+        return this.details.body;
+    }
+}
+
+export class FreebuffAuthError extends FreebuffUpstreamError {
+    constructor(status: number, details: FreebuffErrorDetails, cause?: ErrorCause) { super("AUTH_REJECTED", status, details, cause); }
+}
+
+export class FreebuffRateLimitError extends FreebuffUpstreamError {
+    readonly retryAfterSeconds: number | undefined;
+    readonly resetAt: number | undefined;
+    constructor(status: number, details: FreebuffErrorDetails, cause?: ErrorCause) {
+        super("RATE_LIMITED", status, details, cause);
+        this.retryAfterSeconds = details.retryAfterSeconds;
+        this.resetAt = details.resetAt;
+    }
+}
+
+export function parseUpstreamError(status: number, body: string, headers: HeaderInput, cause?: Error): FreebuffError {
+    const payload = parseJson(body);
+    const text = `${body} ${Object.values(payload).join(" ")}`.toLowerCase();
+    const details: MutableFreebuffErrorDetails = {
+        status,
+        body: safeBody(body),
+        headers: safeHeaders(headers),
+        retryAfterSeconds: numberValue(payload, ["retryAfter", "retry_after"]),
+        resetAt: numberValue(payload, ["resetAt", "reset_at"]),
+        resumesAt: numberValue(payload, ["resumesAt", "resumes_at"]),
+        position: numberValue(payload, ["position", "queuePosition"]),
+    };
+    const retryHeader = headers["retry-after"] ?? headers["Retry-After"];
+    if (details.retryAfterSeconds === undefined && retryHeader !== undefined && /^\d+(?:\.\d+)?$/.test(retryHeader)) {
+        details.retryAfterSeconds = Number(retryHeader);
+    }
+    const resetHeader = headers["x-ratelimit-reset"] ?? headers["X-RateLimit-Reset"];
+    if (details.resetAt === undefined && resetHeader !== undefined && /^\d+$/.test(resetHeader)) details.resetAt = Number(resetHeader) * 1000;
+
+    if (status === 401) return new FreebuffAuthError(status, details, cause);
+    if (status === 429) return new FreebuffRateLimitError(status, details, cause);
+    if (status === 403 && /ban|suspend/.test(text)) return new FreebuffUpstreamError("BANNED", status, details, cause);
+    if (status === 503 && /wait|queue|room/.test(text)) return new FreebuffUpstreamError("WAITING_ROOM", status, details, cause);
+    if (/session[-_ ]?invalid/.test(text)) return new FreebuffUpstreamError("SESSION_INVALID", status, details, cause);
+    if (/run[-_ ]?invalid/.test(text)) return new FreebuffUpstreamError("RUN_INVALID", status, details, cause);
+    return new FreebuffUpstreamError("UPSTREAM", status, details, cause);
+}
+
+export function isFreebuffError(error: Error, code?: FreebuffErrorCode): error is FreebuffError {
+    return error instanceof FreebuffUpstreamError && (code === undefined || error.is(code));
+}
+
+export const FREEBUFF_MAX_ERROR_BODY_LENGTH = MAX_BODY_LENGTH;

--- a/packages/executors/src/freebuff/executor.ts
+++ b/packages/executors/src/freebuff/executor.ts
@@ -1,0 +1,76 @@
+import type {
+    AIProvider,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ModelObject,
+} from "@srouter/types";
+import { FreebuffCoordinator, type FreebuffCoordinatorOptions } from "./coordinator.js";
+import { withFreebuffModelPrefix } from "./convert.js";
+import type { FreebuffConnectionConfig } from "./types.js";
+
+export interface FreebuffExecutorOptions extends FreebuffCoordinatorOptions {
+    readonly id?: string;
+    readonly name?: string;
+    readonly connections?: readonly FreebuffConnectionConfig[];
+}
+
+export class FreebuffExecutor implements AIProvider {
+    public readonly id: string;
+    public readonly name: string;
+    public readonly category = "free_tier" as const;
+    public readonly protocol = "openai" as const;
+    private readonly coordinator: FreebuffCoordinator;
+
+    public constructor(options: FreebuffExecutorOptions = {}) {
+        this.id = options.id ?? "freebuff";
+        this.name = options.name ?? "FreeBuff";
+        this.coordinator = new FreebuffCoordinator(options);
+        for (const connection of options.connections ?? []) this.coordinator.register(connection);
+    }
+
+    public async listModels(): Promise<ModelObject[]> {
+        const models = await this.coordinator.listModels();
+        return models.map((model) => ({ ...model, id: withFreebuffModelPrefix(model.id), owned_by: "freebuff" }));
+    }
+
+    public chatCompletion(request: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+        return this.coordinator.chatCompletion({ ...request, model: withFreebuffModelPrefix(request.model) });
+    }
+
+    public chatCompletionStream(request: ChatCompletionRequest): AsyncGenerator<ChatCompletionChunk, void, void> {
+        return this.coordinator.chatCompletionStream({ ...request, model: withFreebuffModelPrefix(request.model) });
+    }
+
+    public register(config: FreebuffConnectionConfig): void {
+        this.coordinator.register(config);
+    }
+
+    public replaceConnections(configs: readonly FreebuffConnectionConfig[]): void {
+        this.coordinator.replaceConnections(configs);
+    }
+
+    public unregister(connectionId: string): Promise<void> {
+        return this.coordinator.unregister(connectionId);
+    }
+
+    public setEnabled(connectionId: string, enabled: boolean): void {
+        this.coordinator.setEnabled(connectionId, enabled);
+    }
+
+    public updateToken(connectionId: string, accessToken: string): void {
+        this.coordinator.updateToken(connectionId, accessToken);
+    }
+
+    public start(signal?: AbortSignal): Promise<void> {
+        return this.coordinator.start(signal);
+    }
+
+    public shutdown(signal?: AbortSignal): Promise<void> {
+        return this.coordinator.shutdown(signal === undefined ? {} : { signal });
+    }
+
+    public snapshot(): ReturnType<FreebuffCoordinator["snapshot"]> {
+        return this.coordinator.snapshot();
+    }
+}

--- a/packages/executors/src/freebuff/profiles.ts
+++ b/packages/executors/src/freebuff/profiles.ts
@@ -1,0 +1,64 @@
+export interface BrowserHeaders {
+    readonly "User-Agent": string;
+    readonly "Accept-Language": string;
+    readonly "Accept-Encoding": string;
+    readonly "Sec-CH-UA"?: string;
+    readonly "Sec-CH-UA-Platform"?: string;
+    readonly "Sec-Fetch-Site": "none";
+    readonly "Sec-Fetch-Mode": "cors";
+    readonly "Sec-Fetch-Dest": "empty";
+    readonly "Upgrade-Insecure-Requests": "1";
+}
+
+interface BrowserProfile {
+    readonly userAgent: string;
+    readonly acceptLanguage: string;
+    readonly secChUa?: string;
+    readonly secChUaPlatform?: string;
+}
+
+const PROFILES: readonly BrowserProfile[] = [
+    {
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+        acceptLanguage: "en-US,en;q=0.9",
+        secChUa: '"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"',
+        secChUaPlatform: '"Windows"',
+    },
+    {
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+        acceptLanguage: "en-US,en;q=0.9",
+    },
+    {
+        userAgent: "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+        acceptLanguage: "en-US,en;q=0.8",
+    },
+    {
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0",
+        acceptLanguage: "en-US,en;q=0.9",
+    },
+];
+
+let profileCursor = 0;
+
+/**
+ * Returns a browser-like header set, rotating deterministically through known
+ * profiles. This changes HTTP headers only; native fetch uses normal TLS and
+ * this module makes no JA3 or TLS-fingerprint impersonation claim.
+ */
+export function nextBrowserHeaders(): BrowserHeaders {
+    const profile = PROFILES[profileCursor % PROFILES.length];
+    profileCursor += 1;
+    return {
+        "User-Agent": profile.userAgent,
+        "Accept-Language": profile.acceptLanguage,
+        "Accept-Encoding": "gzip, deflate, br",
+        ...(profile.secChUa === undefined ? {} : { "Sec-CH-UA": profile.secChUa }),
+        ...(profile.secChUaPlatform === undefined ? {} : { "Sec-CH-UA-Platform": profile.secChUaPlatform }),
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-Mode": "cors",
+        "Sec-Fetch-Dest": "empty",
+        "Upgrade-Insecure-Requests": "1",
+    };
+}
+
+export const FREEBUFF_BROWSER_PROFILE_COUNT = PROFILES.length;

--- a/packages/executors/src/freebuff/registry.ts
+++ b/packages/executors/src/freebuff/registry.ts
@@ -1,0 +1,255 @@
+import type { ModelObject } from "@srouter/types";
+import type { FreebuffModelRegistryState } from "./types.js";
+
+export const FREEBUFF_REGISTRY_SOURCE_FILES = [
+    "free-agents.ts",
+    "freebuff-model-ids.ts",
+    "freebuff-models.ts",
+    "gemini.ts",
+    "model-config.ts",
+] as const;
+
+export const FREEBUFF_REGISTRY_RAW_BASE =
+    "https://raw.githubusercontent.com/CodebuffAI/codebuff/main/common/src/constants/";
+
+const FALLBACK_AGENTS: readonly { agent: string; models: readonly string[] }[] = [
+    { agent: "base2-free", models: ["deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash", "minimax/minimax-m3", "openai/gpt-5.6-luna", "mimo/mimo-v2.5"] },
+    { agent: "base2-free-minimax-m3", models: ["minimax/minimax-m3"] },
+    { agent: "base2-free-luna", models: ["openai/gpt-5.6-luna"] },
+    { agent: "base2-free-deepseek", models: ["deepseek/deepseek-v4-pro"] },
+    { agent: "base2-free-deepseek-flash", models: ["deepseek/deepseek-v4-flash"] },
+    { agent: "base2-free-mimo", models: ["mimo/mimo-v2.5"] },
+    { agent: "base2-free-glm", models: ["z-ai/glm-5.2"] },
+    { agent: "base2-free-laguna-s-2-1", models: ["poolside/laguna-s-2.1"] },
+    { agent: "base2-free-laguna-s-2-1-openrouter", models: ["openrouter/poolside/laguna-s-2.1"] },
+    { agent: "base2-free-ling-3-flash", models: ["inclusionai/ling-3.0-flash:free"] },
+    { agent: "base2-free-greg-2-ultra", models: ["crof/greg-2-ultra"] },
+    { agent: "base2-free-greg-2-super", models: ["crof/greg-2-super"] },
+    { agent: "base2-free-fable", models: ["anthropic/claude-fable-5"] },
+    { agent: "file-picker", models: ["google/gemini-2.5-flash-lite"] },
+    { agent: "file-picker-max", models: ["google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"] },
+    { agent: "file-lister", models: ["google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"] },
+    { agent: "researcher-web", models: ["google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"] },
+    { agent: "researcher-docs", models: ["google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"] },
+    { agent: "basher", models: ["google/gemini-3.1-flash-lite", "google/gemini-3.5-flash-lite"] },
+    { agent: "code-reviewer-lite", models: ["deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash", "mimo/mimo-v2.5"] },
+];
+
+export interface FreebuffModelRegistryOptions {
+    readonly modelPrefix?: string;
+    readonly sourceUrls?: readonly string[];
+    readonly fetchImpl?: typeof fetch;
+    readonly refreshIntervalMs?: number;
+    readonly requestTimeoutMs?: number;
+}
+
+export interface FreebuffRegistrySnapshot extends FreebuffModelRegistryState {
+    readonly modelCount: number;
+    readonly agentCount: number;
+}
+
+interface ParsedRegistry {
+    readonly modelToAgent: Readonly<Record<string, string>>;
+    readonly agentIds: readonly string[];
+}
+
+function isIdentifier(value: string): boolean {
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
+function collectConstants(text: string): {
+    literals: Map<string, string>;
+    aliases: Map<string, string>;
+    sets: Map<string, string[]>;
+} {
+    const literals = new Map<string, string>();
+    const aliases = new Map<string, string>();
+    const sets = new Map<string, string[]>();
+    const literalPattern = /(?:export\s+)?const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(["'])(.*?)\2/g;
+    for (const match of text.matchAll(literalPattern)) literals.set(match[1] ?? "", match[3] ?? "");
+    const setPattern = /(?:export\s+)?const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*new\s+Set(?:<[^>]+>)?\s*\(\s*\[([\s\S]*?)\]\s*\)/g;
+    for (const match of text.matchAll(setPattern)) {
+        const members: string[] = [];
+        const memberPattern = /(["'])(.*?)\1|\b([A-Za-z_][A-Za-z0-9_]*)\b/g;
+        for (const member of (match[2] ?? "").matchAll(memberPattern)) {
+            const value = member[2] ?? member[3];
+            if (value !== undefined && !["new", "Set"].includes(value)) members.push(value);
+        }
+        sets.set(match[1] ?? "", members);
+    }
+    const aliasPattern = /(?:export\s+)?const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_.]*)\s*(?:as\s+const)?\s*;/g;
+    for (const match of text.matchAll(aliasPattern)) {
+        const target = match[2] ?? "";
+        if (isIdentifier(target) || /^[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*$/.test(target)) aliases.set(match[1] ?? "", target);
+    }
+    return { literals, aliases, sets };
+}
+
+function resolveConstant(name: string, constants: ReturnType<typeof collectConstants>, depth = 0): string {
+    if (depth > 8) return "";
+    const literal = constants.literals.get(name);
+    if (literal !== undefined) return literal;
+    const alias = constants.aliases.get(name);
+    if (alias === undefined) return "";
+    if (alias.includes(".")) return "";
+    return resolveConstant(alias, constants, depth + 1);
+}
+
+function parseMembers(body: string, constants: ReturnType<typeof collectConstants>): string[] {
+    const members: string[] = [];
+    const seen = new Set<string>();
+    const memberPattern = /(["'])(.*?)\1|\b([A-Za-z_][A-Za-z0-9_]*)\b/g;
+    for (const match of body.matchAll(memberPattern)) {
+        const raw = match[2] ?? match[3];
+        if (raw === undefined) continue;
+        const resolved = match[2] !== undefined ? raw : resolveConstant(raw, constants);
+        if (resolved !== "" && !seen.has(resolved)) {
+            seen.add(resolved);
+            members.push(resolved);
+        }
+    }
+    return members;
+}
+
+function parseRegistry(texts: readonly string[]): ParsedRegistry {
+    const text = texts.join("\n");
+    const constants = collectConstants(text);
+    const root = new Map<string, string>();
+    const rootBlock = /(?:export\s+)?const\s+FREEBUFF_ROOT_AGENT_ID_BY_MODEL\s*=\s*\{([\s\S]*?)\n\}/m.exec(text)?.[1] ?? "";
+    const rootPattern = /\[([A-Za-z_][A-Za-z0-9_]*)\]\s*:\s*(["'])(.*?)\2/g;
+    for (const match of rootBlock.matchAll(rootPattern)) {
+        const model = resolveConstant(match[1] ?? "", constants);
+        const agent = match[3] ?? "";
+        if (model !== "" && agent !== "") root.set(model, agent);
+    }
+
+    const agentEntries: { agent: string; models: string[] }[] = [];
+    const agentBlock = /(?:export\s+)?const\s+FREE_MODE_AGENT_MODELS\s*=\s*\{([\s\S]*?)\n\}/m.exec(text)?.[1] ?? "";
+    const entryPattern = /(["'])(.*?)\1\s*:\s*(?:new\s+Set(?:<[^>]+>)?\s*\(\s*\[([\s\S]*?)\]\s*\)|([A-Za-z_][A-Za-z0-9_]*))/g;
+    for (const match of agentBlock.matchAll(entryPattern)) {
+        const agent = match[2] ?? "";
+        const models = match[3] !== undefined
+            ? parseMembers(match[3], constants)
+            : constants.sets.get(match[4] ?? "")?.flatMap((member) => {
+                const resolved = resolveConstant(member, constants);
+                return resolved === "" ? [member] : [resolved];
+            }) ?? [];
+        if (agent !== "" && models.length > 0) agentEntries.push({ agent, models });
+    }
+
+    const modelToAgent = new Map(root);
+    for (const entry of agentEntries) {
+        for (const model of entry.models) if (!modelToAgent.has(model)) modelToAgent.set(model, entry.agent);
+    }
+    return {
+        modelToAgent: Object.fromEntries([...modelToAgent.entries()].sort(([a], [b]) => a.localeCompare(b))),
+        agentIds: [...new Set(agentEntries.map((entry) => entry.agent))],
+    };
+}
+
+function fallbackRegistry(): ParsedRegistry {
+    const modelToAgent = new Map<string, string>();
+    for (const entry of FALLBACK_AGENTS) for (const model of entry.models) if (!modelToAgent.has(model)) modelToAgent.set(model, entry.agent);
+    return {
+        modelToAgent: Object.fromEntries([...modelToAgent.entries()].sort(([a], [b]) => a.localeCompare(b))),
+        agentIds: [...new Set(FALLBACK_AGENTS.map((entry) => entry.agent))],
+    };
+}
+
+function sourceUrls(options: FreebuffModelRegistryOptions): readonly string[] {
+    if (options.sourceUrls && options.sourceUrls.length > 0) return options.sourceUrls;
+    return FREEBUFF_REGISTRY_SOURCE_FILES.map((file) => `${FREEBUFF_REGISTRY_RAW_BASE}${file}`);
+}
+
+export class FreebuffModelRegistry {
+    private readonly prefix: string;
+    private readonly urls: readonly string[];
+    private readonly fetchImpl: typeof fetch;
+    private readonly requestTimeoutMs: number;
+    private readonly refreshIntervalMs: number;
+    private mapping: ParsedRegistry = fallbackRegistry();
+    private fetchedAt = 0;
+    private source = "fallback";
+    private degraded = true;
+    private timer: ReturnType<typeof setInterval> | undefined;
+
+    public constructor(options: FreebuffModelRegistryOptions = {}) {
+        this.prefix = options.modelPrefix ?? "freebuff";
+        this.urls = sourceUrls(options);
+        this.fetchImpl = options.fetchImpl ?? fetch;
+        this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+        this.refreshIntervalMs = options.refreshIntervalMs ?? 15 * 60 * 1_000;
+        if (!Number.isFinite(this.requestTimeoutMs) || this.requestTimeoutMs <= 0) throw new TypeError("requestTimeoutMs must be positive");
+        if (!Number.isFinite(this.refreshIntervalMs) || this.refreshIntervalMs <= 0) throw new TypeError("refreshIntervalMs must be positive");
+    }
+
+    public async refresh(signal?: AbortSignal): Promise<void> {
+        const texts = await Promise.all(this.urls.map((url) => this.fetchSource(url, signal)));
+        const parsed = parseRegistry(texts);
+        if (Object.keys(parsed.modelToAgent).length === 0) throw new Error("FreeBuff registry source contained no models");
+        this.mapping = parsed;
+        this.fetchedAt = Date.now();
+        this.source = this.urls.join(",");
+        this.degraded = false;
+    }
+
+    public models(): ModelObject[] {
+        return Object.keys(this.mapping.modelToAgent).map((model) => ({ id: `${this.prefix}/${model}`, object: "model", owned_by: this.prefix }));
+    }
+
+    public agentForModel(modelId: string): string | null {
+        const bare = modelId.startsWith(`${this.prefix}/`) ? modelId.slice(this.prefix.length + 1) : modelId;
+        return this.mapping.modelToAgent[bare] ?? null;
+    }
+
+    public agentIds(): string[] { return [...this.mapping.agentIds]; }
+
+    public snapshot(): FreebuffRegistrySnapshot {
+        return {
+            models: this.mapping.modelToAgent,
+            fetchedAt: this.fetchedAt,
+            source: this.source,
+            degraded: this.degraded,
+            modelCount: Object.keys(this.mapping.modelToAgent).length,
+            agentCount: this.mapping.agentIds.length,
+        };
+    }
+
+    public start(signal?: AbortSignal): void {
+        this.stop();
+        const refresh = (): void => { void this.refresh(signal).catch(() => undefined); };
+        this.timer = setInterval(refresh, this.refreshIntervalMs);
+        this.timer.unref();
+        refresh();
+    }
+
+    public stop(): void {
+        if (this.timer !== undefined) clearInterval(this.timer);
+        this.timer = undefined;
+    }
+
+    private async fetchSource(url: string, callerSignal?: AbortSignal): Promise<string> {
+        const controller = new AbortController();
+        const abortCaller = (): void => controller.abort(callerSignal?.reason);
+        if (callerSignal?.aborted) abortCaller();
+        else callerSignal?.addEventListener("abort", abortCaller, { once: true });
+        const timer = setTimeout(() => controller.abort(new Error("FreeBuff registry request timed out")), this.requestTimeoutMs);
+        timer.unref();
+        try {
+            const response = await this.fetchImpl(url, { signal: controller.signal, headers: { Accept: "text/plain", "User-Agent": "SRouter-FreeBuff/1.0" } });
+            if (!response.ok) throw new Error(`FreeBuff registry source returned ${response.status}`);
+            return await response.text();
+        } finally {
+            clearTimeout(timer);
+            callerSignal?.removeEventListener("abort", abortCaller);
+        }
+    }
+}
+
+export function parseFreebuffRegistrySources(sources: readonly string[]): Readonly<Record<string, string>> {
+    return parseRegistry(sources).modelToAgent;
+}
+
+export function fallbackFreebuffRegistry(): Readonly<Record<string, string>> {
+    return fallbackRegistry().modelToAgent;
+}

--- a/packages/executors/src/freebuff/runs.test.ts
+++ b/packages/executors/src/freebuff/runs.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { FreebuffRequestOptions, FreebuffUpstreamClientContract } from "./upstream.js";
+import {
+    FreebuffRunManager,
+    type FreebuffRunLease,
+    type FreebuffRunSnapshot,
+} from "./runs.js";
+
+class FakeUpstream implements FreebuffUpstreamClientContract {
+    starts = 0;
+    finishes = 0;
+    startDelayMs = 0;
+    startedAgents: string[] = [];
+    finishedRuns: Array<{ runId: string; totalSteps: number }> = [];
+
+    async createSession(): Promise<{ status: "active"; instanceId: string }> { return { status: "active", instanceId: "session" }; }
+    async getSession(): Promise<{ status: "active"; instanceId: string }> { return { status: "active", instanceId: "session" }; }
+    async endSession(): Promise<void> { return undefined; }
+    async startRun(agentId: string, _options?: FreebuffRequestOptions): Promise<string> {
+        this.starts += 1;
+        this.startedAgents.push(agentId);
+        if (this.startDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, this.startDelayMs));
+        return `run-${this.starts}`;
+    }
+    async finishRun(runId: string, totalSteps: number, _options?: FreebuffRequestOptions): Promise<void> {
+        this.finishes += 1;
+        this.finishedRuns.push({ runId, totalSteps });
+    }
+    async chatCompletions(): Promise<Response> { return new Response(""); }
+}
+
+test("lazily starts and reuses a run with inflight lease accounting", async () => {
+    const upstream = new FakeUpstream();
+    const manager = new FreebuffRunManager(upstream, { rotationIntervalMs: 60_000 });
+    const first = await manager.acquireRun("agent-1");
+    const second = await manager.acquireRun("agent-1");
+    assert.equal(first.runId, second.runId);
+    assert.equal(upstream.starts, 1);
+    assert.equal(manager.snapshot().activeLeases, 2);
+    manager.releaseRun(first);
+    manager.releaseRun(second);
+    assert.equal(manager.snapshot().activeLeases, 0);
+});
+
+test("converges concurrent START calls to one upstream run", async () => {
+    const upstream = new FakeUpstream();
+    upstream.startDelayMs = 20;
+    const manager = new FreebuffRunManager(upstream);
+    const leases = await Promise.all(Array.from({ length: 10 }, () => manager.acquireRun("agent-1")));
+    assert.equal(upstream.starts, 1);
+    assert.equal(new Set(leases.map((lease) => lease.runId)).size, 1);
+    for (const lease of leases) manager.releaseRun(lease);
+});
+
+test("rotates aged runs and finishes the drained run after leases release", async () => {
+    const upstream = new FakeUpstream();
+    const manager = new FreebuffRunManager(upstream, { rotationIntervalMs: 1 });
+    const oldLease = await manager.acquireRun("agent-1");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const newLease = await manager.acquireRun("agent-1");
+    assert.notEqual(newLease.runId, oldLease.runId);
+    assert.equal(upstream.starts, 2);
+    manager.releaseRun(oldLease);
+    await manager.maintain();
+    assert.equal(upstream.finishes, 1);
+    assert.equal(upstream.finishedRuns[0]?.runId, oldLease.runId);
+    manager.releaseRun(newLease);
+});
+
+test("invalidates an agent run and starts a replacement", async () => {
+    const upstream = new FakeUpstream();
+    const manager = new FreebuffRunManager(upstream);
+    const first = await manager.acquireRun("agent-1");
+    manager.invalidateRun("agent-1");
+    const second = await manager.acquireRun("agent-1");
+    assert.notEqual(first.runId, second.runId);
+    assert.equal(upstream.starts, 2);
+    manager.releaseRun(first);
+    manager.releaseRun(second);
+});
+
+test("honors cooldown and resumes after cooldown expires", async () => {
+    const upstream = new FakeUpstream();
+    const manager = new FreebuffRunManager(upstream);
+    manager.cooldown(10);
+    await assert.rejects(() => manager.acquireRun("agent-1"), /cooldown/i);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    const lease = await manager.acquireRun("agent-1");
+    manager.releaseRun(lease);
+});
+
+test("prewarms agents and shutdown finishes active runs", async () => {
+    const upstream = new FakeUpstream();
+    const manager = new FreebuffRunManager(upstream);
+    await manager.prewarm(["agent-1", "agent-2"]);
+    assert.equal(upstream.starts, 2);
+    const snapshot: FreebuffRunSnapshot = manager.snapshot();
+    assert.equal(snapshot.activeRuns, 2);
+    await manager.shutdown();
+    assert.equal(upstream.finishes, 2);
+    assert.equal(manager.snapshot().activeRuns, 0);
+});
+
+test("release is idempotent and does not expose token material", async () => {
+    const upstream = new FakeUpstream();
+    const manager = new FreebuffRunManager(upstream);
+    const lease: FreebuffRunLease = await manager.acquireRun("agent-1");
+    manager.releaseRun(lease);
+    manager.releaseRun(lease);
+    assert.equal(manager.snapshot().activeLeases, 0);
+    assert.equal(JSON.stringify(manager.snapshot()).includes("token"), false);
+});

--- a/packages/executors/src/freebuff/runs.ts
+++ b/packages/executors/src/freebuff/runs.ts
@@ -44,7 +44,10 @@ export class FreebuffRunManager {
     private readonly draining = new Map<string, RunRecord>();
     private readonly starts = new Map<string, Promise<RunRecord>>();
     private readonly leases = new Map<string, RunRecord>();
+    private readonly finishedRunIds = new Set<string>();
     private cooldownUntil = 0;
+    private generation = 0;
+    private shuttingDown = false;
 
     constructor(upstream: FreebuffUpstreamClientContract, options: FreebuffRunManagerOptions = {}) {
         this.upstream = upstream;
@@ -54,6 +57,7 @@ export class FreebuffRunManager {
 
     async acquireRun(agentId: string, options?: FreebuffRequestOptions): Promise<FreebuffRunLease> {
         if (agentId.trim() === "") throw new TypeError("agentId must not be empty");
+        if (this.shuttingDown) throw new Error("FreeBuff run manager is shut down");
         this.assertAvailable();
 
         let current = this.active.get(agentId);
@@ -64,6 +68,7 @@ export class FreebuffRunManager {
         }
 
         if (current === undefined) {
+            const generation = this.generation;
             let start = this.starts.get(agentId);
             if (start === undefined) {
                 start = this.start(agentId, options);
@@ -73,6 +78,10 @@ export class FreebuffRunManager {
                 });
             }
             current = await start;
+            if (this.shuttingDown || generation !== this.generation) {
+                await this.finishOnce(current, options);
+                throw new Error("FreeBuff run manager shutdown invalidated START");
+            }
             if (this.active.get(agentId) === undefined) this.active.set(agentId, current);
         }
 
@@ -134,6 +143,9 @@ export class FreebuffRunManager {
     }
 
     async shutdown(options?: FreebuffRequestOptions): Promise<void> {
+        if (this.shuttingDown) return;
+        this.shuttingDown = true;
+        this.generation += 1;
         const controller = new AbortController();
         const callerSignal = options?.signal;
         const abortCaller = (): void => controller.abort(callerSignal?.reason);
@@ -147,7 +159,15 @@ export class FreebuffRunManager {
         this.draining.clear();
         this.leases.clear();
         try {
-            await Promise.all(records.map((record) => this.upstream.finishRun(record.runId, record.requests, { signal: controller.signal })));
+            await Promise.all(records.map((record) => this.finishOnce(record, { signal: controller.signal })));
+            const pendingStarts = [...this.starts.values()];
+            await Promise.allSettled(pendingStarts.map(async (start) => {
+                try {
+                    await this.finishOnce(await start, { signal: controller.signal });
+                } catch {
+                    // The corresponding acquire call receives the lifecycle error.
+                }
+            }));
         } finally {
             clearTimeout(timer);
             callerSignal?.removeEventListener("abort", abortCaller);
@@ -178,12 +198,23 @@ export class FreebuffRunManager {
         }
         await Promise.all(ready.map(async (record) => {
             try {
-                await this.upstream.finishRun(record.runId, record.requests, options);
+                await this.finishOnce(record, options);
             } catch (error) {
                 this.draining.set(record.runId, record);
                 throw error;
             }
         }));
+    }
+
+    private async finishOnce(record: RunRecord, options?: FreebuffRequestOptions): Promise<void> {
+        if (this.finishedRunIds.has(record.runId)) return;
+        this.finishedRunIds.add(record.runId);
+        try {
+            await this.upstream.finishRun(record.runId, record.requests, options);
+        } catch (error) {
+            this.finishedRunIds.delete(record.runId);
+            throw error;
+        }
     }
 
     private assertAvailable(): void {

--- a/packages/executors/src/freebuff/runs.ts
+++ b/packages/executors/src/freebuff/runs.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "node:crypto";
+import type { FreebuffRequestOptions, FreebuffUpstreamClientContract } from "./upstream.js";
+
+export interface FreebuffRunLease {
+    readonly leaseId: string;
+    readonly agentId: string;
+    readonly runId: string;
+    readonly acquiredAt: number;
+    readonly released: boolean;
+}
+
+export interface FreebuffRunSnapshot {
+    readonly activeRuns: number;
+    readonly activeLeases: number;
+    readonly drainingRuns: number;
+    readonly cooldownUntil?: number;
+}
+
+export interface FreebuffRunManagerOptions {
+    readonly rotationIntervalMs?: number;
+    readonly shutdownTimeoutMs?: number;
+}
+
+interface RunRecord {
+    readonly agentId: string;
+    readonly runId: string;
+    readonly startedAt: number;
+    requests: number;
+    activeLeases: number;
+}
+
+const DEFAULT_ROTATION_INTERVAL_MS = 6 * 60 * 60 * 1_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+
+function positiveOrDefault(value: number | undefined, fallback: number): number {
+    return value === undefined ? fallback : value > 0 && Number.isFinite(value) ? value : fallback;
+}
+
+export class FreebuffRunManager {
+    private readonly upstream: FreebuffUpstreamClientContract;
+    private readonly rotationIntervalMs: number;
+    private readonly shutdownTimeoutMs: number;
+    private readonly active = new Map<string, RunRecord>();
+    private readonly draining = new Map<string, RunRecord>();
+    private readonly starts = new Map<string, Promise<RunRecord>>();
+    private readonly leases = new Map<string, RunRecord>();
+    private cooldownUntil = 0;
+
+    constructor(upstream: FreebuffUpstreamClientContract, options: FreebuffRunManagerOptions = {}) {
+        this.upstream = upstream;
+        this.rotationIntervalMs = positiveOrDefault(options.rotationIntervalMs, DEFAULT_ROTATION_INTERVAL_MS);
+        this.shutdownTimeoutMs = positiveOrDefault(options.shutdownTimeoutMs, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+    }
+
+    async acquireRun(agentId: string, options?: FreebuffRequestOptions): Promise<FreebuffRunLease> {
+        if (agentId.trim() === "") throw new TypeError("agentId must not be empty");
+        this.assertAvailable();
+
+        let current = this.active.get(agentId);
+        if (current !== undefined && Date.now() - current.startedAt >= this.rotationIntervalMs) {
+            this.active.delete(agentId);
+            this.draining.set(current.runId, current);
+            current = undefined;
+        }
+
+        if (current === undefined) {
+            let start = this.starts.get(agentId);
+            if (start === undefined) {
+                start = this.start(agentId, options);
+                this.starts.set(agentId, start);
+                void start.then(() => undefined, () => undefined).finally(() => {
+                    if (this.starts.get(agentId) === start) this.starts.delete(agentId);
+                });
+            }
+            current = await start;
+            if (this.active.get(agentId) === undefined) this.active.set(agentId, current);
+        }
+
+        current.activeLeases += 1;
+        current.requests += 1;
+        const lease: FreebuffRunLease = {
+            leaseId: randomUUID(),
+            agentId,
+            runId: current.runId,
+            acquiredAt: Date.now(),
+            released: false,
+        };
+        this.leases.set(lease.leaseId, current);
+        return lease;
+    }
+
+    releaseRun(lease: FreebuffRunLease): void {
+        const record = this.leases.get(lease.leaseId);
+        if (record === undefined) return;
+        this.leases.delete(lease.leaseId);
+        if (record.activeLeases > 0) record.activeLeases -= 1;
+        Object.assign(lease as { released: boolean }, { released: true });
+        void this.finishReady().catch(() => undefined);
+    }
+
+    invalidateRun(agentId: string): void {
+        const record = this.active.get(agentId);
+        if (record !== undefined) {
+            this.active.delete(agentId);
+            this.draining.set(record.runId, record);
+            void this.finishReady().catch(() => undefined);
+        }
+    }
+
+    async maintain(options?: FreebuffRequestOptions): Promise<void> {
+        const now = Date.now();
+        for (const [agentId, record] of this.active) {
+            if (now - record.startedAt >= this.rotationIntervalMs) {
+                this.active.delete(agentId);
+                this.draining.set(record.runId, record);
+            }
+        }
+        await this.finishReady(options);
+    }
+
+    async prewarm(agentIds: readonly string[], options?: FreebuffRequestOptions): Promise<void> {
+        for (const agentId of agentIds) {
+            const lease = await this.acquireRun(agentId, options);
+            this.releaseRun(lease);
+        }
+    }
+
+    cooldown(durationMs: number): void {
+        if (durationMs > 0 && Number.isFinite(durationMs)) this.cooldownUntil = Date.now() + durationMs;
+    }
+
+    clearCooldown(): void {
+        this.cooldownUntil = 0;
+    }
+
+    async shutdown(options?: FreebuffRequestOptions): Promise<void> {
+        const controller = new AbortController();
+        const callerSignal = options?.signal;
+        const abortCaller = (): void => controller.abort(callerSignal?.reason);
+        if (callerSignal?.aborted) abortCaller();
+        else callerSignal?.addEventListener("abort", abortCaller, { once: true });
+        const timer = setTimeout(() => controller.abort(new Error("FreeBuff run shutdown timed out")), this.shutdownTimeoutMs);
+        timer.unref();
+
+        const records = [...this.active.values(), ...this.draining.values()];
+        this.active.clear();
+        this.draining.clear();
+        this.leases.clear();
+        try {
+            await Promise.all(records.map((record) => this.upstream.finishRun(record.runId, record.requests, { signal: controller.signal })));
+        } finally {
+            clearTimeout(timer);
+            callerSignal?.removeEventListener("abort", abortCaller);
+        }
+    }
+
+    snapshot(): FreebuffRunSnapshot {
+        const snapshot: FreebuffRunSnapshot = {
+            activeRuns: this.active.size,
+            activeLeases: this.leases.size,
+            drainingRuns: this.draining.size,
+        };
+        return this.cooldownUntil > Date.now() ? { ...snapshot, cooldownUntil: this.cooldownUntil } : snapshot;
+    }
+
+    private async start(agentId: string, options?: FreebuffRequestOptions): Promise<RunRecord> {
+        const runId = await this.upstream.startRun(agentId, options);
+        return { agentId, runId, startedAt: Date.now(), requests: 0, activeLeases: 0 };
+    }
+
+    private async finishReady(options?: FreebuffRequestOptions): Promise<void> {
+        const ready: RunRecord[] = [];
+        for (const [runId, record] of this.draining) {
+            if (record.activeLeases === 0) {
+                this.draining.delete(runId);
+                ready.push(record);
+            }
+        }
+        await Promise.all(ready.map(async (record) => {
+            try {
+                await this.upstream.finishRun(record.runId, record.requests, options);
+            } catch (error) {
+                this.draining.set(record.runId, record);
+                throw error;
+            }
+        }));
+    }
+
+    private assertAvailable(): void {
+        if (this.cooldownUntil > Date.now()) throw new Error(`FreeBuff token cooldown active until ${this.cooldownUntil}`);
+        if (this.cooldownUntil !== 0) this.cooldownUntil = 0;
+    }
+}

--- a/packages/executors/src/freebuff/session.test.ts
+++ b/packages/executors/src/freebuff/session.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+    FreebuffRequestOptions,
+    FreebuffSessionResponse,
+    FreebuffUpstreamClientContract,
+} from "./upstream.js";
+import {
+    FreebuffSessionManager,
+    FreebuffWaitingRoomError,
+    type FreebuffSessionLease,
+    type FreebuffSessionSnapshot,
+} from "./session.js";
+
+class FakeUpstream implements FreebuffUpstreamClientContract {
+    creates = 0;
+    gets = 0;
+    ends = 0;
+    createDelayMs = 0;
+    responses: FreebuffSessionResponse[] = [{ status: "active", instanceId: "inst-1", expiresAt: Date.now() + 60_000 }];
+    getResponses: FreebuffSessionResponse[] = [];
+
+    async createSession(_options?: FreebuffRequestOptions): Promise<FreebuffSessionResponse> {
+        this.creates += 1;
+        if (this.createDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, this.createDelayMs));
+        return this.responses[Math.min(this.creates - 1, this.responses.length - 1)] ?? { status: "active", instanceId: "inst-1" };
+    }
+    async getSession(_instanceId: string, _options?: FreebuffRequestOptions): Promise<FreebuffSessionResponse> {
+        this.gets += 1;
+        return this.getResponses[Math.min(this.gets - 1, this.getResponses.length - 1)] ?? { status: "active", instanceId: "inst-1", expiresAt: Date.now() + 60_000 };
+    }
+    async endSession(_instanceId: string, _options?: FreebuffRequestOptions): Promise<void> { this.ends += 1; }
+    async startRun(_agentId: string, _options?: FreebuffRequestOptions): Promise<string> { return "run-1"; }
+    async finishRun(_runId: string, _totalSteps: number, _options?: FreebuffRequestOptions): Promise<void> { return undefined; }
+    async chatCompletions(): Promise<Response> { return new Response(""); }
+}
+
+const activeResponse = (instanceId = "inst-1"): FreebuffSessionResponse => ({
+    status: "active",
+    instanceId,
+    expiresAt: Date.now() + 60_000,
+});
+
+function lease(manager: FreebuffSessionManager): Promise<FreebuffSessionLease> {
+    return manager.ensureSession();
+}
+
+test("creates an active session and reuses it before expiry margin", async () => {
+    const upstream = new FakeUpstream();
+    upstream.responses = [activeResponse()];
+    const manager = new FreebuffSessionManager(upstream, { expiryMarginMs: 5_000 });
+    const first = await lease(manager);
+    const second = await lease(manager);
+    assert.equal(first.instanceId, "inst-1");
+    assert.equal(second.instanceId, "inst-1");
+    assert.equal(upstream.creates, 1);
+    assert.equal(manager.snapshot().status, "active");
+});
+
+test("refreshes an expired session", async () => {
+    const upstream = new FakeUpstream();
+    upstream.responses = [
+        { status: "active", instanceId: "old", expiresAt: Date.now() - 1 },
+        activeResponse("new"),
+    ];
+    const manager = new FreebuffSessionManager(upstream, { expiryMarginMs: 5_000 });
+    const first = await lease(manager);
+    const second = await lease(manager);
+    assert.equal(first.instanceId, "old");
+    assert.equal(second.instanceId, "new");
+    assert.equal(upstream.creates, 2);
+});
+
+test("shares one in-flight refresh among concurrent callers", async () => {
+    const upstream = new FakeUpstream();
+    upstream.createDelayMs = 20;
+    const manager = new FreebuffSessionManager(upstream);
+    const leases = await Promise.all(Array.from({ length: 12 }, () => lease(manager)));
+    assert.equal(upstream.creates, 1);
+    assert.equal(new Set(leases.map((item) => item.instanceId)).size, 1);
+});
+
+test("surfaces queued retry metadata and polls after retry time", async () => {
+    const upstream = new FakeUpstream();
+    upstream.responses = [{ status: "queued", instanceId: "queued-1", position: 2, queueDepth: 7, estimatedWaitMs: 1 }];
+    upstream.getResponses = [activeResponse("ready")];
+    const manager = new FreebuffSessionManager(upstream, { minimumRetryMs: 1 });
+    await assert.rejects(() => lease(manager), (error: Error) => {
+        assert.ok(error instanceof FreebuffWaitingRoomError);
+        assert.equal(error.position, 2);
+        assert.equal(error.queueDepth, 7);
+        return true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const result = await lease(manager);
+    assert.equal(result.instanceId, "ready");
+    assert.equal(upstream.gets, 1);
+});
+
+test("recreates ended and superseded sessions", async () => {
+    const upstream = new FakeUpstream();
+    upstream.responses = [{ status: "ended" }, activeResponse("fresh")];
+    const manager = new FreebuffSessionManager(upstream);
+    const result = await lease(manager);
+    assert.equal(result.instanceId, "fresh");
+    assert.equal(upstream.creates, 2);
+});
+
+test("supports invalidation, disabled sessions, and cleanup", async () => {
+    const upstream = new FakeUpstream();
+    upstream.responses = [{ status: "disabled" }, activeResponse("after-invalidate")];
+    const manager = new FreebuffSessionManager(upstream);
+    const disabled = await lease(manager);
+    assert.equal(disabled.instanceId, undefined);
+    assert.equal(manager.snapshot().status, "disabled");
+    manager.invalidate();
+    const active = await lease(manager);
+    assert.equal(active.instanceId, "after-invalidate");
+    await manager.end();
+    assert.equal(upstream.ends, 1);
+    assert.equal(manager.snapshot().status, "none");
+});
+
+test("returns a stable snapshot without exposing token material", async () => {
+    const upstream = new FakeUpstream();
+    const manager = new FreebuffSessionManager(upstream);
+    await lease(manager);
+    const snapshot: FreebuffSessionSnapshot = manager.snapshot();
+    assert.deepEqual(Object.keys(snapshot).sort(), ["expiresAt", "instanceId", "position", "queueDepth", "retryAt", "status"]);
+    assert.equal(JSON.stringify(snapshot).includes("freebuff"), false);
+});

--- a/packages/executors/src/freebuff/session.ts
+++ b/packages/executors/src/freebuff/session.ts
@@ -142,6 +142,10 @@ export class FreebuffSessionManager {
     private async refresh(options: FreebuffRequestOptions | undefined, generation: number): Promise<FreebuffSessionLease> {
         for (let attempt = 0; attempt < this.maxRefreshIterations; attempt += 1) {
             const response = await this.fetchState(options);
+            if (generation !== this.generation) {
+                if (response.instanceId !== undefined) await this.upstream.endSession(response.instanceId, options).catch(() => undefined);
+                throw new Error("FreeBuff session refresh invalidated by lifecycle change");
+            }
             const status = response.status ?? "active";
             if (status === "active" || status === "ready") {
                 const next = activeState(response);

--- a/packages/executors/src/freebuff/session.ts
+++ b/packages/executors/src/freebuff/session.ts
@@ -1,0 +1,199 @@
+import type {
+    FreebuffRequestOptions,
+    FreebuffSessionResponse,
+    FreebuffUpstreamClientContract,
+} from "./upstream.js";
+
+export type FreebuffSessionStatus = "none" | "active" | "queued" | "disabled";
+
+export interface FreebuffSessionLease {
+    readonly instanceId?: string;
+    readonly expiresAt?: number;
+    readonly status: "active" | "disabled";
+}
+
+export interface FreebuffSessionSnapshot {
+    readonly status: FreebuffSessionStatus;
+    readonly instanceId?: string;
+    readonly expiresAt?: number;
+    readonly position?: number;
+    readonly queueDepth?: number;
+    readonly retryAt?: number;
+}
+
+export interface FreebuffSessionManagerOptions {
+    readonly expiryMarginMs?: number;
+    readonly minimumRetryMs?: number;
+    readonly maxRefreshIterations?: number;
+}
+
+export class FreebuffWaitingRoomError extends Error {
+    readonly name = "FreebuffWaitingRoomError" as const;
+    readonly position: number | undefined;
+    readonly queueDepth: number | undefined;
+    readonly retryAt: number;
+    readonly retryAfterMs: number;
+
+    constructor(position: number | undefined, queueDepth: number | undefined, retryAt: number, retryAfterMs: number) {
+        super("FreeBuff session is waiting in queue");
+        this.position = position;
+        this.queueDepth = queueDepth;
+        this.retryAt = retryAt;
+        this.retryAfterMs = retryAfterMs;
+    }
+}
+
+interface SessionState {
+    status: FreebuffSessionStatus;
+    instanceId?: string;
+    expiresAt?: number;
+    position?: number;
+    queueDepth?: number;
+    retryAt?: number;
+}
+
+const DEFAULT_EXPIRY_MARGIN_MS = 5_000;
+const DEFAULT_MINIMUM_RETRY_MS = 1_000;
+const DEFAULT_MAX_REFRESH_ITERATIONS = 5;
+
+function parseTimestamp(value: string | number | undefined): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value > 10_000_000_000 ? value : value * 1_000;
+    }
+    if (typeof value === "string") {
+        const numeric = Number(value);
+        if (Number.isFinite(numeric) && value.trim() !== "") return numeric > 10_000_000_000 ? numeric : numeric * 1_000;
+        const parsed = Date.parse(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+}
+
+function activeState(response: FreebuffSessionResponse): SessionState {
+    return {
+        status: "active",
+        instanceId: response.instanceId,
+        expiresAt: parseTimestamp(response.expiresAt),
+    };
+}
+
+export class FreebuffSessionManager {
+    private readonly upstream: FreebuffUpstreamClientContract;
+    private readonly expiryMarginMs: number;
+    private readonly minimumRetryMs: number;
+    private readonly maxRefreshIterations: number;
+    private state: SessionState = { status: "none" };
+    private refreshPromise: Promise<FreebuffSessionLease> | undefined;
+    private generation = 0;
+
+    constructor(upstream: FreebuffUpstreamClientContract, options: FreebuffSessionManagerOptions = {}) {
+        this.upstream = upstream;
+        this.expiryMarginMs = options.expiryMarginMs ?? DEFAULT_EXPIRY_MARGIN_MS;
+        this.minimumRetryMs = options.minimumRetryMs ?? DEFAULT_MINIMUM_RETRY_MS;
+        this.maxRefreshIterations = options.maxRefreshIterations ?? DEFAULT_MAX_REFRESH_ITERATIONS;
+        if (!Number.isFinite(this.expiryMarginMs) || this.expiryMarginMs < 0) throw new TypeError("expiryMarginMs must be non-negative");
+        if (!Number.isFinite(this.minimumRetryMs) || this.minimumRetryMs < 0) throw new TypeError("minimumRetryMs must be non-negative");
+        if (!Number.isInteger(this.maxRefreshIterations) || this.maxRefreshIterations < 1) throw new TypeError("maxRefreshIterations must be positive");
+    }
+
+    async ensureSession(options?: FreebuffRequestOptions): Promise<FreebuffSessionLease> {
+        const now = Date.now();
+        if (this.state.status === "active" && (this.state.expiresAt === undefined || now < this.state.expiresAt - this.expiryMarginMs)) {
+            return this.toLease(this.state);
+        }
+        if (this.state.status === "disabled") return { status: "disabled" };
+        if (this.state.status === "queued" && this.state.retryAt !== undefined && now < this.state.retryAt) {
+            throw this.waitingError(this.state);
+        }
+        if (this.refreshPromise !== undefined) return this.refreshPromise;
+        const generation = this.generation;
+        const refresh = this.refresh(options, generation);
+        this.refreshPromise = refresh;
+        try {
+            return await refresh;
+        } finally {
+            if (this.refreshPromise === refresh) this.refreshPromise = undefined;
+        }
+    }
+
+    invalidate(): void {
+        this.generation += 1;
+        this.state = { status: "none" };
+    }
+
+    async end(options?: FreebuffRequestOptions): Promise<void> {
+        this.generation += 1;
+        const instanceId = this.state.instanceId;
+        this.state = { status: "none" };
+        if (instanceId !== undefined) await this.upstream.endSession(instanceId, options);
+    }
+
+    snapshot(): FreebuffSessionSnapshot {
+        return {
+            status: this.state.status,
+            instanceId: this.state.instanceId,
+            expiresAt: this.state.expiresAt,
+            position: this.state.position,
+            queueDepth: this.state.queueDepth,
+            retryAt: this.state.retryAt,
+        };
+    }
+
+    private async refresh(options: FreebuffRequestOptions | undefined, generation: number): Promise<FreebuffSessionLease> {
+        for (let attempt = 0; attempt < this.maxRefreshIterations; attempt += 1) {
+            const response = await this.fetchState(options);
+            const status = response.status ?? "active";
+            if (status === "active" || status === "ready") {
+                const next = activeState(response);
+                if (generation === this.generation) this.state = next;
+                return this.toLease(next);
+            }
+            if (status === "disabled") {
+                const next: SessionState = { status: "disabled" };
+                if (generation === this.generation) this.state = next;
+                return { status: "disabled" };
+            }
+            if (status === "queued" || status === "waiting" || status === "waiting_room") {
+                const retryAfter = Math.max(
+                    this.minimumRetryMs,
+                    Number.isFinite(response.estimatedWaitMs ?? Number.NaN) ? (response.estimatedWaitMs ?? 0) : 0,
+                );
+                const next: SessionState = {
+                    status: "queued",
+                    instanceId: response.instanceId,
+                    position: response.position,
+                    queueDepth: response.queueDepth,
+                    retryAt: Date.now() + retryAfter,
+                };
+                if (generation === this.generation) this.state = next;
+                throw this.waitingError(next);
+            }
+            if (status === "ended" || status === "superseded" || status === "none") {
+                if (generation === this.generation) this.state = { status: "none" };
+                continue;
+            }
+            throw new Error(`FreeBuff session returned unsupported status: ${status}`);
+        }
+        throw new Error("FreeBuff session refresh limit exceeded");
+    }
+
+    private async fetchState(options?: FreebuffRequestOptions): Promise<FreebuffSessionResponse> {
+        if (this.state.status === "queued" && this.state.instanceId !== undefined) {
+            return this.upstream.getSession(this.state.instanceId, options);
+        }
+        return this.upstream.createSession(options);
+    }
+
+    private waitingError(state: SessionState): FreebuffWaitingRoomError {
+        const retryAt = state.retryAt ?? Date.now() + this.minimumRetryMs;
+        return new FreebuffWaitingRoomError(state.position, state.queueDepth, retryAt, Math.max(0, retryAt - Date.now()));
+    }
+
+    private toLease(state: SessionState): FreebuffSessionLease {
+        return {
+            status: state.status === "disabled" ? "disabled" : "active",
+            ...(state.instanceId === undefined ? {} : { instanceId: state.instanceId }),
+            ...(state.expiresAt === undefined ? {} : { expiresAt: state.expiresAt }),
+        };
+    }
+}

--- a/packages/executors/src/freebuff/types.ts
+++ b/packages/executors/src/freebuff/types.ts
@@ -1,0 +1,59 @@
+export type FreebuffErrorCode =
+    | "AUTH_REJECTED"
+    | "RATE_LIMITED"
+    | "BANNED"
+    | "WAITING_ROOM"
+    | "SESSION_INVALID"
+    | "RUN_INVALID"
+    | "UPSTREAM";
+
+export interface FreebuffConnectionConfig {
+    id: string;
+    accessToken: string;
+    baseUrl: string;
+    enabled: boolean;
+    instanceId?: string;
+}
+
+export interface FreebuffConfig {
+    providerId: string;
+    connections: readonly FreebuffConnectionConfig[];
+    defaultBaseUrl: string;
+    modelPrefix: "freebuff";
+    sessionExpiryMarginMs: number;
+    runLeaseMs: number;
+}
+
+export interface FreebuffModelRegistryState {
+    models: Readonly<Record<string, string>>;
+    fetchedAt: number;
+    source: string;
+    degraded: boolean;
+}
+
+export interface FreebuffLease {
+    leaseId: string;
+    connectionId: string;
+    runId: string;
+    acquiredAt: number;
+    expiresAt: number;
+    released: boolean;
+}
+
+export interface FreebuffErrorDetails {
+    readonly status: number;
+    readonly body: string;
+    readonly headers: Readonly<Record<string, string>>;
+    readonly retryAfterSeconds?: number;
+    readonly resetAt?: number;
+    readonly resumesAt?: number;
+    readonly position?: number;
+}
+
+export interface FreebuffError extends Error {
+    readonly name: "FreebuffError";
+    readonly code: FreebuffErrorCode;
+    readonly status: number;
+    readonly details: FreebuffErrorDetails;
+    is(code: FreebuffErrorCode): boolean;
+}

--- a/packages/executors/src/freebuff/upstream.test.ts
+++ b/packages/executors/src/freebuff/upstream.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import test from "node:test";
+import { once } from "node:events";
+import { gzipSync } from "node:zlib";
+import {
+    FreebuffUpstreamClient,
+    buildChatEnvelope,
+    createFreebuffTransport,
+    type FreebuffChatOptions,
+    type FreebuffTransportConfig,
+} from "./upstream.js";
+import { FreebuffAuthError, FreebuffRateLimitError } from "./errors.js";
+
+interface CapturedRequest {
+    method: string;
+    path: string;
+    headers: Record<string, string | undefined>;
+    body: string;
+}
+
+interface MockResponse {
+    status: number;
+    headers?: Record<string, string>;
+    body: string;
+    encodedBody?: Uint8Array;
+    delayMs?: number;
+}
+
+interface MockState {
+    requests: CapturedRequest[];
+    responses: Record<string, MockResponse>;
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function readRequest(request: IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(chunk));
+        request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        request.on("error", reject);
+    });
+}
+
+async function startMockServer(): Promise<{ server: Server; baseUrl: string; state: MockState }> {
+    const state: MockState = { requests: [], responses: {} };
+    const server = createServer(async (request: IncomingMessage, response: ServerResponse) => {
+        const body = await readRequest(request);
+        const path = request.url ?? "/";
+        const headers: Record<string, string | undefined> = {
+            authorization: headerValue(request.headers.authorization),
+            "content-type": headerValue(request.headers["content-type"]),
+            accept: headerValue(request.headers.accept),
+            "x-freebuff-model": headerValue(request.headers["x-freebuff-model"]),
+            "x-freebuff-instance-id": headerValue(request.headers["x-freebuff-instance-id"]),
+            "user-agent": headerValue(request.headers["user-agent"]),
+        };
+        state.requests.push({ method: request.method ?? "", path, headers, body });
+        const configured = state.responses[`${request.method ?? ""} ${path}`] ?? { status: 200, body: "{}" };
+        if (configured.delayMs !== undefined) await new Promise((resolve) => setTimeout(resolve, configured.delayMs));
+        response.writeHead(configured.status, configured.headers ?? { "content-type": "application/json" });
+        response.end(configured.encodedBody ?? configured.body);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    return { server, baseUrl: `http://127.0.0.1:${address.port}`, state };
+}
+
+async function closeServer(server: Server): Promise<void> {
+    server.close();
+    await once(server, "close");
+}
+
+function config(baseUrl: string, overrides: Partial<FreebuffTransportConfig> = {}): FreebuffTransportConfig {
+    return {
+        baseUrl,
+        accessToken: "freebuff-test-token",
+        timeoutMs: 1_000,
+        ...overrides,
+    };
+}
+
+function client(baseUrl: string, overrides: Partial<FreebuffTransportConfig> = {}): FreebuffUpstreamClient {
+    return new FreebuffUpstreamClient(createFreebuffTransport(config(baseUrl, overrides)));
+}
+
+function parseJson(body: string): Record<string, string | boolean | Record<string, string> | string[]> {
+    return JSON.parse(body) as Record<string, string | boolean | Record<string, string> | string[]>;
+}
+
+test("buildChatEnvelope is pure, forces streaming, denies collection, and preserves nested model IDs", () => {
+    const input = {
+        model: "provider/namespace/model",
+        messages: [{ role: "user", content: "hello" }],
+        stop: ["custom-stop"],
+        provider: { data_collection: "allow" },
+    };
+    const first = buildChatEnvelope(input, { runId: "run-1", clientId: "client-1", instanceId: "instance-1" });
+    const second = buildChatEnvelope(input, { runId: "run-1", clientId: "client-1", instanceId: "instance-1" });
+    assert.deepEqual(first, second);
+    assert.equal(first.model, input.model);
+    assert.equal(first.stream, true);
+    assert.deepEqual(first.stop, input.stop);
+    assert.deepEqual(first.provider, { data_collection: "deny" });
+    assert.deepEqual(first.codebuff_metadata, {
+        run_id: "run-1",
+        client_id: "client-1",
+        freebuff_instance_id: "instance-1",
+    });
+});
+
+test("runs the complete lifecycle with exact paths, methods, auth, and metadata headers", async () => {
+    const fixture = await startMockServer();
+    try {
+        fixture.state.responses["POST /api/v1/freebuff/session"] = { status: 200, body: JSON.stringify({ status: "ready", instanceId: "instance-1" }) };
+        fixture.state.responses["GET /api/v1/freebuff/session"] = { status: 200, body: JSON.stringify({ status: "ready", instanceId: "instance-1" }) };
+        fixture.state.responses["DELETE /api/v1/freebuff/session"] = { status: 204, body: "" };
+        fixture.state.responses["POST /api/v1/agent-runs"] = { status: 200, body: JSON.stringify({ runId: "run-1" }) };
+
+        const upstream = client(fixture.baseUrl);
+        const created = await upstream.createSession();
+        const fetched = await upstream.getSession("instance-1");
+        await upstream.endSession("instance-1");
+        const runId = await upstream.startRun("agent-1");
+        await upstream.finishRun(runId, 3);
+
+        assert.equal(created.status, "ready");
+        assert.equal(fetched.instanceId, "instance-1");
+        assert.equal(runId, "run-1");
+        assert.deepEqual(fixture.state.requests.map((request) => `${request.method} ${request.path}`), [
+            "POST /api/v1/freebuff/session",
+            "GET /api/v1/freebuff/session",
+            "DELETE /api/v1/freebuff/session",
+            "POST /api/v1/agent-runs",
+            "POST /api/v1/agent-runs",
+        ]);
+        for (const request of fixture.state.requests) {
+            assert.equal(request.headers.authorization, "Bearer freebuff-test-token");
+            assert.equal(request.headers["content-type"], "application/json");
+        }
+        assert.deepEqual(parseJson(fixture.state.requests[3].body), { action: "START", agentId: "agent-1" });
+        assert.deepEqual(parseJson(fixture.state.requests[4].body), {
+            action: "FINISH",
+            runId: "run-1",
+            status: "completed",
+            totalSteps: 3,
+            directCredits: 0,
+            totalCredits: 0,
+        });
+    } finally {
+        await closeServer(fixture.server);
+    }
+});
+
+test("captures chat envelope, exact headers, and returns the SSE body", async () => {
+    const fixture = await startMockServer();
+    try {
+        const sse = "data: {\"id\":\"chunk-1\"}\n\ndata: [DONE]\n\n";
+        fixture.state.responses["POST /api/v1/chat/completions"] = { status: 200, headers: { "content-type": "text/event-stream" }, body: sse };
+        const upstream = client(fixture.baseUrl);
+        const options: FreebuffChatOptions = { model: "vendor/nested/model", runId: "run-1", clientId: "client-1", instanceId: "instance-1" };
+        const response = await upstream.chatCompletions({ model: options.model ?? "", messages: [{ role: "user", content: "hello" }] }, options);
+        assert.equal(await response.text(), sse);
+        const request = fixture.state.requests[0];
+        assert.equal(request.path, "/api/v1/chat/completions");
+        assert.equal(request.headers.authorization, "Bearer freebuff-test-token");
+        assert.equal(request.headers["x-freebuff-model"], options.model);
+        assert.equal(request.headers["x-freebuff-instance-id"], "instance-1");
+        assert.match(request.headers["user-agent"] ?? "", /./);
+        const body = JSON.parse(request.body) as {
+            model: string;
+            stream: boolean;
+            stop: string[];
+            provider: { data_collection: string };
+            codebuff_metadata: { run_id: string; client_id: string; freebuff_instance_id: string };
+        };
+        assert.equal(body.model, options.model);
+        assert.equal(body.stream, true);
+        assert.deepEqual(body.stop, ["cb_easp"]);
+        assert.deepEqual(body.provider, { data_collection: "deny" });
+        assert.deepEqual(body.codebuff_metadata, { run_id: "run-1", client_id: "client-1", freebuff_instance_id: "instance-1" });
+    } finally {
+        await closeServer(fixture.server);
+    }
+});
+
+test("does not overwrite an explicitly supplied stop value and omits optional instance header", async () => {
+    const fixture = await startMockServer();
+    try {
+        fixture.state.responses["POST /api/v1/chat/completions"] = { status: 200, body: "{}" };
+        const upstream = client(fixture.baseUrl);
+        await (await upstream.chatCompletions({ model: "m", messages: [], stop: ["user-stop"] }, { model: "m", runId: "r", clientId: "c" })).text();
+        const request = fixture.state.requests[0];
+        assert.equal(request.headers["x-freebuff-instance-id"], undefined);
+        const body = JSON.parse(request.body) as { stop: string[]; codebuff_metadata: Record<string, string> };
+        assert.deepEqual(body.stop, ["user-stop"]);
+        assert.deepEqual(body.codebuff_metadata, { run_id: "r", client_id: "c" });
+    } finally {
+        await closeServer(fixture.server);
+    }
+});
+
+test("classifies bounded upstream errors", async () => {
+    const fixture = await startMockServer();
+    try {
+        fixture.state.responses["POST /api/v1/chat/completions"] = { status: 401, body: "freebuff-secret-token" + "x".repeat(5000) };
+        await assert.rejects(
+            () => client(fixture.baseUrl).chatCompletions({ model: "m", messages: [] }, { model: "m", runId: "r", clientId: "c" }),
+            (error: Error) => error instanceof FreebuffAuthError && !error.message.includes("freebuff-secret-token"),
+        );
+        fixture.state.responses["POST /api/v1/chat/completions"] = { status: 429, headers: { "retry-after": "12" }, body: JSON.stringify({ error: "quota" }) };
+        await assert.rejects(
+            () => client(fixture.baseUrl).chatCompletions({ model: "m", messages: [] }, { model: "m", runId: "r", clientId: "c" }),
+            (error: Error) => error instanceof FreebuffRateLimitError && error.retryAfterSeconds === 12,
+        );
+    } finally {
+        await closeServer(fixture.server);
+    }
+});
+
+test("honors caller abort and per-call timeout", async () => {
+    const fixture = await startMockServer();
+    try {
+        fixture.state.responses["GET /api/v1/freebuff/session"] = { status: 200, body: "{}", delayMs: 100 };
+        const controller = new AbortController();
+        const aborted = client(fixture.baseUrl).getSession("instance-1", { signal: controller.signal });
+        controller.abort();
+        await assert.rejects(aborted, (error: Error) => error.name === "AbortError");
+
+        const timeoutFixture = await startMockServer();
+        try {
+            timeoutFixture.state.responses["GET /api/v1/freebuff/session"] = { status: 200, body: "{}", delayMs: 100 };
+            await assert.rejects(
+                () => client(timeoutFixture.baseUrl, { timeoutMs: 10 }).getSession("instance-1"),
+                (error: Error) => error.name === "TimeoutError" || error.name === "AbortError",
+            );
+        } finally {
+            await closeServer(timeoutFixture.server);
+        }
+    } finally {
+        await closeServer(fixture.server);
+    }
+});

--- a/packages/executors/src/freebuff/upstream.ts
+++ b/packages/executors/src/freebuff/upstream.ts
@@ -1,0 +1,344 @@
+import { nextBrowserHeaders, type BrowserHeaders } from "./profiles.js";
+import { parseUpstreamError } from "./errors.js";
+
+export interface FreebuffJsonObject {
+    [key: string]: FreebuffJsonValue;
+}
+
+export type FreebuffJsonPrimitive = string | number | boolean | null;
+export type FreebuffJsonValue = FreebuffJsonPrimitive | FreebuffJsonObject | FreebuffJsonValue[];
+
+export interface FreebuffChatRequest extends FreebuffJsonObject {
+    model: string;
+    messages: FreebuffJsonObject[];
+}
+
+export interface FreebuffChatOptions {
+    readonly model?: string;
+    readonly runId: string;
+    readonly clientId: string;
+    readonly instanceId?: string;
+}
+
+export interface FreebuffEnvelopeMetadata {
+    readonly run_id: string;
+    readonly client_id: string;
+    readonly freebuff_instance_id?: string;
+}
+
+export interface FreebuffUpstreamChatRequest extends FreebuffJsonObject {
+    model: string;
+    messages: FreebuffJsonObject[];
+    stream: true;
+    provider: FreebuffJsonObject;
+    codebuff_metadata: FreebuffJsonObject;
+    stop: FreebuffJsonValue;
+}
+
+export interface FreebuffSessionResponse {
+    status?: string;
+    instanceId?: string;
+    expiresAt?: string | number;
+    position?: number;
+    queueDepth?: number;
+    estimatedWaitMs?: number;
+    pollAt?: string | number;
+    accessTier?: string;
+    countryCode?: string;
+    countryBlockReason?: string;
+}
+
+export interface FreebuffTransportConfig {
+    readonly baseUrl: string;
+    readonly accessToken: string;
+    readonly timeoutMs?: number;
+    readonly maxErrorBodyBytes?: number;
+    readonly maxRedirects?: number;
+    readonly fetchImpl?: typeof fetch;
+}
+
+export interface FreebuffRequestOptions {
+    readonly signal?: AbortSignal;
+    readonly timeoutMs?: number;
+}
+
+export interface FreebuffTransportResponse {
+    readonly response: Response;
+}
+
+export interface FreebuffTransport {
+    readonly request: (path: string, init: RequestInit, options?: FreebuffRequestOptions) => Promise<FreebuffTransportResponse>;
+}
+
+export interface FreebuffUpstreamClientContract {
+    createSession(options?: FreebuffRequestOptions): Promise<FreebuffSessionResponse>;
+    getSession(instanceId: string, options?: FreebuffRequestOptions): Promise<FreebuffSessionResponse>;
+    endSession(instanceId: string, options?: FreebuffRequestOptions): Promise<void>;
+    startRun(agentId: string, options?: FreebuffRequestOptions): Promise<string>;
+    finishRun(runId: string, totalSteps: number, options?: FreebuffRequestOptions): Promise<void>;
+    chatCompletions(req: FreebuffChatRequest, options: FreebuffChatOptions & FreebuffRequestOptions): Promise<Response>;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_ERROR_BODY_BYTES = 8 * 1024;
+const DEFAULT_MAX_REDIRECTS = 3;
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function objectValue(value: FreebuffJsonValue): FreebuffJsonObject {
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) return value;
+    return {};
+}
+
+function cloneJsonValue(value: FreebuffJsonValue): FreebuffJsonValue {
+    if (Array.isArray(value)) return value.map(cloneJsonValue);
+    if (typeof value === "object" && value !== null) {
+        const copy: FreebuffJsonObject = {};
+        for (const [key, child] of Object.entries(value)) copy[key] = cloneJsonValue(child);
+        return copy;
+    }
+    return value;
+}
+
+function isPlainObject(value: FreebuffJsonValue): value is FreebuffJsonObject {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function buildChatEnvelope(req: FreebuffChatRequest, options: FreebuffChatOptions): FreebuffUpstreamChatRequest {
+    const envelope: FreebuffJsonObject = {};
+    for (const [key, value] of Object.entries(req)) envelope[key] = cloneJsonValue(value);
+    envelope.model = req.model;
+    envelope.messages = req.messages.map(cloneJsonValue);
+    envelope.codebuff_metadata = {
+        run_id: options.runId,
+        client_id: options.clientId,
+        ...(options.instanceId === undefined ? {} : { freebuff_instance_id: options.instanceId }),
+    };
+    envelope.provider = { data_collection: "deny" };
+    envelope.stream = true;
+    if (envelope.stop === undefined) envelope.stop = ["cb_easp"];
+    return envelope as FreebuffUpstreamChatRequest;
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+    return `${baseUrl.replace(/\/$/, "")}${path}`;
+}
+
+function validateBaseUrl(baseUrl: string): URL {
+    const url = new URL(baseUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") throw new TypeError("baseUrl must use http or https");
+    return url;
+}
+
+
+function headerRecord(headers: Headers): Record<string, string> {
+    const output: Record<string, string> = {};
+    headers.forEach((value, key) => { output[key] = value; });
+    return output;
+}
+
+function timeoutError(): Error {
+    const error = new Error("FreeBuff upstream request timed out");
+    error.name = "TimeoutError";
+    return error;
+}
+
+function combineSignals(signal: AbortSignal | undefined, timeoutMs: number): { signal: AbortSignal; cleanup: () => void } {
+    const controller = new AbortController();
+    const abortFromCaller = (): void => controller.abort(signal?.reason);
+    if (signal?.aborted) abortFromCaller();
+    else signal?.addEventListener("abort", abortFromCaller, { once: true });
+    const timer = setTimeout(() => controller.abort(timeoutError()), timeoutMs);
+    const cleanup = (): void => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", abortFromCaller);
+    };
+    return { signal: controller.signal, cleanup };
+}
+
+async function readBounded(response: Response, maxBytes: number): Promise<string> {
+    if (!response.body) return "";
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+        while (total < maxBytes) {
+            const item = await reader.read();
+            if (item.done) break;
+            const remaining = maxBytes - total;
+            const chunk = item.value.byteLength > remaining ? item.value.slice(0, remaining) : item.value;
+            chunks.push(chunk);
+            total += chunk.byteLength;
+            if (chunk.byteLength < item.value.byteLength) break;
+        }
+    } finally {
+        await reader.cancel().catch(() => undefined);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+    return new TextDecoder().decode(bytes);
+}
+
+async function assertResponse(response: Response, maxErrorBodyBytes: number): Promise<void> {
+    if (response.ok) return;
+    const body = await readBounded(response, maxErrorBodyBytes);
+    throw parseUpstreamError(response.status, body, headerRecord(response.headers));
+}
+
+function parseJsonObject(body: string, operation: string): FreebuffJsonObject {
+    const parsed: FreebuffJsonValue = JSON.parse(body) as FreebuffJsonValue;
+    if (!isPlainObject(parsed)) throw new Error(`FreeBuff ${operation} response must be a JSON object`);
+    return parsed;
+}
+
+function responseBodyError(error: Error, signal: AbortSignal): Error {
+    if (signal.aborted && error.name === "AbortError") {
+        const reason = signal.reason;
+        if (reason instanceof Error && reason.name === "TimeoutError") return reason;
+    }
+    return error;
+}
+
+function responseWithCleanup(response: Response, cleanup: () => void): Response {
+    if (response.body === null) {
+        cleanup();
+        return response;
+    }
+    const reader = response.body.getReader();
+    let released = false;
+    const release = (): void => {
+        if (released) return;
+        released = true;
+        cleanup();
+    };
+    const body = new ReadableStream<Uint8Array>({
+        async pull(controller): Promise<void> {
+            try {
+                const item = await reader.read();
+                if (item.done) {
+                    controller.close();
+                    release();
+                } else {
+                    controller.enqueue(item.value);
+                }
+            } catch (error) {
+                release();
+                controller.error(error);
+            }
+        },
+        async cancel(): Promise<void> {
+            try {
+                await reader.cancel();
+            } finally {
+                release();
+            }
+        },
+    });
+    return new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers });
+}
+
+export function createFreebuffTransport(config: FreebuffTransportConfig): FreebuffTransport {
+    const base = validateBaseUrl(config.baseUrl);
+    if (config.accessToken.trim() === "") throw new TypeError("accessToken must not be empty");
+    const fetchImpl = config.fetchImpl ?? fetch;
+    const defaultTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const maxErrorBodyBytes = config.maxErrorBodyBytes ?? DEFAULT_ERROR_BODY_BYTES;
+    const maxRedirects = config.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+    if (!Number.isFinite(defaultTimeoutMs) || defaultTimeoutMs <= 0) throw new TypeError("timeoutMs must be positive");
+    if (!Number.isInteger(maxRedirects) || maxRedirects < 0) throw new TypeError("maxRedirects must be a non-negative integer");
+    if (!Number.isInteger(maxErrorBodyBytes) || maxErrorBodyBytes <= 0) throw new TypeError("maxErrorBodyBytes must be positive");
+
+    const request = async (path: string, init: RequestInit, options: FreebuffRequestOptions = {}): Promise<FreebuffTransportResponse> => {
+        const headers = new Headers(init.headers);
+        headers.set("Authorization", `Bearer ${config.accessToken}`);
+        headers.set("Content-Type", "application/json");
+        const browserHeaders: BrowserHeaders = nextBrowserHeaders();
+        for (const [name, value] of Object.entries(browserHeaders)) headers.set(name, value);
+        const timeout = options.timeoutMs ?? defaultTimeoutMs;
+        if (!Number.isFinite(timeout) || timeout <= 0) throw new TypeError("timeoutMs must be positive");
+        const combined = combineSignals(options.signal, timeout);
+        try {
+            const response = await fetchImpl(joinUrl(base.toString().replace(/\/$/, ""), path), {
+                ...init,
+                headers,
+                signal: combined.signal,
+                redirect: "manual",
+            });
+            let current = response;
+            for (let redirect = 0; redirect < maxRedirects && current.status >= 300 && current.status < 400; redirect += 1) {
+                const location = current.headers.get("location");
+                if (location === null) break;
+                const method = init.method?.toUpperCase() ?? "GET";
+                if (!SAFE_METHODS.has(method)) throw new Error(`FreeBuff redirect refused for ${method} ${path}`);
+                const redirectUrl = new URL(location, current.url || base.toString());
+                if (redirectUrl.origin !== base.origin) throw new Error(`FreeBuff cross-origin redirect refused for ${path}`);
+                await current.body?.cancel();
+                current = await fetchImpl(redirectUrl, { ...init, headers, signal: combined.signal, redirect: "manual" });
+            }
+            if (current.status >= 300 && current.status < 400) throw new Error(`FreeBuff redirect limit exceeded for ${path}`);
+            return { response: responseWithCleanup(current, combined.cleanup) };
+        } catch (error) {
+            combined.cleanup();
+            const caught = error instanceof Error ? error : new Error("FreeBuff transport failed");
+            throw responseBodyError(caught, combined.signal);
+        }
+    };
+    return { request };
+}
+
+export class FreebuffUpstreamClient implements FreebuffUpstreamClientContract {
+    private readonly transport: FreebuffTransport;
+    private readonly maxErrorBodyBytes: number;
+
+    public constructor(transport: FreebuffTransport, maxErrorBodyBytes = DEFAULT_ERROR_BODY_BYTES) {
+        this.transport = transport;
+        this.maxErrorBodyBytes = maxErrorBodyBytes;
+    }
+
+    public async createSession(options?: FreebuffRequestOptions): Promise<FreebuffSessionResponse> {
+        const result = await this.transport.request("/api/v1/freebuff/session", { method: "POST", body: "{}" }, options);
+        await assertResponse(result.response, this.maxErrorBodyBytes);
+        return parseJsonObject(await result.response.text(), "session") as FreebuffSessionResponse;
+    }
+
+    public async getSession(instanceId: string, options?: FreebuffRequestOptions): Promise<FreebuffSessionResponse> {
+        const result = await this.transport.request("/api/v1/freebuff/session", { method: "GET", headers: { "x-freebuff-instance-id": instanceId } }, options);
+        if (result.response.status === 404) return { status: "disabled" };
+        await assertResponse(result.response, this.maxErrorBodyBytes);
+        return parseJsonObject(await result.response.text(), "session") as FreebuffSessionResponse;
+    }
+
+    public async endSession(instanceId: string, options?: FreebuffRequestOptions): Promise<void> {
+        const result = await this.transport.request("/api/v1/freebuff/session", { method: "DELETE", headers: { "x-freebuff-instance-id": instanceId } }, options);
+        if (result.response.status === 404) return;
+        await assertResponse(result.response, this.maxErrorBodyBytes);
+    }
+
+    public async startRun(agentId: string, options?: FreebuffRequestOptions): Promise<string> {
+        const result = await this.transport.request("/api/v1/agent-runs", { method: "POST", body: JSON.stringify({ action: "START", agentId }) }, options);
+        await assertResponse(result.response, this.maxErrorBodyBytes);
+        const body = parseJsonObject(await result.response.text(), "START run");
+        if (typeof body.runId !== "string" || body.runId === "") throw new Error("FreeBuff START response missing runId");
+        return body.runId;
+    }
+
+    public async finishRun(runId: string, totalSteps: number, options?: FreebuffRequestOptions): Promise<void> {
+        const result = await this.transport.request("/api/v1/agent-runs", { method: "POST", body: JSON.stringify({ action: "FINISH", runId, status: "completed", totalSteps, directCredits: 0, totalCredits: 0 }) }, options);
+        await assertResponse(result.response, this.maxErrorBodyBytes);
+    }
+
+    public async chatCompletions(req: FreebuffChatRequest, options: FreebuffChatOptions & FreebuffRequestOptions): Promise<Response> {
+        const body = buildChatEnvelope(req, options);
+        const result = await this.transport.request("/api/v1/chat/completions", {
+            method: "POST",
+            headers: {
+                Accept: "application/json, text/event-stream",
+                "x-freebuff-model": options.model ?? req.model,
+                ...(options.instanceId === undefined ? {} : { "x-freebuff-instance-id": options.instanceId }),
+            },
+            body: JSON.stringify(body),
+        }, options);
+        await assertResponse(result.response, this.maxErrorBodyBytes);
+        return result.response;
+    }
+}

--- a/packages/executors/src/index.ts
+++ b/packages/executors/src/index.ts
@@ -4,7 +4,7 @@ export * from "./base.js";
 export * from "./codex.js";
 export * from "./commandcode.js";
 export * from "./openai.js";
-export * from "./freebuff/executor.js";
+export * from "./freebuff.js";
 export * from "./freebuff/coordinator.js";
 export * from "./freebuff/registry.js";
 export * from "./freebuff/types.js";

--- a/packages/executors/src/index.ts
+++ b/packages/executors/src/index.ts
@@ -4,3 +4,8 @@ export * from "./base.js";
 export * from "./codex.js";
 export * from "./commandcode.js";
 export * from "./openai.js";
+export * from "./freebuff/executor.js";
+export * from "./freebuff/coordinator.js";
+export * from "./freebuff/registry.js";
+export * from "./freebuff/types.js";
+export * from "./freebuff/errors.js";

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -8,6 +8,7 @@ const PROVIDER_ALIASES: Record<string, string> = {
     antigravity: "antigravity",
     openai_codex: "openai",
     commandcode: "commandcode",
+    freebuff: "freebuff",
     gemini: "gemini",
     vertex: "vertex",
 };
@@ -25,6 +26,19 @@ function stripModelPrefix(modelId: string, alias: string, providerId: string): s
 }
 
 export const DEFAULT_CATALOG: ProviderDefinition[] = [
+    {
+        id: "freebuff",
+        name: "FreeBuff",
+        category: "free_tier",
+        protocol: "openai",
+        description: "Native FreeBuff/Codebuff provider with live model registry and multi-token failover.",
+        icon: "🟢",
+        defaultBaseUrl: "https://www.codebuff.com",
+        requiresApiKey: false,
+        supportsCustomUrl: true,
+        status: { state: "no_connections", message: "FreeBuff token missing" },
+        models: [],
+    },
     {
         id: "openai_codex",
         name: "OpenAI Codex / ChatGPT",
@@ -162,6 +176,15 @@ export class ProviderRegistry {
         if (catItem) {
             const connectedCount = Array.from(this.providers.keys()).filter((k) => k === catItem.id || k.startsWith(`${catItem.id}_`) || k.startsWith(`${catItem.id}-`)).length;
             catItem.status = { state: "connected", connectedCount };
+        }
+    }
+
+    unregisterProvider(providerId: string): void {
+        this.providers.delete(providerId);
+        const baseId = providerId.split("_")[0]?.split("-")[0] ?? providerId;
+        const catItem = this.catalog.find((c) => c.id === providerId || c.id === baseId);
+        if (catItem?.id === "freebuff") {
+            catItem.status = { state: "no_connections", message: "FreeBuff token missing" };
         }
     }
 


### PR DESCRIPTION
## Reference & documentation
- [Design spec](https://github.com/seaavey/SRouter/blob/docs/freebuff-native-spec/docs/superpowers/specs/2026-08-12-freebuff-native-design.md)
- [Implementation plan](https://github.com/seaavey/SRouter/blob/docs/freebuff-native-spec/docs/superpowers/plans/2026-08-12-freebuff-native.md)
- [Reference implementation: trefeon/freebuff-proxy](https://github.com/trefeon/freebuff-proxy)

## Summary
- Add a native FreeBuff/Codebuff executor with typed request conversion, browser-like headers, SSE parsing, and non-stream accumulation.
- Add per-token session and agent-run lifecycle managers with pooling, cooldowns, failover, and shutdown cleanup.
- Add a live model registry with verified-state retention and degraded fallback behavior.
- Wire the FreeBuff catalog, provider loading, legacy/API token mapping, stale-connection cleanup, and runtime unregister on deletion.
- Preserve nested upstream model IDs and legacy upstream finish reasons without widening the public SRouter finish-reason type.

## Review fixes
- Prevent failover after a streaming response has already emitted a chunk.
- Prevent late `START` results from resurrecting runs after shutdown.
- Invalidate late session refresh results after session teardown.
- Accept FreeBuff credentials through `accessToken` and legacy `apiKey` provider configuration.
- Use `https://www.codebuff.com` consistently as the default upstream.

## Verification
- Full workspace build order passed: types, db, providers, translator, executors, and API typecheck.
- Focused FreeBuff tests passed: 35 tests, 0 failures.
- `git diff --check` passed.
- No `rejectUnauthorized: false` or credential logging in the FreeBuff executor sources.
- No real FreeBuff credentials are included.

## Scope note
This PR contains the native runtime implementation and API wiring, not documentation only. Pure Node.js uses browser-like headers as best effort; native JA3/uTLS impersonation is out of scope.

## Merge
Please review first. Do not merge until explicitly authorized.