### PR TITLE
feat(api): add Anthropic Messages API support for Claude Code compatibility

### DIFF
--- a/apps/api/src/controllers/messages.controller.ts
+++ b/apps/api/src/controllers/messages.controller.ts
@@ -1,0 +1,97 @@
+import type { Context } from "hono";
+import { streamSSE } from "hono/streaming";
+import {
+    anthropicToOpenAIRequest,
+    openAIToAnthropicResponse,
+    openAIToAnthropicStream,
+} from "@srouter/translator";
+import type { AnthropicMessageRequest } from "@srouter/types";
+import { ChatLogic } from "@/logic/chat.logic.js";
+
+export class MessagesController {
+    public static async createMessage(c: Context): Promise<Response> {
+        const startTime = Date.now();
+        let body: AnthropicMessageRequest;
+        try {
+            body = await c.req.json<AnthropicMessageRequest>();
+        } catch {
+            return c.json(
+                {
+                    type: "error",
+                    error: {
+                        type: "invalid_request_error",
+                        message: "Invalid JSON request body",
+                    },
+                },
+                400,
+            );
+        }
+
+        if (!body.model) {
+            return c.json(
+                {
+                    type: "error",
+                    error: {
+                        type: "invalid_request_error",
+                        message: "Missing required field 'model'",
+                    },
+                },
+                400,
+            );
+        }
+
+        const openAIReq = anthropicToOpenAIRequest(body);
+
+        // 1. Streaming response (Anthropic SSE)
+        if (body.stream) {
+            c.header("Content-Type", "text/event-stream");
+            c.header("Cache-Control", "no-cache");
+            c.header("Connection", "keep-alive");
+
+            return streamSSE(c, async (stream) => {
+                try {
+                    const chunkGenerator = ChatLogic.processStreamingCompletion(openAIReq, startTime);
+                    const anthropicStream = openAIToAnthropicStream(chunkGenerator, body.model);
+
+                    for await (const event of anthropicStream) {
+                        await stream.writeSSE({
+                            event: event.type,
+                            data: JSON.stringify(event),
+                        });
+                    }
+                } catch (error) {
+                    const errorMessage = error instanceof Error ? error.message : String(error);
+                    await stream.writeSSE({
+                        event: "error",
+                        data: JSON.stringify({
+                            type: "error",
+                            error: {
+                                type: "api_error",
+                                message: errorMessage || "Error occurred during streaming",
+                            },
+                        }),
+                    });
+                }
+            });
+        }
+
+        // 2. Non-streaming response (JSON)
+        try {
+            const openAIRes = await ChatLogic.processNonStreamingCompletion(openAIReq, startTime);
+            const anthropicRes = openAIToAnthropicResponse(openAIRes, body.model);
+            return c.json(anthropicRes);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return c.json(
+                {
+                    type: "error",
+                    error: {
+                        type: "api_error",
+                        message: errorMessage || "Internal server error",
+                    },
+                },
+                500,
+            );
+        }
+    }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import {
 import { chatRoute } from "@/routes/v1/chat.js";
 import { keysRoute } from "@/routes/v1/keys.js";
 import { logsRoute } from "@/routes/v1/logs.js";
+import { messagesRoute } from "@/routes/v1/messages.js";
 import { modelsRoute } from "@/routes/v1/models.js";
 import { providersRoute } from "@/routes/v1/providers.js";
 import { quotaRoute } from "@/routes/v1/quota.js";
@@ -47,12 +48,16 @@ app.get("/health", (c) => {
 // Mount OpenAI & Anthropic v1 API routes
 app.route("/v1", modelsRoute);
 app.route("/v1", chatRoute);
+app.route("/v1", messagesRoute);
 app.route("/v1", providersRoute);
 app.route("/v1", keysRoute);
 app.route("/v1", logsRoute);
 app.route("/v1", authRoute);
 app.route("/v1", quotaRoute);
 app.route("/v1", settingsRoute);
+
+// Also mount root-level /messages for Anthropic clients sending to base URL directly
+app.route("/", messagesRoute);
 
 const port = Number(process.env.PORT) || 3000;
 
@@ -66,12 +71,16 @@ serve(
     },
 );
 
-// Secondary listener on Port 1455 for OAuth callbacks
+// Secondary listener on Port 1455 for OAuth callbacks and local Anthropic proxy
 const oauthApp = new Hono();
 oauthApp.get("/auth/callback", (c) => handleOAuthCallback(c));
 oauthApp.post("/auth/callback", (c) => handleOAuthCallback(c));
 oauthApp.get("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
 oauthApp.post("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
+oauthApp.route("/v1", messagesRoute);
+oauthApp.route("/", messagesRoute);
+oauthApp.route("/v1", chatRoute);
+oauthApp.route("/v1", modelsRoute);
 
 const oauthPort = Number(process.env.OAUTH_PORT) || 1455;
 

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -5,6 +5,7 @@ import { err } from "@/utils/response.js";
 export async function apiKeyAuth(c: Context, next: Next) {
     const isRequired = getRequireApiKeyDB();
     const authHeader = c.req.header("Authorization") || c.req.header("authorization");
+    const xApiKey = c.req.header("x-api-key") || c.req.header("X-Api-Key") || c.req.header("X-API-KEY");
     const clientHeader = c.req.header("X-SRouter-Client") || c.req.header("x-srouter-client");
 
     // Allow internal web playground / dashboard requests
@@ -13,7 +14,9 @@ export async function apiKeyAuth(c: Context, next: Next) {
     }
 
     let bearerKey: string | null = null;
-    if (authHeader && authHeader.startsWith("Bearer ")) {
+    if (xApiKey) {
+        bearerKey = xApiKey.trim();
+    } else if (authHeader && authHeader.startsWith("Bearer ")) {
         bearerKey = authHeader.slice(7).trim();
     } else if (authHeader) {
         bearerKey = authHeader.trim();

--- a/apps/api/src/routes/v1/messages.ts
+++ b/apps/api/src/routes/v1/messages.ts
@@ -1,0 +1,8 @@
+import { Hono } from "hono";
+import { MessagesController } from "@/controllers/messages.controller.js";
+import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
+
+export const messagesRoute = new Hono();
+
+// POST /v1/messages (and /messages) with apiKeyAuth
+messagesRoute.post("/messages", apiKeyAuth, MessagesController.createMessage);

--- a/apps/api/tests/messages.test.ts
+++ b/apps/api/tests/messages.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { Hono } from "hono";
+import {
+    createAPIKeyDB,
+    deleteAPIKeyDB,
+    deleteProviderDB,
+    setRequireApiKeyDB,
+    upsertProviderDB,
+} from "@srouter/db";
+import type { AIProvider, ChatCompletionRequest, ChatCompletionResponse, ProviderConfig } from "@srouter/types";
+import { messagesRoute } from "../src/routes/v1/messages.js";
+
+const app = new Hono();
+app.route("/v1", messagesRoute);
+app.route("/", messagesRoute);
+
+const createdKeyIds: string[] = [];
+const createdProviderIds: string[] = [];
+
+afterEach(async () => {
+    setRequireApiKeyDB(false);
+    for (const id of createdKeyIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+    const { registry } = await import("../src/services/registry.js");
+    for (const id of createdProviderIds.splice(0)) {
+        deleteProviderDB(id);
+        registry.unregisterProvider(id);
+    }
+});
+
+test("POST /v1/messages returns Anthropic message response for non-streaming request", async () => {
+    const { registry } = await import("../src/services/registry.js");
+    const mockProvider: AIProvider = {
+        id: "anthropic_test",
+        name: "Mock Anthropic Provider",
+        listModels: async () => [{ id: "claude-3-7-sonnet-20250219", object: "model" }],
+        chatCompletion: async (req: ChatCompletionRequest): Promise<ChatCompletionResponse> => {
+            return {
+                id: "chatcmpl-mock-123",
+                object: "chat.completion",
+                created: 1786759000,
+                model: req.model,
+                choices: [
+                    {
+                        index: 0,
+                        message: {
+                            role: "assistant",
+                            content: "Hello from Claude via SRouter!",
+                        },
+                        finish_reason: "stop",
+                    },
+                ],
+                usage: {
+                    prompt_tokens: 15,
+                    completion_tokens: 8,
+                    total_tokens: 23,
+                },
+            };
+        },
+        chatCompletionStream: async function* () {},
+    };
+    registry.registerProvider(mockProvider);
+    createdProviderIds.push(mockProvider.id);
+
+    const res = await app.request("/v1/messages", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+            model: "claude-3-7-sonnet-20250219",
+            messages: [{ role: "user", content: "Hello" }],
+            max_tokens: 1024,
+            stream: false,
+        }),
+    });
+
+    assert.equal(res.status, 200);
+    const data = (await res.json()) as {
+        id: string;
+        type: string;
+        role: string;
+        content: Array<{ type: string; text: string }>;
+        model: string;
+        stop_reason: string;
+        usage: { input_tokens: number; output_tokens: number };
+    };
+
+    assert.equal(data.type, "message");
+    assert.equal(data.role, "assistant");
+    assert.equal(data.model, "claude-3-7-sonnet-20250219");
+    assert.equal(data.stop_reason, "end_turn");
+    assert.equal(data.content[0]?.type, "text");
+    assert.equal(data.content[0]?.text, "Hello from Claude via SRouter!");
+    assert.equal(data.usage.input_tokens, 15);
+    assert.equal(data.usage.output_tokens, 8);
+});
+
+test("POST /v1/messages authenticates with x-api-key header when require_api_key is true", async () => {
+    setRequireApiKeyDB(true);
+    const keyRecord = createAPIKeyDB({ name: "Claude Code Key" });
+    createdKeyIds.push(keyRecord.id);
+
+    const { registry } = await import("../src/services/registry.js");
+    const mockProvider: AIProvider = {
+        id: "mock_auth_provider",
+        name: "Mock Auth Provider",
+        listModels: async () => [{ id: "mock-auth-provider/test-model", object: "model" }],
+        chatCompletion: async (req: ChatCompletionRequest): Promise<ChatCompletionResponse> => {
+            return {
+                id: "chatcmpl-mock-456",
+                object: "chat.completion",
+                created: 1786759000,
+                model: req.model,
+                choices: [
+                    {
+                        index: 0,
+                        message: {
+                            role: "assistant",
+                            content: "Authenticated successfully with x-api-key!",
+                        },
+                        finish_reason: "stop",
+                    },
+                ],
+                usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+            };
+        },
+        chatCompletionStream: async function* () {},
+    };
+    registry.registerProvider(mockProvider);
+    createdProviderIds.push(mockProvider.id);
+
+    // 1. Request with invalid key -> 401
+    const resInvalid = await app.request("/v1/messages", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "x-api-key": "invalid-key-token",
+        },
+        body: JSON.stringify({
+            model: "mock-auth-provider/test-model",
+            messages: [{ role: "user", content: "Test" }],
+            max_tokens: 512,
+        }),
+    });
+    assert.equal(resInvalid.status, 401);
+
+    // 2. Request with valid x-api-key -> 200
+    const resValid = await app.request("/v1/messages", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "x-api-key": keyRecord.key,
+        },
+        body: JSON.stringify({
+            model: "mock-auth-provider/test-model",
+            messages: [{ role: "user", content: "Test" }],
+            max_tokens: 512,
+        }),
+    });
+    assert.equal(resValid.status, 200);
+    const data = (await resValid.json()) as { content: Array<{ text: string }> };
+    assert.equal(data.content[0]?.text, "Authenticated successfully with x-api-key!");
+});
+
+test("POST /v1/messages streams Anthropic SSE events", async () => {
+    const { registry } = await import("../src/services/registry.js");
+    const mockProvider: AIProvider = {
+        id: "stream_provider_test",
+        name: "Mock Stream Provider",
+        listModels: async () => [{ id: "mock-model", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            yield {
+                id: "chunk-1",
+                object: "chat.completion.chunk",
+                created: 1786759000,
+                model: "mock-model",
+                choices: [{ index: 0, delta: { role: "assistant", content: "Chunk 1 " }, finish_reason: null }],
+            };
+            yield {
+                id: "chunk-2",
+                object: "chat.completion.chunk",
+                created: 1786759000,
+                model: "mock-model",
+                choices: [{ index: 0, delta: { content: "Chunk 2" }, finish_reason: "stop" }],
+            };
+        },
+    };
+    registry.registerProvider(mockProvider);
+    createdProviderIds.push(mockProvider.id);
+
+    const res = await app.request("/v1/messages", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model: "mock-model",
+            messages: [{ role: "user", content: "Stream test" }],
+            max_tokens: 256,
+            stream: true,
+        }),
+    });
+
+    assert.equal(res.status, 200);
+    const sseText = await res.text();
+    assert.ok(sseText.includes("event: message_start"));
+    assert.ok(sseText.includes("event: content_block_start"));
+    assert.ok(sseText.includes("event: content_block_delta"));
+    assert.ok(sseText.includes("event: message_delta"));
+    assert.ok(sseText.includes("event: message_stop"));
+    assert.ok(sseText.includes("Chunk 1 "));
+    assert.ok(sseText.includes("Chunk 2"));
+});

--- a/packages/translator/package.json
+++ b/packages/translator/package.json
@@ -12,7 +12,8 @@
     },
     "scripts": {
         "build": "tsc",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "test": "tsx --test tests/**/*.test.ts"
     },
     "dependencies": {
         "@srouter/constants": "workspace:*",
@@ -21,6 +22,7 @@
     },
     "devDependencies": {
         "@types/node": "^26.1.1",
+        "tsx": "^4.19.3",
         "typescript": "^5.0.0"
     }
 }

--- a/packages/translator/src/anthropic.ts
+++ b/packages/translator/src/anthropic.ts
@@ -1,0 +1,443 @@
+import { randomUUID } from "node:crypto";
+import type {
+    AnthropicContentBlock,
+    AnthropicMessage,
+    AnthropicMessageRequest,
+    AnthropicMessageResponse,
+    AnthropicStreamEvent,
+    AnthropicTool,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    ChatMessageContentPart,
+    FinishReason,
+    ToolCall,
+    ToolDefinition,
+} from "@srouter/types";
+
+/**
+ * Converts Anthropic format Messages API request to OpenAI format ChatCompletionRequest.
+ */
+export function anthropicToOpenAIRequest(
+    req: AnthropicMessageRequest,
+): ChatCompletionRequest {
+    const messages: ChatMessage[] = [];
+
+    // 1. Process system prompt
+    if (req.system) {
+        if (typeof req.system === "string") {
+            messages.push({ role: "system", content: req.system });
+        } else if (Array.isArray(req.system)) {
+            const systemText = req.system
+                .map((b) => (b.type === "text" ? b.text || "" : ""))
+                .filter(Boolean)
+                .join("\n\n");
+            if (systemText) {
+                messages.push({ role: "system", content: systemText });
+            }
+        }
+    }
+
+    // 2. Process conversation messages
+    for (const msg of req.messages || []) {
+        if (typeof msg.content === "string") {
+            messages.push({
+                role: msg.role,
+                content: msg.content,
+            });
+            continue;
+        }
+
+        if (!Array.isArray(msg.content)) continue;
+
+        // Group content parts and extract tool calls / tool results
+        const textAndImageParts: ChatMessageContentPart[] = [];
+        const toolCalls: ToolCall[] = [];
+        const toolResults: AnthropicContentBlock[] = [];
+
+        for (const block of msg.content) {
+            if (block.type === "text") {
+                if (block.text) {
+                    textAndImageParts.push({ type: "text", text: block.text });
+                }
+            } else if (block.type === "image" && block.source) {
+                textAndImageParts.push({
+                    type: "image_url",
+                    image_url: {
+                        url: `data:${block.source.media_type};base64,${block.source.data}`,
+                    },
+                });
+            } else if (block.type === "tool_use") {
+                toolCalls.push({
+                    id: block.id || `call_${randomUUID().slice(0, 8)}`,
+                    type: "function",
+                    function: {
+                        name: block.name || "",
+                        arguments: typeof block.input === "string" ? block.input : JSON.stringify(block.input || {}),
+                    },
+                });
+            } else if (block.type === "tool_result") {
+                toolResults.push(block);
+            }
+        }
+
+        // Assistant with tool calls or text
+        if (msg.role === "assistant") {
+            let contentStr: string | undefined = undefined;
+            if (textAndImageParts.length === 1 && textAndImageParts[0]?.type === "text") {
+                contentStr = textAndImageParts[0].text;
+            } else if (textAndImageParts.length > 1) {
+                contentStr = textAndImageParts.map((p) => (p.type === "text" ? p.text : "")).join("\n");
+            }
+
+            messages.push({
+                role: "assistant",
+                content: contentStr ?? (toolCalls.length > 0 ? null : ""),
+                tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+            });
+        } else if (msg.role === "user") {
+            // Check if this user message contains tool results
+            if (toolResults.length > 0) {
+                for (const tr of toolResults) {
+                    let resultText = "";
+                    if (typeof tr.content === "string") {
+                        resultText = tr.content;
+                    } else if (Array.isArray(tr.content)) {
+                        resultText = tr.content
+                            .map((b) => (b.type === "text" ? b.text || "" : JSON.stringify(b)))
+                            .join("\n");
+                    }
+
+                    messages.push({
+                        role: "tool",
+                        tool_call_id: tr.tool_use_id || "",
+                        content: resultText,
+                    });
+                }
+            }
+
+            // Normal user message content
+            if (textAndImageParts.length === 1 && textAndImageParts[0]?.type === "text") {
+                messages.push({
+                    role: "user",
+                    content: textAndImageParts[0].text || "",
+                });
+            } else if (textAndImageParts.length > 0) {
+                messages.push({
+                    role: "user",
+                    content: textAndImageParts,
+                });
+            }
+        }
+    }
+
+    // 3. Process tool definitions
+    let tools: ToolDefinition[] | undefined = undefined;
+    if (Array.isArray(req.tools) && req.tools.length > 0) {
+        tools = req.tools.map((t) => {
+            const antTool = t as AnthropicTool;
+            if ("input_schema" in antTool) {
+                const schema = antTool.input_schema || {};
+                return {
+                    type: "function",
+                    function: {
+                        name: antTool.name,
+                        description: antTool.description,
+                        parameters: {
+                            type: "object",
+                            ...(typeof schema === "object" ? schema : {}),
+                        },
+                    },
+                } as ToolDefinition;
+            }
+            return t as ToolDefinition;
+        });
+    }
+
+    // 4. Process tool_choice
+    let tool_choice: ChatCompletionRequest["tool_choice"] = undefined;
+    if (req.tool_choice) {
+        if (req.tool_choice.type === "auto") {
+            tool_choice = "auto";
+        } else if (req.tool_choice.type === "any") {
+            tool_choice = "required";
+        } else if (req.tool_choice.type === "tool" && req.tool_choice.name) {
+            tool_choice = {
+                type: "function",
+                function: { name: req.tool_choice.name },
+            };
+        }
+    }
+
+    return {
+        model: req.model,
+        messages,
+        max_tokens: req.max_tokens,
+        temperature: req.temperature,
+        top_p: req.top_p,
+        stop: req.stop_sequences,
+        tools,
+        tool_choice,
+        stream: req.stream ?? false,
+    };
+}
+
+function mapFinishReason(
+    finishReason?: FinishReason | null,
+): "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" {
+    if (finishReason === "tool_calls" || (finishReason as string) === "function_call") {
+        return "tool_use";
+    }
+    if (finishReason === "length") {
+        return "max_tokens";
+    }
+    if (finishReason === "stop") {
+        return "end_turn";
+    }
+    return "end_turn";
+}
+
+/**
+ * Converts standard OpenAI ChatCompletionResponse to Anthropic MessageResponse.
+ */
+export function openAIToAnthropicResponse(
+    res: ChatCompletionResponse,
+    originalModel: string,
+): AnthropicMessageResponse {
+    const choice = res.choices?.[0];
+    const contentBlocks: AnthropicContentBlock[] = [];
+
+    if (choice?.message) {
+        const msg = choice.message;
+        const reasoning = (msg as { reasoning_content?: string }).reasoning_content;
+
+        // Reasoning/thinking content if present
+        if (reasoning) {
+            contentBlocks.push({
+                type: "thinking",
+                thinking: reasoning,
+            });
+        }
+
+        // Text content
+        if (typeof msg.content === "string") {
+            contentBlocks.push({
+                type: "text",
+                text: msg.content,
+            });
+        } else if (Array.isArray(msg.content)) {
+            const text = msg.content.map((p) => (p.type === "text" ? p.text : "")).join("\n");
+            if (text) {
+                contentBlocks.push({
+                    type: "text",
+                    text,
+                });
+            }
+        }
+
+        // Tool calls
+        if (Array.isArray(msg.tool_calls)) {
+            for (const tc of msg.tool_calls) {
+                let parsedInput: Record<string, unknown> = {};
+                try {
+                    parsedInput = JSON.parse(tc.function.arguments || "{}") as Record<string, unknown>;
+                } catch {
+                    parsedInput = { raw: tc.function.arguments };
+                }
+                contentBlocks.push({
+                    type: "tool_use",
+                    id: tc.id,
+                    name: tc.function.name,
+                    input: parsedInput,
+                });
+            }
+        }
+    }
+
+    return {
+        id: res.id ? `msg_${res.id.replace(/^chatcmpl-/, "")}` : `msg_${randomUUID()}`,
+        type: "message",
+        role: "assistant",
+        content: contentBlocks,
+        model: originalModel,
+        stop_reason: mapFinishReason(choice?.finish_reason),
+        stop_sequence: null,
+        usage: {
+            input_tokens: res.usage?.prompt_tokens ?? 0,
+            output_tokens: res.usage?.completion_tokens ?? 0,
+        },
+    };
+}
+
+/**
+ * Converts OpenAI streaming chunks to Anthropic SSE event stream.
+ */
+export async function* openAIToAnthropicStream(
+    stream: AsyncGenerator<ChatCompletionChunk>,
+    originalModel: string,
+): AsyncGenerator<AnthropicStreamEvent> {
+    const messageId = `msg_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
+    let hasStarted = false;
+    let currentBlockIndex = -1;
+    let currentBlockType: "text" | "thinking" | "tool_use" | null = null;
+    let finishReason: FinishReason | null = null;
+    let outputTokensCount = 0;
+
+    // Track active tool calls by index from OpenAI chunks
+    const toolMap = new Map<number, { anthropicIndex: number; id: string; name: string }>();
+
+    for await (const chunk of stream) {
+        if (!hasStarted) {
+            hasStarted = true;
+            yield {
+                type: "message_start",
+                message: {
+                    id: messageId,
+                    type: "message",
+                    role: "assistant",
+                    model: originalModel,
+                    content: [],
+                    stop_reason: null,
+                    stop_sequence: null,
+                    usage: {
+                        input_tokens: chunk.usage?.prompt_tokens ?? 0,
+                        output_tokens: 1,
+                    },
+                },
+            };
+        }
+
+        const choice = chunk.choices?.[0];
+        if (!choice) continue;
+
+        if (choice.finish_reason) {
+            finishReason = choice.finish_reason;
+        }
+
+        const delta = choice.delta;
+        if (!delta) continue;
+
+        const reasoning = (delta as { reasoning_content?: string }).reasoning_content;
+
+        // 1. Handle reasoning / thinking delta
+        if (reasoning) {
+            if (currentBlockType !== "thinking") {
+                if (currentBlockType !== null) {
+                    yield { type: "content_block_stop", index: currentBlockIndex };
+                }
+                currentBlockIndex++;
+                currentBlockType = "thinking";
+                yield {
+                    type: "content_block_start",
+                    index: currentBlockIndex,
+                    content_block: { type: "thinking", thinking: "" },
+                };
+            }
+            outputTokensCount++;
+            yield {
+                type: "content_block_delta",
+                index: currentBlockIndex,
+                delta: {
+                    type: "thinking_delta",
+                    thinking: reasoning,
+                },
+            };
+        }
+
+        // 2. Handle text content delta
+        if (delta.content) {
+            if (currentBlockType !== "text") {
+                if (currentBlockType !== null) {
+                    yield { type: "content_block_stop", index: currentBlockIndex };
+                }
+                currentBlockIndex++;
+                currentBlockType = "text";
+                yield {
+                    type: "content_block_start",
+                    index: currentBlockIndex,
+                    content_block: { type: "text", text: "" },
+                };
+            }
+            outputTokensCount++;
+            yield {
+                type: "content_block_delta",
+                index: currentBlockIndex,
+                delta: {
+                    type: "text_delta",
+                    text: delta.content,
+                },
+            };
+        }
+
+        // 3. Handle tool calls delta
+        if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+                const chunkIndex = tc.index ?? 0;
+                let existingTool = toolMap.get(chunkIndex);
+
+                if (!existingTool && (tc.id || tc.function?.name)) {
+                    if (currentBlockType !== null) {
+                        yield { type: "content_block_stop", index: currentBlockIndex };
+                    }
+                    currentBlockIndex++;
+                    currentBlockType = "tool_use";
+                    existingTool = {
+                        anthropicIndex: currentBlockIndex,
+                        id: tc.id || `toolu_${randomUUID().replace(/-/g, "").slice(0, 24)}`,
+                        name: tc.function?.name || "",
+                    };
+                    toolMap.set(chunkIndex, existingTool);
+
+                    yield {
+                        type: "content_block_start",
+                        index: currentBlockIndex,
+                        content_block: {
+                            type: "tool_use",
+                            id: existingTool.id,
+                            name: existingTool.name,
+                            input: {},
+                        },
+                    };
+                }
+
+                if (existingTool && tc.function?.arguments) {
+                    outputTokensCount++;
+                    yield {
+                        type: "content_block_delta",
+                        index: existingTool.anthropicIndex,
+                        delta: {
+                            type: "input_json_delta",
+                            partial_json: tc.function.arguments,
+                        },
+                    };
+                }
+            }
+        }
+    }
+
+    // Close any open content block
+    if (currentBlockType !== null) {
+        yield {
+            type: "content_block_stop",
+            index: currentBlockIndex,
+        };
+    }
+
+    // Message delta (stop reason)
+    yield {
+        type: "message_delta",
+        delta: {
+            stop_reason: mapFinishReason(finishReason),
+            stop_sequence: null,
+        },
+        usage: {
+            output_tokens: Math.max(outputTokensCount, 1),
+        },
+    };
+
+    // Message stop
+    yield {
+        type: "message_stop",
+    };
+}

--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./adapter.js";
+export * from "./anthropic.js";
 export * from "./commandcode.js";
 export * from "./gemini.js";
 export * from "./responses.js";

--- a/packages/translator/tests/anthropic.test.ts
+++ b/packages/translator/tests/anthropic.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+    anthropicToOpenAIRequest,
+    openAIToAnthropicResponse,
+    openAIToAnthropicStream,
+} from "../src/anthropic.js";
+import type {
+    AnthropicMessageRequest,
+    ChatCompletionChunk,
+    ChatCompletionResponse,
+} from "@srouter/types";
+
+test("anthropicToOpenAIRequest maps system string, messages, and tools", () => {
+    const req: AnthropicMessageRequest = {
+        model: "claude-3-7-sonnet-20250219",
+        system: "You are a helpful coding assistant.",
+        max_tokens: 4096,
+        messages: [
+            {
+                role: "user",
+                content: "Run test suite",
+            },
+            {
+                role: "assistant",
+                content: [
+                    {
+                        type: "tool_use",
+                        id: "call_123",
+                        name: "bash",
+                        input: { command: "pnpm test" },
+                    },
+                ],
+            },
+            {
+                role: "user",
+                content: [
+                    {
+                        type: "tool_result",
+                        tool_use_id: "call_123",
+                        content: "Tests passed: 20",
+                    },
+                ],
+            },
+        ],
+        tools: [
+            {
+                name: "bash",
+                description: "Execute a bash command",
+                input_schema: {
+                    type: "object",
+                    properties: { command: { type: "string" } },
+                    required: ["command"],
+                },
+            },
+        ],
+    };
+
+    const openAIReq = anthropicToOpenAIRequest(req);
+    assert.equal(openAIReq.model, "claude-3-7-sonnet-20250219");
+    assert.equal(openAIReq.max_tokens, 4096);
+    assert.equal(openAIReq.messages.length, 4);
+
+    // System message
+    assert.equal(openAIReq.messages[0]?.role, "system");
+    assert.equal(openAIReq.messages[0]?.content, "You are a helpful coding assistant.");
+
+    // User message
+    assert.equal(openAIReq.messages[1]?.role, "user");
+    assert.equal(openAIReq.messages[1]?.content, "Run test suite");
+
+    // Assistant tool_calls
+    assert.equal(openAIReq.messages[2]?.role, "assistant");
+    assert.equal(openAIReq.messages[2]?.tool_calls?.length, 1);
+    assert.equal(openAIReq.messages[2]?.tool_calls?.[0]?.id, "call_123");
+    assert.equal(openAIReq.messages[2]?.tool_calls?.[0]?.function.name, "bash");
+    assert.equal(openAIReq.messages[2]?.tool_calls?.[0]?.function.arguments, '{"command":"pnpm test"}');
+
+    // Tool result
+    assert.equal(openAIReq.messages[3]?.role, "tool");
+    assert.equal(openAIReq.messages[3]?.tool_call_id, "call_123");
+    assert.equal(openAIReq.messages[3]?.content, "Tests passed: 20");
+
+    // Tools schema
+    assert.equal(openAIReq.tools?.length, 1);
+    assert.equal(openAIReq.tools?.[0]?.function.name, "bash");
+    assert.deepEqual(openAIReq.tools?.[0]?.function.parameters, {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+    });
+});
+
+test("openAIToAnthropicResponse maps OpenAI response to Anthropic message format", () => {
+    const openAIRes: ChatCompletionResponse = {
+        id: "chatcmpl-test-123",
+        object: "chat.completion",
+        created: 1786759000,
+        model: "claude-3-7-sonnet-20250219",
+        choices: [
+            {
+                index: 0,
+                message: {
+                    role: "assistant",
+                    content: "I ran the tests.",
+                    tool_calls: [
+                        {
+                            id: "call_abc",
+                            type: "function",
+                            function: {
+                                name: "read_file",
+                                arguments: '{"path":"main.ts"}',
+                            },
+                        },
+                    ],
+                },
+                finish_reason: "tool_calls",
+            },
+        ],
+        usage: {
+            prompt_tokens: 150,
+            completion_tokens: 45,
+            total_tokens: 195,
+        },
+    };
+
+    const antRes = openAIToAnthropicResponse(openAIRes, "claude-3-7-sonnet-20250219");
+    assert.equal(antRes.type, "message");
+    assert.equal(antRes.role, "assistant");
+    assert.equal(antRes.stop_reason, "tool_use");
+    assert.equal(antRes.content.length, 2);
+
+    assert.equal(antRes.content[0]?.type, "text");
+    assert.equal(antRes.content[0]?.text, "I ran the tests.");
+
+    assert.equal(antRes.content[1]?.type, "tool_use");
+    assert.equal(antRes.content[1]?.id, "call_abc");
+    assert.equal(antRes.content[1]?.name, "read_file");
+    assert.deepEqual(antRes.content[1]?.input, { path: "main.ts" });
+
+    assert.equal(antRes.usage.input_tokens, 150);
+    assert.equal(antRes.usage.output_tokens, 45);
+});
+
+test("openAIToAnthropicStream translates streaming chunks into Anthropic SSE events", async () => {
+    async function* mockStream(): AsyncGenerator<ChatCompletionChunk> {
+        yield {
+            id: "chatcmpl-stream-1",
+            object: "chat.completion.chunk",
+            created: 1786759000,
+            model: "claude-3-7-sonnet-20250219",
+            choices: [
+                {
+                    index: 0,
+                    delta: { role: "assistant", content: "Hello " },
+                    finish_reason: null,
+                },
+            ],
+            usage: { prompt_tokens: 20, completion_tokens: 0, total_tokens: 20 },
+        };
+        yield {
+            id: "chatcmpl-stream-1",
+            object: "chat.completion.chunk",
+            created: 1786759000,
+            model: "claude-3-7-sonnet-20250219",
+            choices: [
+                {
+                    index: 0,
+                    delta: { content: "world!" },
+                    finish_reason: null,
+                },
+            ],
+        };
+        yield {
+            id: "chatcmpl-stream-1",
+            object: "chat.completion.chunk",
+            created: 1786759000,
+            model: "claude-3-7-sonnet-20250219",
+            choices: [
+                {
+                    index: 0,
+                    delta: {},
+                    finish_reason: "stop",
+                },
+            ],
+        };
+    }
+
+    const events: unknown[] = [];
+    for await (const event of openAIToAnthropicStream(mockStream(), "claude-3-7-sonnet-20250219")) {
+        events.push(event);
+    }
+
+    assert.equal(events.length, 7);
+    assert.equal((events[0] as { type: string }).type, "message_start");
+    assert.equal((events[1] as { type: string }).type, "content_block_start");
+    assert.equal((events[2] as { type: string; delta: { text: string } }).delta.text, "Hello ");
+    assert.equal((events[3] as { type: string; delta: { text: string } }).delta.text, "world!");
+    assert.equal((events[4] as { type: string }).type, "content_block_stop");
+    assert.equal((events[5] as { type: string; delta: { stop_reason: string } }).delta.stop_reason, "end_turn");
+    assert.equal((events[6] as { type: string }).type, "message_stop");
+});

--- a/packages/types/src/anthropic.ts
+++ b/packages/types/src/anthropic.ts
@@ -1,8 +1,11 @@
 import type { ChatMessageRole, ToolDefinition } from "./openai.js";
 
 export interface AnthropicContentBlock {
-    type: "text" | "image" | "tool_use" | "tool_result";
+    type: "text" | "image" | "tool_use" | "tool_result" | "thinking" | "redacted_thinking";
     text?: string;
+    thinking?: string;
+    signature?: string;
+    data?: string;
     source?: {
         type: "base64";
         media_type: string;
@@ -10,9 +13,11 @@ export interface AnthropicContentBlock {
     };
     id?: string;
     name?: string;
-    input?: Record<string, string | number | boolean>;
+    input?: Record<string, unknown>;
     tool_use_id?: string;
     content?: string | AnthropicContentBlock[];
+    is_error?: boolean;
+    cache_control?: { type: "ephemeral" };
 }
 
 export interface AnthropicMessage {
@@ -20,18 +25,39 @@ export interface AnthropicMessage {
     content: string | AnthropicContentBlock[];
 }
 
+export interface AnthropicTool {
+    name: string;
+    description?: string;
+    input_schema: {
+        type?: "object" | string;
+        properties?: Record<string, unknown>;
+        required?: string[];
+        [key: string]: unknown;
+    };
+    cache_control?: { type: "ephemeral" };
+}
+
 export interface AnthropicMessageRequest {
     model: string;
     messages: AnthropicMessage[];
     system?: string | AnthropicContentBlock[];
     max_tokens: number;
-    metadata?: Record<string, string | number | boolean>;
+    metadata?: Record<string, unknown>;
     stop_sequences?: string[];
     stream?: boolean;
     temperature?: number;
     top_p?: number;
     top_k?: number;
-    tools?: ToolDefinition[];
+    tools?: AnthropicTool[] | ToolDefinition[];
+    tool_choice?: {
+        type: "auto" | "any" | "tool";
+        name?: string;
+        disable_parallel_tool_use?: boolean;
+    };
+    thinking?: {
+        type: "enabled" | "disabled";
+        budget_tokens?: number;
+    };
 }
 
 export interface AnthropicMessageResponse {
@@ -49,3 +75,59 @@ export interface AnthropicMessageResponse {
         cache_creation_input_tokens?: number;
     };
 }
+
+export type AnthropicStreamEvent =
+    | {
+          type: "message_start";
+          message: {
+              id: string;
+              type: "message";
+              role: "assistant";
+              model: string;
+              content: [];
+              stop_reason: null;
+              stop_sequence: null;
+              usage: {
+                  input_tokens: number;
+                  output_tokens: number;
+                  cache_creation_input_tokens?: number;
+                  cache_read_input_tokens?: number;
+              };
+          };
+      }
+    | {
+          type: "content_block_start";
+          index: number;
+          content_block:
+              | { type: "text"; text: string }
+              | { type: "thinking"; thinking: string }
+              | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+      }
+    | {
+          type: "content_block_delta";
+          index: number;
+          delta:
+              | { type: "text_delta"; text: string }
+              | { type: "thinking_delta"; thinking: string }
+              | { type: "input_json_delta"; partial_json: string };
+      }
+    | {
+          type: "content_block_stop";
+          index: number;
+      }
+    | {
+          type: "message_delta";
+          delta: {
+              stop_reason: "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | null;
+              stop_sequence: string | null;
+          };
+          usage: {
+              output_tokens: number;
+          };
+      }
+    | {
+          type: "message_stop";
+      }
+    | {
+          type: "ping";
+      };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.2.0
+      tsx:
+        specifier: ^4.19.3
+        version: 4.23.11
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
This PR introduces native support for the **Anthropic Messages API** (`POST /v1/messages` and `POST /messages`), enabling full compatibility with **Claude Code** and other Anthropic-native CLI / SDK tools.

### Features
1. **Anthropic Translator** (`@srouter/translator`):
   - Converts Anthropic messages, system prompts, multimodal images, and tool use/result schemas (`input_schema`) to SRouter internal request format.
   - Converts non-streaming model outputs to Anthropic message format.
   - Real-time streaming translator from OpenAI chunks to Anthropic SSE events (`message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`).
2. **Messages Controller & Routes** (`apps/api`):
   - Mounted `POST /v1/messages` and `POST /messages` on the primary port (3000) and proxy port (1455).
   - Supports streaming SSE and JSON responses.
3. **Authentication**:
   - Added support for standard Anthropic `x-api-key` header alongside `Authorization: Bearer`.
4. **Testing**:
   - Added unit tests for translator and integration tests in `apps/api`.