### PR TITLE
feat: add Neosantara provider integration

### DIFF
--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -29,6 +29,18 @@ if (process.env.ANTHROPIC_API_KEY) {
     );
 }
 
+// 3. Register env-configured Neosantara Provider if present
+if (process.env.NEOSANTARA_API_KEY) {
+    registry.registerProvider(
+        new OpenAIExecutor({
+            id: "neosantara",
+            name: "Neosantara",
+            apiKey: process.env.NEOSANTARA_API_KEY,
+            baseUrl: process.env.NEOSANTARA_BASE_URL || "https://api.neosantara.xyz/v1",
+        }),
+    );
+}
+
 /**
  * Load saved OAuth & Custom providers from SQLite Database on startup
  */
@@ -87,6 +99,17 @@ export function loadSavedProvidersFromDB(): void {
                         accessToken: p.accessToken,
                         refreshToken: p.refreshToken,
                         accountId: p.accountId,
+                    }),
+                );
+                break;
+            case providerType === "neosantara" || p.id.startsWith("neosantara"):
+                registry.registerProvider(
+                    new OpenAIExecutor({
+                        id: p.id || p.providerId,
+                        name: p.name,
+                        baseUrl: baseUrl || process.env.NEOSANTARA_BASE_URL || "https://api.neosantara.xyz/v1",
+                        apiKey: p.apiKey,
+                        accessToken: p.accessToken,
                     }),
                 );
                 break;

--- a/apps/api/tests/neosantara-env.test.ts
+++ b/apps/api/tests/neosantara-env.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+const originalFetch = globalThis.fetch;
+const originalKey = process.env.NEOSANTARA_API_KEY;
+const originalBaseUrl = process.env.NEOSANTARA_BASE_URL;
+
+after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.NEOSANTARA_API_KEY;
+    else process.env.NEOSANTARA_API_KEY = originalKey;
+    if (originalBaseUrl === undefined) delete process.env.NEOSANTARA_BASE_URL;
+    else process.env.NEOSANTARA_BASE_URL = originalBaseUrl;
+});
+
+test("environment Neosantara connection honors the configured base URL", async () => {
+    const fixtureKey = "fixture-env-key-not-a-secret";
+    process.env.NEOSANTARA_API_KEY = fixtureKey;
+    process.env.NEOSANTARA_BASE_URL = "https://neosantara.test/v1";
+
+    let requestUrl = "";
+    let hasBearerHeader = false;
+    globalThis.fetch = async (input, init) => {
+        requestUrl = String(input);
+        const authorization = new Headers(init?.headers).get("authorization") ?? "";
+        hasBearerHeader = authorization.startsWith("Bearer ") && authorization.endsWith(fixtureKey);
+        return Response.json({ data: [] });
+    };
+
+    const { registry } = await import("../src/services/registry.js");
+    const provider = registry.getProvider("neosantara");
+    assert.ok(provider);
+    await provider.listModels();
+
+    assert.equal(requestUrl, "https://neosantara.test/v1/models");
+    assert.equal(hasBearerHeader, true);
+    registry.unregisterProvider("neosantara");
+});

--- a/apps/api/tests/neosantara-provider.test.ts
+++ b/apps/api/tests/neosantara-provider.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
+import type { ProviderConfig } from "@srouter/types";
+
+const createdIds: string[] = [];
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const id of createdIds.splice(0)) deleteProviderDB(id);
+});
+
+test("saved Neosantara connections use the official URL and bearer auth", async () => {
+    const id = `neosantara_test_${Date.now()}`;
+    const fixtureKey = "fixture-key-not-a-secret";
+    createdIds.push(id);
+
+    const config: ProviderConfig = {
+        id,
+        providerId: "neosantara",
+        name: "Neosantara Test",
+        category: "api_key",
+        protocol: "openai",
+        accessToken: fixtureKey,
+        enabled: true,
+        createdAt: Date.now(),
+    };
+    upsertProviderDB(config);
+
+    let requestUrl = "";
+    let authorization = "";
+    globalThis.fetch = async (input, init) => {
+        requestUrl = String(input);
+        authorization = new Headers(init?.headers).get("authorization") ?? "";
+        return Response.json({ data: [] });
+    };
+
+    const { loadSavedProvidersFromDB, registry } = await import("../src/services/registry.js");
+    loadSavedProvidersFromDB();
+    const provider = registry.getProvider(id);
+    assert.ok(provider);
+    await provider.listModels();
+
+    assert.equal(requestUrl, "https://api.neosantara.xyz/v1/models");
+    assert.equal(authorization.startsWith("Bearer "), true);
+    assert.equal(authorization.endsWith(fixtureKey), true);
+
+    registry.unregisterProvider(id);
+});

--- a/docs/superpowers/plans/2026-08-12-neosantara-provider.md
+++ b/docs/superpowers/plans/2026-08-12-neosantara-provider.md
@@ -1,0 +1,125 @@
+# Neosantara Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Add Neosantara as a first-class API-key OpenAI-compatible provider with live models, Chat Completions, SSE streaming, and tools.
+
+**Architecture:** Reuse the existing `OpenAIExecutor`. Add catalog metadata and aliasing in `packages/providers`, then add explicit environment and SQLite loader wiring in `apps/api`. Use deterministic fetch mocks for URL, auth-header presence, model routing, JSON chat, SSE, tools, and errors.
+
+**Tech Stack:** TypeScript, pnpm workspace, Node `node:test` with existing `tsx`, Hono registry, OpenAI-compatible JSON/SSE.
+
+## Global constraints
+
+- Provider ID: `neosantara`.
+- Default URL: `https://api.neosantara.xyz/v1`.
+- Authentication is a runtime Bearer credential; never print, log, commit, or return credentials.
+- Scope: Models, Chat Completions, SSE streaming, and OpenAI-compatible tools only.
+- Exclude Responses API, Coding Plan, OAuth/JWT, embeddings, media endpoints, and a duplicate executor.
+- Failed model discovery returns an empty list; do not fabricate stale fallback models.
+- Remove only the first `neosantara/` prefix and preserve all internal model slashes.
+- Use pnpm and dependency-order builds. Do not commit generated or unrelated files.
+
+---
+
+### Task 1: Add catalog metadata and alias
+
+**Files:**
+- Modify: `packages/providers/src/registry.ts`
+- Test: `packages/providers/tests/registry.test.ts`
+
+**Produces:** The alias resolver recognizes `neosantara` and suffixed saved IDs. The catalog entry has ID/name `neosantara`/`Neosantara`, API-key category, OpenAI protocol, official default URL, required-credential flag enabled, custom URL support enabled, disconnected status, and an empty model array.
+
+- [ ] **Step 1: Write failing tests.** Extend the existing registry tests to assert every contract in the Produces paragraph. Also assert that resolving `neosantara_123` returns the `neosantara` alias.
+- [ ] **Step 2: Run the red test.** Run `pnpm --filter @srouter/providers test`. Expected: the new assertions fail because the alias and catalog entry are absent.
+- [ ] **Step 3: Implement the catalog.** Add the alias and catalog entry described above. Do not add static models.
+- [ ] **Step 4: Run the green test.** Run `pnpm --filter @srouter/providers test` and require zero failures.
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/providers/src/registry.ts packages/providers/tests/registry.test.ts
+git commit -m "feat(neosantara): add provider catalog metadata"
+```
+
+---
+
+### Task 2: Wire environment and saved connections
+
+**Files:**
+- Modify: `apps/api/src/services/registry.ts`
+- Test: `apps/api/tests/neosantara-provider.test.ts`
+
+**Produces:** An environment-configured Neosantara executor is registered at startup when its configured credential exists. Saved connections with provider ID `neosantara` or a `neosantara`-prefixed connection ID use the saved URL, otherwise the configured override, otherwise the official URL. This branch must precede generic OpenAI fallback handling.
+
+- [ ] **Step 1: Add a deterministic loader test.** Use an in-memory database or existing API fixture, a local-only fixture credential, and mocked `fetch`. Invoke the loader, call `listModels()`, and assert the request URL is `https://api.neosantara.xyz/v1/models` and that the Authorization header starts with `Bearer `. Assert values only in memory; never print the fixture.
+- [ ] **Step 2: Run the red test.** Run `pnpm --filter api test`. Expected: the new loader assertion fails before explicit Neosantara wiring exists.
+- [ ] **Step 3: Add environment registration.** Register `OpenAIExecutor` with ID `neosantara`, name `Neosantara`, the runtime environment credential, and the configured base URL with official URL fallback.
+- [ ] **Step 4: Add the saved-provider branch.** Before generic OpenAI handling, match the provider ID/prefix, construct `OpenAIExecutor` with the saved ID/name/credential, and apply URL precedence: saved URL, configured override, official default.
+- [ ] **Step 5: Run loader verification.**
+
+```bash
+pnpm --filter api test
+pnpm --filter api exec tsc --noEmit
+```
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add apps/api/src/services/registry.ts apps/api/tests/neosantara-provider.test.ts
+git commit -m "feat(neosantara): wire environment and saved connections"
+```
+
+---
+
+### Task 3: Test OpenAI executor behavior
+
+**Files:**
+- Test: `packages/executors/tests/neosantara.test.ts`
+- Inspect/modify only if required: `packages/executors/src/openai.ts`
+
+**Produces:** Deterministic coverage for URL, Bearer-header presence, model discovery, JSON chat, nested model IDs, SSE, tools, and error propagation.
+
+- [ ] **Step 1: Add mocked fetch tests.** Construct `OpenAIExecutor` with ID `neosantara`, official URL, and an in-memory fixture credential. Restore `globalThis.fetch` in `finally`. Cover:
+  1. Model listing calls `/models`, sends a Bearer header, and returns IDs prefixed `neosantara/<upstream-id>`.
+  2. Non-streaming chat calls `/chat/completions`, sends `stream: false`, and maps `neosantara/garda-core` to `garda-core`.
+  3. `neosantara/provider/model-with-slash` maps to `provider/model-with-slash`, preserving the internal slash.
+  4. Streaming sends `stream: true` and parses JSON SSE chunks plus `[DONE]`.
+  5. Tool definitions survive request serialization and a streamed tool-call delta is yielded.
+  6. Non-2xx responses include status/upstream text but not the fixture credential.
+- [ ] **Step 2: Run focused tests.** Run `pnpm --filter @srouter/executors test`. Expected: existing tests pass and any missing behavior is exposed by the new tests.
+- [ ] **Step 3: Fix only a demonstrated shared-executor issue.** If nested model IDs fail, replace single-index splitting with first-prefix removal: find the first slash and return everything after it; return the original model when no slash exists. Use it for JSON and streaming requests while preserving existing provider behavior.
+- [ ] **Step 4: Run tests/build.**
+
+```bash
+pnpm --filter @srouter/executors test
+pnpm --filter @srouter/executors build
+```
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/executors/src/openai.ts packages/executors/tests/neosantara.test.ts
+git commit -m "test(neosantara): verify OpenAI-compatible behavior"
+```
+
+If no executor source change is required, stage only the test file.
+
+---
+
+### Task 4: Full verification and final audit
+
+**Files:** Inspect all files changed by Tasks 1–3. Modify only for a concrete verification failure.
+
+- [ ] **Step 1: Install without lockfile churn.** Run `CI=true pnpm install --frozen-lockfile`.
+- [ ] **Step 2: Build and typecheck.** Run, in order: `@srouter/types build`, `@srouter/db build`, `@srouter/providers build`, `@srouter/pricing build`, `@srouter/translator build`, `@srouter/executors build`, then `pnpm --filter api exec tsc --noEmit`.
+- [ ] **Step 3: Run tests.** Run provider tests, executor tests, and API tests. Require zero failures; keep API tests serial if SQLite requires it.
+- [ ] **Step 4: Build web and inspect scope.** Run `pnpm --filter web build`, `git diff --check`, `git status --short`, and `git diff --stat origin/main...HEAD`. No generated cache, credential, report, or unrelated file may be staged.
+- [ ] **Step 5: Audit security and markers.** Review the diff for credential field names, runtime environment names, Bearer headers, fixture values, and conflict markers. Real secret values are forbidden.
+- [ ] **Step 6: Commit only a concrete correction.** If verification finds a defect, stage only its specific files and use `git commit -m "fix(neosantara): address verification finding"`; do not create an empty commit.
+
+## Completion checklist
+
+- [ ] Catalog and alias pass.
+- [ ] Environment and saved-provider loading pass.
+- [ ] Models, chat, SSE, tools, nested model IDs, and errors pass with mocks.
+- [ ] Full builds, API typecheck, relevant tests, web build, and diff check pass.
+- [ ] No credential, generated artifact, or unrelated file is included.

--- a/docs/superpowers/specs/2026-08-12-neosantara-provider-design.md
+++ b/docs/superpowers/specs/2026-08-12-neosantara-provider-design.md
@@ -1,0 +1,182 @@
+# Neosantara Provider Design
+
+**Date:** 2026-08-12
+**Status:** Approved design; implementation has not started
+
+## Goal
+
+Add Neosantara as a first-class SRouter provider for the Neosantara API-key OpenAI-compatible API, supporting live model discovery, Chat Completions, SSE streaming, and tool calls without adding a new wire protocol.
+
+## Scope
+
+### Included
+
+- Provider catalog entry with ID `neosantara`.
+- API-key authentication using `Authorization: Bearer <key>`.
+- Default API base URL `https://api.neosantara.xyz/v1`.
+- Optional environment configuration through `NEOSANTARA_API_KEY` and `NEOSANTARA_BASE_URL`.
+- Live model discovery through `GET /models`.
+- Non-streaming `POST /chat/completions`.
+- Streaming `POST /chat/completions` with SSE.
+- OpenAI-compatible tool definitions and tool-call chunks passed through unchanged.
+- Saved-provider startup loading with an explicit Neosantara case before generic OpenAI fallbacks.
+- Model IDs using the `neosantara/<model-id>` SRouter prefix, with only that provider prefix removed before the upstream request.
+
+### Excluded
+
+- Responses API.
+- Embeddings, image generation, audio, video, OCR, and other specialized endpoints.
+- Neosantara Coding Plan authentication or coding-agent endpoints.
+- OAuth, JWT, automatic key rotation, or a custom Neosantara executor.
+- A static fabricated model catalog used as a substitute for failed live discovery.
+
+## External API contract
+
+The official Neosantara documentation describes an OpenAI-compatible API at `https://api.neosantara.xyz/v1`:
+
+- Authentication: `Authorization: Bearer <NEOSANTARA_API_KEY>`.
+- Models: `GET /v1/models`.
+- Chat: `POST /v1/chat/completions`.
+- Streaming: the normal OpenAI `stream: true` SSE contract.
+- Tools: OpenAI-compatible function definitions and tool calls.
+
+References:
+
+- [Neosantara authentication](https://docs.neosantara.xyz/en/authentication)
+- [Neosantara OpenAI-compatible API](https://docs.neosantara.xyz/en/sdk/openai-compat/index)
+- [Neosantara Chat Completions](https://docs.neosantara.xyz/en/sdk/openai-compat/chat-completions)
+- [Neosantara tool calls](https://docs.neosantara.xyz/en/sdk/openai-compat/tool-calls)
+- [Neosantara models overview](https://docs.neosantara.xyz/en/models-overview)
+
+## Architecture
+
+Neosantara will use the existing `OpenAIExecutor` rather than duplicating an executor. The provider is protocol-compatible, so the integration adds provider identity, defaults, and explicit startup wiring while reusing the tested request, response, and SSE behavior.
+
+### Catalog
+
+Add one `ProviderDefinition` to `packages/providers/src/registry.ts`:
+
+- `id`: `neosantara`
+- `name`: `Neosantara`
+- `category`: `api_key`
+- `protocol`: `openai`
+- `defaultBaseUrl`: `https://api.neosantara.xyz/v1`
+- `requiresApiKey`: `true`
+- `supportsCustomUrl`: `true`
+- disconnected status when no connection is registered
+- no hard-coded model list; live models come from the upstream `/models` endpoint
+
+Add `neosantara: "neosantara"` to the provider alias map so model routing understands both `neosantara/<model>` and saved connection IDs such as `neosantara_<suffix>`.
+
+### Environment startup
+
+In `apps/api/src/services/registry.ts`, register an environment-configured `OpenAIExecutor` when `NEOSANTARA_API_KEY` is present:
+
+```ts
+new OpenAIExecutor({
+    id: "neosantara",
+    name: "Neosantara",
+    apiKey: process.env.NEOSANTARA_API_KEY,
+    baseUrl: process.env.NEOSANTARA_BASE_URL || "https://api.neosantara.xyz/v1",
+})
+```
+
+This must be placed alongside the existing environment provider registrations and must not expose the key in catalog responses or logs.
+
+### Saved connections
+
+In `loadSavedProvidersFromDB()`, add an explicit Neosantara branch before generic `p.protocol === "openai"` handling. It must use the saved `baseUrl` when present and otherwise use `NEOSANTARA_BASE_URL` or the official default. It must pass the saved API key/access token through the existing `OpenAIExecutor` credential fields.
+
+The explicit branch prevents Neosantara connections from being silently treated as an arbitrary OpenAI provider and preserves the provider-specific default URL.
+
+### Model routing and prefix handling
+
+The registry alias must map `neosantara` to itself. The generic executor must strip only the first provider prefix when routing a request:
+
+- `neosantara/garda-core` → upstream model `garda-core`.
+- `neosantara/provider/model-with-slash` → upstream model `provider/model-with-slash`.
+- `garda-core` remains `garda-core` when no prefix is present.
+
+No suffix or model-internal slash may be removed.
+
+### Runtime behavior
+
+- `listModels()` calls the configured `/models` endpoint and returns the upstream model objects under the Neosantara provider namespace, following existing OpenAI executor behavior.
+- `chatCompletion()` calls `/chat/completions` with `stream: false` and the selected bare model.
+- `chatCompletionStream()` calls `/chat/completions` with `stream: true` and parses standard SSE through the existing `streamLines`/`parseDataLine` helpers.
+- Tool definitions are included in the request unchanged according to the existing OpenAI request type.
+- Tool-call deltas are yielded unchanged according to the existing OpenAI chunk type.
+- Non-2xx responses include HTTP status and upstream error text without printing credentials.
+- Missing or failed model discovery returns an empty model list rather than fabricated models.
+
+## Files and responsibilities
+
+Expected implementation files:
+
+- Modify `packages/providers/src/registry.ts`: alias and catalog metadata.
+- Modify `apps/api/src/services/registry.ts`: environment registration and saved-provider branch.
+- Modify or add focused tests beside the existing provider/executor tests: catalog metadata, routing, auth, model listing, chat body, streaming, and tools.
+- Modify `pnpm-lock.yaml` only if a new test/runtime dependency is genuinely required; reuse existing tooling where possible.
+
+No database schema change is expected because existing provider fields already persist the API key, base URL, category, protocol, and enabled state.
+
+## Error handling and security
+
+- Never include API keys in response bodies, catalog data, logs, test output, or committed fixtures.
+- Use the existing `OpenAIExecutor` bearer-header behavior; do not add alternate authentication guesses.
+- Preserve custom base URLs for compatible proxies, but default new Neosantara connections to the official URL.
+- Treat upstream model-list failures as an unavailable live connection, not proof that no models exist permanently.
+- Do not add a static list of Neosantara models that can become stale.
+
+## Testing strategy
+
+Focused tests must prove:
+
+1. Catalog metadata identifies Neosantara as an API-key OpenAI provider and uses the official default URL.
+2. Alias routing recognizes `neosantara/garda-core`.
+3. A saved Neosantara connection receives the correct default URL and is loaded by the explicit branch.
+4. Requests use `Authorization: Bearer <redacted test token>` and never emit the token in errors or output.
+5. `/models` response models are returned with the Neosantara namespace.
+6. Non-streaming chat sends the bare model and `stream: false`.
+7. Streaming chat sends `stream: true` and yields parsed SSE chunks.
+8. Tool definitions survive request serialization and tool-call chunks survive response parsing.
+9. A nested model ID preserves its internal slash after only the `neosantara/` prefix is stripped.
+10. Non-2xx upstream responses produce the existing executor error shape.
+
+Validation commands after implementation:
+
+```bash
+pnpm --filter @srouter/types build
+pnpm --filter @srouter/db build
+pnpm --filter @srouter/providers build
+pnpm --filter @srouter/pricing build
+pnpm --filter @srouter/translator build
+pnpm --filter @srouter/executors build
+pnpm --filter api exec tsc --noEmit
+pnpm --filter @srouter/providers test
+pnpm --filter @srouter/executors test
+pnpm --filter api test
+pnpm --filter web build
+git diff --check
+```
+
+A live API smoke test is optional and requires a user-provided Neosantara API key. If performed, the key must be supplied through the environment and must never be printed or committed.
+
+## Acceptance criteria
+
+The provider is ready for implementation review when:
+
+- Neosantara appears in the provider catalog with the official default URL.
+- Environment and saved connections use `OpenAIExecutor` with the correct Neosantara defaults.
+- Model discovery, chat, streaming, and tools are covered by deterministic mocks.
+- Provider prefixes are stripped exactly without damaging nested model IDs.
+- All relevant builds, typechecks, tests, web build, and diff checks pass.
+- No credential or unrelated generated artifact appears in the diff.
+
+## Design decisions
+
+- Dedicated thin integration over a duplicated executor: the upstream wire protocol is already OpenAI-compatible.
+- API-key API only: Coding Plan is a separate product with separate scope and authentication.
+- Dynamic model discovery over static models: avoids stale model IDs.
+- Explicit loader branch: guarantees the official Neosantara default URL and provider identity.
+- No database migration: current provider persistence is sufficient.

--- a/packages/executors/src/openai.ts
+++ b/packages/executors/src/openai.ts
@@ -1,6 +1,11 @@
 import type { AIProvider, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ModelListResponse, ModelObject } from "@srouter/types";
 import { parseDataLine, streamLines } from "./base.js";
 
+function stripProviderPrefix(model: string): string {
+    const slash = model.indexOf("/");
+    return slash >= 0 ? model.slice(slash + 1) : model;
+}
+
 export interface OpenAIExecutorOptions {
     id?: string;
     name?: string;
@@ -73,7 +78,7 @@ export class OpenAIExecutor implements AIProvider {
     }
 
     async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
-        let targetModel = req.model.includes("/") ? (req.model.split("/")[1] ?? req.model) : req.model;
+        const targetModel = stripProviderPrefix(req.model);
 
         const res = await fetch(`${this.baseUrl}/chat/completions`, {
             method: "POST",
@@ -90,7 +95,7 @@ export class OpenAIExecutor implements AIProvider {
     }
 
     async *chatCompletionStream(req: ChatCompletionRequest): AsyncGenerator<ChatCompletionChunk, void, void> {
-        let targetModel = req.model.includes("/") ? (req.model.split("/")[1] ?? req.model) : req.model;
+        const targetModel = stripProviderPrefix(req.model);
 
         const res = await fetch(`${this.baseUrl}/chat/completions`, {
             method: "POST",

--- a/packages/executors/tests/neosantara.test.ts
+++ b/packages/executors/tests/neosantara.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import type { ChatCompletionRequest } from "@srouter/types";
+import { OpenAIExecutor } from "../src/openai.js";
+
+const originalFetch = globalThis.fetch;
+const fixtureKey = "fixture-key-not-a-secret";
+
+function executor(): OpenAIExecutor {
+    return new OpenAIExecutor({
+        id: "neosantara",
+        name: "Neosantara",
+        baseUrl: "https://api.neosantara.xyz/v1",
+        accessToken: fixtureKey,
+    });
+}
+
+function request(model: string): ChatCompletionRequest {
+    return { model, messages: [{ role: "user", content: "hello" }] };
+}
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test("Neosantara lists namespaced live models with bearer auth", async () => {
+    let url = "";
+    let authorized = false;
+    globalThis.fetch = async (input, init) => {
+        url = String(input);
+        const auth = new Headers(init?.headers).get("authorization") ?? "";
+        authorized = auth.startsWith("Bearer ") && auth.endsWith(fixtureKey);
+        return Response.json({ data: [{ id: "garda-core", object: "model", owned_by: "neosantara" }] });
+    };
+
+    const models = await executor().listModels();
+    assert.equal(url, "https://api.neosantara.xyz/v1/models");
+    assert.equal(authorized, true);
+    assert.deepEqual(models, [{ id: "neosantara/garda-core", object: "model", owned_by: "neosantara" }]);
+});
+
+test("Neosantara chat sends bare model and preserves nested upstream IDs", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return Response.json({ id: "chat", object: "chat.completion", created: 1, model: "test", choices: [] });
+    };
+
+    await executor().chatCompletion(request("neosantara/garda-core"));
+    await executor().chatCompletion(request("neosantara/provider/model-with-slash"));
+
+    assert.equal(bodies[0]?.model, "garda-core");
+    assert.equal(bodies[0]?.stream, false);
+    assert.equal(bodies[1]?.model, "provider/model-with-slash");
+});
+
+test("Neosantara streaming preserves tools and yields tool-call deltas", async () => {
+    let body: Record<string, unknown> | undefined;
+    const chunk = {
+        id: "chunk",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "garda-core",
+        choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "weather", arguments: "{}" } }] }, finish_reason: null }],
+    };
+    globalThis.fetch = async (_input, init) => {
+        body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`));
+                controller.close();
+            },
+        });
+        return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+    };
+
+    const tools = [{ type: "function" as const, function: { name: "weather", description: "Weather", parameters: { type: "object", properties: {} } } }];
+    const output = [];
+    for await (const item of executor().chatCompletionStream({ ...request("neosantara/garda-core"), tools })) output.push(item);
+
+    assert.equal(body?.stream, true);
+    assert.deepEqual(body?.tools, tools);
+    assert.deepEqual(output, [chunk]);
+});
+
+test("Neosantara upstream errors do not expose credentials", async () => {
+    globalThis.fetch = async () => new Response("upstream unavailable", { status: 503 });
+    await assert.rejects(
+        executor().chatCompletion(request("neosantara/garda-core")),
+        (error: Error) => error.message.includes("503") && error.message.includes("upstream unavailable") && !error.message.includes(fixtureKey),
+    );
+});

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -10,6 +10,7 @@ const PROVIDER_ALIASES: Record<string, string> = {
     commandcode: "commandcode",
     gemini: "gemini",
     vertex: "vertex",
+    neosantara: "neosantara",
 };
 
 export function getProviderAlias(providerId: string): string {
@@ -46,6 +47,19 @@ export const DEFAULT_CATALOG: ProviderDefinition[] = [
             { id: "gpt-5.6-luna", object: "model", owned_by: "kiro" },
             { id: "simple-task", object: "model", owned_by: "kiro" },
         ],
+    },
+    {
+        id: "neosantara",
+        name: "Neosantara",
+        category: "api_key",
+        protocol: "openai",
+        description: "Neosantara unified OpenAI-compatible AI gateway.",
+        icon: "🌏",
+        defaultBaseUrl: "https://api.neosantara.xyz/v1",
+        requiresApiKey: true,
+        supportsCustomUrl: true,
+        status: { state: "disconnected", message: "Neosantara API key missing" },
+        models: [],
     },
     {
         id: "openai_codex",

--- a/packages/providers/tests/registry.test.ts
+++ b/packages/providers/tests/registry.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { ProviderRegistry } from "../src/registry.js";
+import { DEFAULT_CATALOG, getProviderAlias, ProviderRegistry } from "../src/registry.js";
 import type { AIProvider } from "@srouter/types";
 
 const provider: AIProvider = {
@@ -19,4 +19,22 @@ test("unregisterProvider removes a deleted runtime connection", () => {
     assert.equal(registry.unregisterProvider(provider.id), true);
     assert.equal(registry.getProvider(provider.id), undefined);
     assert.equal(registry.unregisterProvider(provider.id), false);
+});
+
+test("Neosantara has the API-key OpenAI catalog contract", () => {
+    const item = DEFAULT_CATALOG.find((entry) => entry.id === "neosantara");
+    assert.ok(item);
+    assert.equal(item.name, "Neosantara");
+    assert.equal(item.category, "api_key");
+    assert.equal(item.protocol, "openai");
+    assert.equal(item.defaultBaseUrl, "https://api.neosantara.xyz/v1");
+    assert.equal(item.requiresApiKey, true);
+    assert.equal(item.supportsCustomUrl, true);
+    assert.equal(item.status.state, "disconnected");
+    assert.deepEqual(item.models, []);
+});
+
+test("Neosantara uses its own model prefix alias", () => {
+    assert.equal(getProviderAlias("neosantara"), "neosantara");
+    assert.equal(getProviderAlias("neosantara_123"), "neosantara");
 });


### PR DESCRIPTION
## Summary
- add Neosantara as a first-class API-key OpenAI-compatible provider
- support environment and saved connections with the official `https://api.neosantara.xyz/v1` default
- preserve nested upstream model IDs while supporting live models, JSON chat, SSE streaming, and tool calls
- add deterministic provider, loader, authentication, streaming, tools, and error-handling coverage

## Design
- [Approved design spec](https://github.com/seaavey/SRouter/blob/feat/neosantara-provider/docs/superpowers/specs/2026-08-12-neosantara-provider-design.md)
- [Implementation plan](https://github.com/seaavey/SRouter/blob/feat/neosantara-provider/docs/superpowers/plans/2026-08-12-neosantara-provider.md)
- [Official Neosantara documentation](https://docs.neosantara.xyz/)

## Validation
- `CI=true pnpm install --frozen-lockfile`
- dependency-order builds: types, db, providers, pricing, translator, executors
- `pnpm --filter api exec tsc --noEmit`
- provider tests: 3/3
- executor tests: 11/11
- API tests: 6/6
- web production build
- `git diff --check origin/main...HEAD`
- security/scope audit: no credentials, generated artifacts, or conflict markers

## Scope
This PR covers the API-key OpenAI-compatible Models and Chat Completions paths, including SSE and tools. Responses API, Coding Plan, embeddings, and media endpoints are intentionally excluded.

This PR is ready for review and is not authorized for merge yet.