### PR TITLE
feat(auth): add first-run admin sessions

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,7 @@ import {
     handleOAuthCallback,
     handleQoderOAuthCallback,
 } from "@/routes/v1/auth.js";
+import { adminRoute } from "@/routes/v1/admin.js";
 import { chatRoute } from "@/routes/v1/chat.js";
 import { keysRoute } from "@/routes/v1/keys.js";
 import { logsRoute } from "@/routes/v1/logs.js";
@@ -42,6 +43,7 @@ app.get("/health", (c) => {
 
 // Mount OpenAI & Anthropic v1 API routes
 app.route("/v1", modelsRoute);
+app.route("/v1", adminRoute);
 app.route("/v1", chatRoute);
 app.route("/v1", messagesRoute);
 app.route("/v1", providersRoute);

--- a/apps/api/src/middleware/adminAuth.ts
+++ b/apps/api/src/middleware/adminAuth.ts
@@ -1,0 +1,32 @@
+import type { Context, MiddlewareHandler, Next } from "hono";
+import { getCookie } from "hono/cookie";
+import { adminAuthStore, type AdminAuthStore } from "@srouter/db";
+import { err } from "@/utils/response.js";
+import { ADMIN_SESSION_COOKIE, verifyAdminSession } from "@/services/adminAuth.js";
+
+export interface AdminAuthMiddlewareOptions {
+    store?: AdminAuthStore;
+    now?: () => number;
+}
+
+export function createAdminAuthMiddleware(
+    options: AdminAuthMiddlewareOptions = {},
+): MiddlewareHandler {
+    const store = options.store ?? adminAuthStore;
+    const now = options.now ?? (() => Date.now());
+
+    return async (c: Context, next: Next) => {
+        const sessionToken = getCookie(c, ADMIN_SESSION_COOKIE);
+        if (!verifyAdminSession(store, sessionToken, now())) {
+            return err(c, "Admin authentication is required", 401, {
+                type: "authentication_error",
+                code: "authentication_required",
+            });
+        }
+
+        c.set("authType", "admin_session");
+        return next();
+    };
+}
+
+export const adminAuth = createAdminAuthMiddleware();

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -1,61 +1,80 @@
 import type { Context, Next } from "hono";
-import { getAPIKeyByKeyDB, getRequireApiKeyDB } from "@srouter/db";
+import { getCookie } from "hono/cookie";
+import {
+    adminAuthStore,
+    getAPIKeyByKeyDB,
+    getRequireApiKeyDB,
+    type AdminAuthStore,
+} from "@srouter/db";
 import { err } from "@/utils/response.js";
+import { ADMIN_SESSION_COOKIE, verifyAdminSession } from "@/services/adminAuth.js";
 
-export async function apiKeyAuth(c: Context, next: Next) {
-    const isRequired = getRequireApiKeyDB();
-    const authHeader = c.req.header("Authorization") || c.req.header("authorization");
-    const xApiKey =
-        c.req.header("x-api-key") || c.req.header("X-Api-Key") || c.req.header("X-API-KEY");
-    const clientHeader = c.req.header("X-SRouter-Client") || c.req.header("x-srouter-client");
+export interface ApiKeyAuthOptions {
+    store?: AdminAuthStore;
+    now?: () => number;
+}
 
-    // Allow internal web playground / dashboard requests
-    if (clientHeader === "web-internal" || clientHeader === "playground") {
-        return await next();
-    }
+export function createApiKeyAuth(options: ApiKeyAuthOptions = {}) {
+    const store = options.store ?? adminAuthStore;
+    const now = options.now ?? (() => Date.now());
 
-    let bearerKey: string | null = null;
-    if (xApiKey) {
-        bearerKey = xApiKey.trim();
-    } else if (authHeader && authHeader.startsWith("Bearer ")) {
-        bearerKey = authHeader.slice(7).trim();
-    } else if (authHeader) {
-        bearerKey = authHeader.trim();
-    }
-
-    if (bearerKey) {
-        const apiKeyRow = getAPIKeyByKeyDB(bearerKey);
-        if (apiKeyRow) {
-            if (!apiKeyRow.enabled) {
-                return err(c, "The provided SRouter API Key is disabled", 401, {
-                    type: "invalid_request_error",
-                    code: "api_key_disabled",
-                });
-            }
-            c.set("apiKeyRow", apiKeyRow);
+    return async function apiKeyAuth(c: Context, next: Next) {
+        if (verifyAdminSession(store, getCookie(c, ADMIN_SESSION_COOKIE), now())) {
+            c.set("authType", "admin_session");
             return await next();
         }
 
-        // If a key was provided but not found in DB and auth is required
-        if (isRequired) {
-            return err(c, "Invalid SRouter API Key", 401, {
-                type: "invalid_request_error",
-                code: "invalid_api_key",
-            });
+        const isRequired = getRequireApiKeyDB();
+        const authHeader = c.req.header("Authorization") || c.req.header("authorization");
+        const xApiKey =
+            c.req.header("x-api-key") || c.req.header("X-Api-Key") || c.req.header("X-API-KEY");
+
+        let bearerKey: string | null = null;
+        if (xApiKey) {
+            bearerKey = xApiKey.trim();
+        } else if (authHeader && authHeader.startsWith("Bearer ")) {
+            bearerKey = authHeader.slice(7).trim();
+        } else if (authHeader) {
+            bearerKey = authHeader.trim();
         }
-    }
 
-    if (isRequired && !bearerKey) {
-        return err(
-            c,
-            "Missing SRouter API Key. Please provide a valid key via 'Authorization: Bearer <key>' header or disable 'Require API Key' in Settings.",
-            401,
-            {
-                type: "invalid_request_error",
-                code: "missing_api_key",
-            },
-        );
-    }
+        if (bearerKey) {
+            const apiKeyRow = getAPIKeyByKeyDB(bearerKey);
+            if (apiKeyRow) {
+                if (!apiKeyRow.enabled) {
+                    return err(c, "The provided SRouter API Key is disabled", 401, {
+                        type: "invalid_request_error",
+                        code: "api_key_disabled",
+                    });
+                }
+                c.set("apiKeyRow", apiKeyRow);
+                c.set("authType", "api_key");
+                return await next();
+            }
 
-    return await next();
+            // If a key was provided but not found in DB and auth is required
+            if (isRequired) {
+                return err(c, "Invalid SRouter API Key", 401, {
+                    type: "invalid_request_error",
+                    code: "invalid_api_key",
+                });
+            }
+        }
+
+        if (isRequired && !bearerKey) {
+            return err(
+                c,
+                "Missing SRouter API Key. Please provide a valid key via 'Authorization: Bearer <key>' header or disable 'Require API Key' in Settings.",
+                401,
+                {
+                    type: "invalid_request_error",
+                    code: "missing_api_key",
+                },
+            );
+        }
+
+        return await next();
+    };
 }
+
+export const apiKeyAuth = createApiKeyAuth();

--- a/apps/api/src/routes/v1/admin.ts
+++ b/apps/api/src/routes/v1/admin.ts
@@ -1,0 +1,189 @@
+import { getConnInfo } from "@hono/node-server/conninfo";
+import { Hono } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { adminAuthStore, type AdminAuthStore } from "@srouter/db";
+import { err, ok } from "@/utils/response.js";
+import {
+    ADMIN_SESSION_COOKIE,
+    ADMIN_SESSION_TTL_MS,
+    createAdminSession,
+    hashAdminPassword,
+    isLoopbackAddress,
+    revokeAdminSession,
+    validateAdminPassword,
+    verifyAdminPassword,
+    verifyAdminSession,
+} from "@/services/adminAuth.js";
+import type { Context } from "hono";
+
+const MAX_LOGIN_FAILURES = 5;
+const LOGIN_BLOCK_MS = 15 * 60 * 1000;
+
+interface AdminRequestBody {
+    password?: unknown;
+    confirmation?: unknown;
+    setupToken?: unknown;
+}
+
+export interface AdminRouteOptions {
+    store?: AdminAuthStore;
+    getClientAddress?: (c: Context) => string | undefined;
+    getSetupToken?: () => string | undefined;
+    now?: () => number;
+    secureCookies?: boolean;
+}
+
+function getDirectClientAddress(c: Context): string | undefined {
+    try {
+        return getConnInfo(c).remote.address ?? undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+async function readBody(c: Context): Promise<AdminRequestBody | null> {
+    try {
+        const body: unknown = await c.req.json();
+        if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+        return body as AdminRequestBody;
+    } catch {
+        return null;
+    }
+}
+
+function setAdminSessionCookie(c: Context, token: string, secure: boolean): void {
+    setCookie(c, ADMIN_SESSION_COOKIE, token, {
+        httpOnly: true,
+        maxAge: Math.floor(ADMIN_SESSION_TTL_MS / 1000),
+        path: "/",
+        sameSite: "Lax",
+        secure,
+    });
+}
+
+function clearAdminSessionCookie(c: Context, secure: boolean): void {
+    deleteCookie(c, ADMIN_SESSION_COOKIE, { path: "/", secure });
+}
+
+export function createAdminRoute(options: AdminRouteOptions = {}): Hono {
+    const store = options.store ?? adminAuthStore;
+    const getClientAddress = options.getClientAddress ?? getDirectClientAddress;
+    const getSetupToken = options.getSetupToken ?? (() => process.env.SROUTER_SETUP_TOKEN);
+    const now = options.now ?? (() => Date.now());
+    const secureCookies = options.secureCookies ?? process.env.SROUTER_SECURE_COOKIES === "true";
+    const failedLogins = new Map<string, { count: number; blockedUntil: number }>();
+    const route = new Hono();
+
+    route.get("/admin/status", (c) => {
+        const authenticated = verifyAdminSession(store, getCookie(c, ADMIN_SESSION_COOKIE), now());
+        return ok(c, { setupRequired: !store.hasAdminAccount(), authenticated });
+    });
+
+    route.post("/admin/setup", async (c) => {
+        if (store.hasAdminAccount()) {
+            return err(c, "Admin setup has already been completed", 409, {
+                type: "authentication_error",
+                code: "setup_already_complete",
+            });
+        }
+
+        const body = await readBody(c);
+        const passwordError = validateAdminPassword(body?.password);
+        if (passwordError) {
+            return err(c, passwordError, 400, {
+                type: "invalid_request_error",
+                code: "invalid_password",
+            });
+        }
+
+        if (body?.confirmation !== body.password) {
+            return err(c, "Password confirmation does not match", 400, {
+                type: "invalid_request_error",
+                code: "password_mismatch",
+            });
+        }
+
+        const address = getClientAddress(c);
+        const configuredSetupToken = getSetupToken();
+        const hasValidSetupToken =
+            Boolean(configuredSetupToken) && body?.setupToken === configuredSetupToken;
+        if (!isLoopbackAddress(address) && !hasValidSetupToken) {
+            return err(
+                c,
+                "Initial admin setup is only available from localhost or with a setup token",
+                403,
+                {
+                    type: "authentication_error",
+                    code: "setup_not_allowed",
+                },
+            );
+        }
+
+        const created = store.createAdminAccount(hashAdminPassword(body.password as string), now());
+        if (!created) {
+            return err(c, "Admin setup has already been completed", 409, {
+                type: "authentication_error",
+                code: "setup_already_complete",
+            });
+        }
+
+        const sessionToken = createAdminSession(store, now());
+        setAdminSessionCookie(c, sessionToken, secureCookies);
+        return ok(c, { authenticated: true }, 201);
+    });
+
+    route.post("/admin/login", async (c) => {
+        const address = getClientAddress(c) ?? "unknown";
+        const timestamp = now();
+        const failure = failedLogins.get(address);
+        if (failure && failure.blockedUntil > timestamp) {
+            return err(c, "Too many failed login attempts", 429, {
+                type: "authentication_error",
+                code: "login_rate_limited",
+            });
+        }
+        if (failure && failure.blockedUntil > 0 && failure.blockedUntil <= timestamp) {
+            failedLogins.delete(address);
+        }
+
+        const body = await readBody(c);
+        const password = typeof body?.password === "string" ? body.password : "";
+        const passwordHash = store.getPasswordHash();
+        if (!passwordHash || !verifyAdminPassword(password, passwordHash)) {
+            const current = failedLogins.get(address);
+            const count = (current?.count ?? 0) + 1;
+            failedLogins.set(address, {
+                count,
+                blockedUntil: count >= MAX_LOGIN_FAILURES ? timestamp + LOGIN_BLOCK_MS : 0,
+            });
+            return err(c, "Invalid admin password", 401, {
+                type: "authentication_error",
+                code: "invalid_credentials",
+            });
+        }
+
+        failedLogins.delete(address);
+        const sessionToken = createAdminSession(store, timestamp);
+        setAdminSessionCookie(c, sessionToken, secureCookies);
+        return ok(c, { authenticated: true });
+    });
+
+    route.post("/admin/logout", (c) => {
+        const sessionToken = getCookie(c, ADMIN_SESSION_COOKIE);
+        if (!verifyAdminSession(store, sessionToken, now())) {
+            clearAdminSessionCookie(c, secureCookies);
+            return err(c, "Admin authentication is required", 401, {
+                type: "authentication_error",
+                code: "authentication_required",
+            });
+        }
+
+        revokeAdminSession(store, sessionToken);
+        clearAdminSessionCookie(c, secureCookies);
+        return c.body(null, 204);
+    });
+
+    return route;
+}
+
+export const adminRoute = createAdminRoute();

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { AuthController } from "@/controllers/auth.controller.js";
+import { adminAuth } from "@/middleware/adminAuth.js";
 
 export const authRoute = new Hono();
 
@@ -10,70 +11,70 @@ export const handleQoderOAuthCallback = AuthController.handleQoderOAuthCallback;
 
 // --- OpenAI OAuth ---
 // 1. GET /v1/auth/openai/login - Initiate OAuth PKCE Login Flow
-authRoute.get("/auth/openai/login", AuthController.loginOpenAI);
+authRoute.get("/auth/openai/login", adminAuth, AuthController.loginOpenAI);
 
 // 2. GET & POST /v1/auth/openai/callback - OAuth Callback Receiver
 authRoute.get("/auth/openai/callback", AuthController.handleOAuthCallback);
 authRoute.post("/auth/openai/callback", AuthController.handleOAuthCallback);
 
 // 3. POST /v1/auth/openai/token & POST /v1/auth/openai/import-token
-authRoute.post("/auth/openai/token", AuthController.importToken);
-authRoute.post("/auth/openai/import-token", AuthController.importToken);
+authRoute.post("/auth/openai/token", adminAuth, AuthController.importToken);
+authRoute.post("/auth/openai/import-token", adminAuth, AuthController.importToken);
 
 // --- Antigravity OAuth ---
 // 1. GET /v1/auth/antigravity/login - Initiate Antigravity OAuth PKCE Login Flow
-authRoute.get("/auth/antigravity/login", AuthController.loginAntigravity);
+authRoute.get("/auth/antigravity/login", adminAuth, AuthController.loginAntigravity);
 
 // 2. GET & POST /v1/auth/antigravity/callback - Antigravity OAuth Callback Receiver
 authRoute.get("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
 authRoute.post("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
 
 // 3. POST /v1/auth/antigravity/token & POST /v1/auth/antigravity/import-token
-authRoute.post("/auth/antigravity/token", AuthController.importAntigravityToken);
-authRoute.post("/auth/antigravity/import-token", AuthController.importAntigravityToken);
+authRoute.post("/auth/antigravity/token", adminAuth, AuthController.importAntigravityToken);
+authRoute.post("/auth/antigravity/import-token", adminAuth, AuthController.importAntigravityToken);
 
 // --- CommandCode Provider (API key) ---
 // 1. POST /v1/auth/commandcode/token & POST /v1/auth/commandcode/import-token
-authRoute.post("/auth/commandcode/token", AuthController.importCommandCodeToken);
-authRoute.post("/auth/commandcode/import-token", AuthController.importCommandCodeToken);
+authRoute.post("/auth/commandcode/token", adminAuth, AuthController.importCommandCodeToken);
+authRoute.post("/auth/commandcode/import-token", adminAuth, AuthController.importCommandCodeToken);
 
 // --- Anthropic Provider (API key) ---
 // 1. POST /v1/auth/anthropic/token & POST /v1/auth/anthropic/import-token
-authRoute.post("/auth/anthropic/token", AuthController.importAnthropicToken);
-authRoute.post("/auth/anthropic/import-token", AuthController.importAnthropicToken);
+authRoute.post("/auth/anthropic/token", adminAuth, AuthController.importAnthropicToken);
+authRoute.post("/auth/anthropic/import-token", adminAuth, AuthController.importAnthropicToken);
 
 // --- GoRouter Provider (API key) ---
 // 1. POST /v1/auth/gorouter/token & POST /v1/auth/gorouter/import-token
-authRoute.post("/auth/gorouter/token", AuthController.importGoRouterToken);
-authRoute.post("/auth/gorouter/import-token", AuthController.importGoRouterToken);
+authRoute.post("/auth/gorouter/token", adminAuth, AuthController.importGoRouterToken);
+authRoute.post("/auth/gorouter/import-token", adminAuth, AuthController.importGoRouterToken);
 
 // --- BluesMinds Provider (API key) ---
 // 1. POST /v1/auth/bluesminds/token & POST /v1/auth/bluesminds/import-token
-authRoute.post("/auth/bluesminds/token", AuthController.importBluesMindsToken);
-authRoute.post("/auth/bluesminds/import-token", AuthController.importBluesMindsToken);
+authRoute.post("/auth/bluesminds/token", adminAuth, AuthController.importBluesMindsToken);
+authRoute.post("/auth/bluesminds/import-token", adminAuth, AuthController.importBluesMindsToken);
 
 // --- SeekAI Provider (API key) ---
 // 1. POST /v1/auth/seekai/token & POST /v1/auth/seekai/import-token
-authRoute.post("/auth/seekai/token", AuthController.importSeekAIToken);
-authRoute.post("/auth/seekai/import-token", AuthController.importSeekAIToken);
+authRoute.post("/auth/seekai/token", adminAuth, AuthController.importSeekAIToken);
+authRoute.post("/auth/seekai/import-token", adminAuth, AuthController.importSeekAIToken);
 
 // --- TabiToken Provider (API key) ---
 // 1. POST /v1/auth/tabitoken/token & POST /v1/auth/tabitoken/import-token
-authRoute.post("/auth/tabitoken/token", AuthController.importTabiTokenToken);
-authRoute.post("/auth/tabitoken/import-token", AuthController.importTabiTokenToken);
+authRoute.post("/auth/tabitoken/token", adminAuth, AuthController.importTabiTokenToken);
+authRoute.post("/auth/tabitoken/import-token", adminAuth, AuthController.importTabiTokenToken);
 
 // --- Qoder Provider (OAuth & PAT) ---
 // 1. GET /v1/auth/qoder/login - Initiate Qoder OAuth PKCE Login Flow
-authRoute.get("/auth/qoder/login", AuthController.loginQoder);
+authRoute.get("/auth/qoder/login", adminAuth, AuthController.loginQoder);
 
 // 2. GET & POST /v1/auth/qoder/callback - Qoder OAuth Callback Receiver
 authRoute.get("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
 authRoute.post("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
 
 // 3. GET & POST /v1/auth/qoder/poll - Device Flow Poll Receiver
-authRoute.get("/auth/qoder/poll", AuthController.pollQoder);
-authRoute.post("/auth/qoder/poll", AuthController.pollQoder);
+authRoute.get("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
+authRoute.post("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
 
 // 4. POST /v1/auth/qoder/token & POST /v1/auth/qoder/import-token
-authRoute.post("/auth/qoder/token", AuthController.importQoderToken);
-authRoute.post("/auth/qoder/import-token", AuthController.importQoderToken);
+authRoute.post("/auth/qoder/token", adminAuth, AuthController.importQoderToken);
+authRoute.post("/auth/qoder/import-token", adminAuth, AuthController.importQoderToken);

--- a/apps/api/src/routes/v1/keys.ts
+++ b/apps/api/src/routes/v1/keys.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { KeysController } from "@/controllers/keys.controller.js";
+import { adminAuth } from "@/middleware/adminAuth.js";
 
 export const keysRoute = new Hono();
+keysRoute.use("/*", adminAuth);
 
 // GET /v1/keys - List all virtual API keys
 keysRoute.get("/keys", KeysController.listKeys);

--- a/apps/api/src/routes/v1/logs.ts
+++ b/apps/api/src/routes/v1/logs.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { LogsController } from "@/controllers/logs.controller.js";
+import { adminAuth } from "@/middleware/adminAuth.js";
 
 export const logsRoute = new Hono();
+logsRoute.use("/*", adminAuth);
 
 // GET /v1/logs - Get recent request logs
 logsRoute.get("/logs", LogsController.listLogs);

--- a/apps/api/src/routes/v1/models.ts
+++ b/apps/api/src/routes/v1/models.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { ModelsController } from "@/controllers/models.controller.js";
+import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const modelsRoute = new Hono();
+modelsRoute.use("/*", apiKeyAuth);
 
 // GET /v1/models
 modelsRoute.get("/models", ModelsController.listModels);

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { ProvidersController } from "@/controllers/providers.controller.js";
+import { adminAuth } from "@/middleware/adminAuth.js";
 
 export const providersRoute = new Hono();
+providersRoute.use("/*", adminAuth);
 
 // GET /v1/providers - Flat list of all provider definitions
 providersRoute.get("/providers", ProvidersController.listProviders);

--- a/apps/api/src/routes/v1/quota.ts
+++ b/apps/api/src/routes/v1/quota.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { QuotaController } from "@/controllers/quota.controller.js";
+import { adminAuth } from "@/middleware/adminAuth.js";
 
 export const quotaRoute = new Hono();
+quotaRoute.use("/*", adminAuth);
 
 // GET /v1/quota and /v1/qouta - Fetch key quota & usage stats
 quotaRoute.get("/quota", QuotaController.getQuota);

--- a/apps/api/src/routes/v1/settings.ts
+++ b/apps/api/src/routes/v1/settings.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { SettingsController } from "@/controllers/settings.controller.js";
+import { adminAuth } from "@/middleware/adminAuth.js";
 
 export const settingsRoute = new Hono();
+settingsRoute.use("/*", adminAuth);
 
 // GET /v1/settings
 settingsRoute.get("/settings", SettingsController.getSettings);

--- a/apps/api/src/services/adminAuth.ts
+++ b/apps/api/src/services/adminAuth.ts
@@ -1,0 +1,110 @@
+import { createHash, randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+import { adminAuthStore, type AdminAuthStore } from "@srouter/db";
+
+export const ADMIN_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const ADMIN_SESSION_COOKIE = "srouter_admin_session";
+
+const PASSWORD_HASH_ALGORITHM = "scrypt";
+const PASSWORD_HASH_LENGTH = 64;
+const PASSWORD_SALT_LENGTH = 16;
+const PASSWORD_SCRYPT_N = 16_384;
+const PASSWORD_SCRYPT_R = 8;
+const PASSWORD_SCRYPT_P = 1;
+const PASSWORD_SCRYPT_MAXMEM = 32 * 1024 * 1024;
+
+export function validateAdminPassword(value: unknown): string | null {
+    if (typeof value !== "string" || value.length === 0) {
+        return "Password is required";
+    }
+    if (value.length < 12) {
+        return "Password must be at least 12 characters";
+    }
+    if (value.length > 128) {
+        return "Password must be at most 128 characters";
+    }
+    return null;
+}
+
+export function hashAdminPassword(password: string): string {
+    const salt = randomBytes(PASSWORD_SALT_LENGTH);
+    const derivedKey = scryptSync(password, salt, PASSWORD_HASH_LENGTH, {
+        N: PASSWORD_SCRYPT_N,
+        r: PASSWORD_SCRYPT_R,
+        p: PASSWORD_SCRYPT_P,
+        maxmem: PASSWORD_SCRYPT_MAXMEM,
+    });
+
+    return [
+        PASSWORD_HASH_ALGORITHM,
+        PASSWORD_SCRYPT_N,
+        PASSWORD_SCRYPT_R,
+        PASSWORD_SCRYPT_P,
+        salt.toString("base64url"),
+        derivedKey.toString("base64url"),
+    ].join("$");
+}
+
+export function verifyAdminPassword(password: string, storedHash: string): boolean {
+    try {
+        const parts = storedHash.split("$");
+        if (parts.length !== 6 || parts[0] !== PASSWORD_HASH_ALGORITHM) return false;
+
+        const [, nValue, rValue, pValue, saltValue, hashValue] = parts;
+        const n = Number(nValue);
+        const r = Number(rValue);
+        const p = Number(pValue);
+        if (![n, r, p].every((value) => Number.isSafeInteger(value) && value > 0)) {
+            return false;
+        }
+
+        const salt = Buffer.from(saltValue, "base64url");
+        const expected = Buffer.from(hashValue, "base64url");
+        if (salt.length === 0 || expected.length === 0) return false;
+
+        const actual = scryptSync(password, salt, expected.length, {
+            N: n,
+            r,
+            p,
+            maxmem: PASSWORD_SCRYPT_MAXMEM,
+        });
+        return actual.length === expected.length && timingSafeEqual(actual, expected);
+    } catch {
+        return false;
+    }
+}
+
+export function hashSessionToken(token: string): string {
+    return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function createAdminSession(
+    store: Pick<AdminAuthStore, "createSession"> = adminAuthStore,
+    now = Date.now(),
+): string {
+    const token = randomBytes(32).toString("base64url");
+    store.createSession(hashSessionToken(token), now, now + ADMIN_SESSION_TTL_MS);
+    return token;
+}
+
+export function verifyAdminSession(
+    store: Pick<AdminAuthStore, "getSession"> = adminAuthStore,
+    token: string | undefined,
+    now = Date.now(),
+): boolean {
+    if (!token) return false;
+    return store.getSession(hashSessionToken(token), now) !== null;
+}
+
+export function revokeAdminSession(
+    store: Pick<AdminAuthStore, "deleteSession"> = adminAuthStore,
+    token: string | undefined,
+): boolean {
+    if (!token) return false;
+    return store.deleteSession(hashSessionToken(token));
+}
+
+export function isLoopbackAddress(address: string | undefined): boolean {
+    if (!address) return false;
+    const normalized = address.toLowerCase().replace(/^::ffff:/, "");
+    return normalized === "127.0.0.1" || normalized === "::1";
+}

--- a/apps/api/tests/admin-auth-middleware.test.ts
+++ b/apps/api/tests/admin-auth-middleware.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, test } from "node:test";
+import { Hono } from "hono";
+import { AdminAuthStore } from "../../../packages/db/src/adminAuth.js";
+import { setRequireApiKeyDB } from "@srouter/db";
+import { ADMIN_SESSION_COOKIE, createAdminSession } from "../src/services/adminAuth.js";
+import { createAdminAuthMiddleware } from "../src/middleware/adminAuth.js";
+import { createApiKeyAuth } from "../src/middleware/apiKeyAuth.js";
+
+afterEach(() => {
+    setRequireApiKeyDB(false);
+});
+
+test("admin middleware requires a valid session cookie", async () => {
+    const store = new AdminAuthStore(new DatabaseSync(":memory:"));
+    store.createAdminAccount("hash");
+    const app = new Hono();
+    app.use("/*", createAdminAuthMiddleware({ store }));
+    app.get("/providers", (c) => c.json({ ok: true }));
+
+    const rejected = await app.request("/providers");
+    assert.equal(rejected.status, 401);
+
+    const token = createAdminSession(store);
+    const accepted = await app.request("/providers", {
+        headers: { Cookie: `${ADMIN_SESSION_COOKIE}=${token}` },
+    });
+    assert.equal(accepted.status, 200);
+});
+
+test("client-identifying headers do not bypass API-key auth", async () => {
+    setRequireApiKeyDB(true);
+    const store = new AdminAuthStore(new DatabaseSync(":memory:"));
+    store.createAdminAccount("hash");
+    const app = new Hono();
+    app.use("/*", createApiKeyAuth({ store }));
+    app.post("/chat/completions", (c) => c.json({ ok: true }));
+
+    const spoofed = await app.request("/chat/completions", {
+        method: "POST",
+        headers: { "X-SRouter-Client": "playground" },
+    });
+    assert.equal(spoofed.status, 401);
+
+    const token = createAdminSession(store);
+    const adminRequest = await app.request("/chat/completions", {
+        method: "POST",
+        headers: { Cookie: `${ADMIN_SESSION_COOKIE}=${token}` },
+    });
+    assert.equal(adminRequest.status, 200);
+});

--- a/apps/api/tests/admin-auth-route.test.ts
+++ b/apps/api/tests/admin-auth-route.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { test } from "node:test";
+import { Hono } from "hono";
+import { AdminAuthStore } from "../../../packages/db/src/adminAuth.js";
+import { createAdminRoute } from "../src/routes/v1/admin.js";
+import { hashAdminPassword } from "../src/services/adminAuth.js";
+
+function createTestApp(options: { address?: string; setupToken?: string } = {}) {
+    const store = new AdminAuthStore(new DatabaseSync(":memory:"));
+    const app = new Hono();
+    app.route(
+        "/v1",
+        createAdminRoute({
+            store,
+            getClientAddress: () => options.address,
+            getSetupToken: () => options.setupToken,
+            secureCookies: false,
+        }),
+    );
+    return { app, store };
+}
+
+function getSessionCookie(response: Response): string {
+    const cookie = response.headers.get("set-cookie")?.match(/srouter_admin_session=([^;]+)/)?.[1];
+    assert.ok(cookie);
+    return `srouter_admin_session=${cookie}`;
+}
+
+test("admin status reports setup and authentication state", async () => {
+    const { app } = createTestApp();
+
+    const initial = await app.request("/v1/admin/status");
+    assert.equal(initial.status, 200);
+    assert.deepEqual(await initial.json(), { setupRequired: true, authenticated: false });
+});
+
+test("local setup creates an account and establishes a session", async () => {
+    const { app, store } = createTestApp({ address: "127.0.0.1" });
+
+    const setup = await app.request("/v1/admin/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            password: "correct horse battery staple",
+            confirmation: "correct horse battery staple",
+        }),
+    });
+
+    assert.equal(setup.status, 201);
+    assert.deepEqual(await setup.json(), { authenticated: true });
+    assert.equal(store.hasAdminAccount(), true);
+
+    const status = await app.request("/v1/admin/status", {
+        headers: { Cookie: getSessionCookie(setup) },
+    });
+    assert.deepEqual(await status.json(), { setupRequired: false, authenticated: true });
+});
+
+test("remote setup requires the configured one-time setup token", async () => {
+    const withoutToken = createTestApp({ address: "192.168.1.10", setupToken: "setup-secret" });
+    const rejected = await withoutToken.app.request("/v1/admin/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            password: "correct horse battery staple",
+            confirmation: "correct horse battery staple",
+        }),
+    });
+    assert.equal(rejected.status, 403);
+
+    const accepted = await withoutToken.app.request("/v1/admin/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            password: "correct horse battery staple",
+            confirmation: "correct horse battery staple",
+            setupToken: "setup-secret",
+        }),
+    });
+    assert.equal(accepted.status, 201);
+
+    const second = await withoutToken.app.request("/v1/admin/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            password: "another correct password",
+            confirmation: "another correct password",
+            setupToken: "setup-secret",
+        }),
+    });
+    assert.equal(second.status, 409);
+});
+
+test("login and logout manage the admin session", async () => {
+    const { app, store } = createTestApp({ address: "127.0.0.1" });
+    store.createAdminAccount(hashAdminPassword("correct horse battery staple"));
+
+    const invalid = await app.request("/v1/admin/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: "wrong password" }),
+    });
+    assert.equal(invalid.status, 401);
+
+    const login = await app.request("/v1/admin/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: "correct horse battery staple" }),
+    });
+    assert.equal(login.status, 200);
+    const cookie = getSessionCookie(login);
+
+    const logout = await app.request("/v1/admin/logout", {
+        method: "POST",
+        headers: { Cookie: cookie },
+    });
+    assert.equal(logout.status, 204);
+
+    const status = await app.request("/v1/admin/status", { headers: { Cookie: cookie } });
+    assert.deepEqual(await status.json(), { setupRequired: false, authenticated: false });
+});
+
+test("repeated failed logins are throttled", async () => {
+    const { app, store } = createTestApp({ address: "192.168.1.10" });
+    store.createAdminAccount("invalid-password-hash");
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+        const response = await app.request("/v1/admin/login", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ password: "wrong password" }),
+        });
+        assert.equal(response.status, 401);
+    }
+
+    const throttled = await app.request("/v1/admin/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: "wrong password" }),
+    });
+    assert.equal(throttled.status, 429);
+});

--- a/apps/api/tests/admin-auth-service.test.ts
+++ b/apps/api/tests/admin-auth-service.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { test } from "node:test";
+import { AdminAuthStore } from "../../../packages/db/src/adminAuth.js";
+import {
+    ADMIN_SESSION_TTL_MS,
+    createAdminSession,
+    hashAdminPassword,
+    hashSessionToken,
+    isLoopbackAddress,
+    validateAdminPassword,
+    verifyAdminPassword,
+    verifyAdminSession,
+} from "../src/services/adminAuth.js";
+
+test("admin passwords use salted scrypt hashes", () => {
+    const firstHash = hashAdminPassword("correct horse battery staple");
+    const secondHash = hashAdminPassword("correct horse battery staple");
+
+    assert.notEqual(firstHash, secondHash);
+    assert.notEqual(firstHash, "correct horse battery staple");
+    assert.equal(verifyAdminPassword("correct horse battery staple", firstHash), true);
+    assert.equal(verifyAdminPassword("wrong password", firstHash), false);
+});
+
+test("admin password validation enforces the setup policy", () => {
+    assert.equal(validateAdminPassword("short"), "Password must be at least 12 characters");
+    assert.equal(validateAdminPassword("a".repeat(129)), "Password must be at most 128 characters");
+    assert.equal(validateAdminPassword("a".repeat(12)), null);
+    assert.equal(validateAdminPassword(null), "Password is required");
+});
+
+test("admin sessions store only a token hash and expire", () => {
+    const store = new AdminAuthStore(new DatabaseSync(":memory:"));
+    const token = createAdminSession(store, 1_000);
+
+    assert.equal(
+        store.getSession(hashSessionToken(token), 1_000)?.tokenHash,
+        hashSessionToken(token),
+    );
+    assert.equal(verifyAdminSession(store, token, 1_000), true);
+    assert.equal(verifyAdminSession(store, token, 1_000 + ADMIN_SESSION_TTL_MS), false);
+});
+
+test("loopback detection accepts local IPv4 and IPv6 addresses only", () => {
+    assert.equal(isLoopbackAddress("127.0.0.1"), true);
+    assert.equal(isLoopbackAddress("::1"), true);
+    assert.equal(isLoopbackAddress("::ffff:127.0.0.1"), true);
+    assert.equal(isLoopbackAddress("192.168.1.10"), false);
+    assert.equal(isLoopbackAddress(undefined), false);
+});

--- a/apps/api/tests/admin-auth-store.test.ts
+++ b/apps/api/tests/admin-auth-store.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { test } from "node:test";
+import { AdminAuthStore } from "../../../packages/db/src/adminAuth.js";
+
+test("admin auth store creates one account and preserves its hash", () => {
+    const store = new AdminAuthStore(new DatabaseSync(":memory:"));
+
+    assert.equal(store.hasAdminAccount(), false);
+    assert.equal(store.createAdminAccount("hash-one", 100), true);
+    assert.equal(store.hasAdminAccount(), true);
+    assert.equal(store.getPasswordHash(), "hash-one");
+    assert.equal(store.createAdminAccount("hash-two", 200), false);
+    assert.equal(store.getPasswordHash(), "hash-one");
+});
+
+test("admin auth store creates, finds, and deletes sessions", () => {
+    const store = new AdminAuthStore(new DatabaseSync(":memory:"));
+
+    store.createSession("token-hash", 100, 200);
+
+    assert.deepEqual(store.getSession("token-hash", 150), {
+        tokenHash: "token-hash",
+        createdAt: 100,
+        expiresAt: 200,
+    });
+    assert.equal(store.deleteSession("token-hash"), true);
+    assert.equal(store.getSession("token-hash", 150), null);
+
+    store.createSession("expired-token-hash", 100, 200);
+    assert.equal(store.getSession("expired-token-hash", 200), null);
+});

--- a/apps/web/src/components/auth/AdminAuthGate.tsx
+++ b/apps/web/src/components/auth/AdminAuthGate.tsx
@@ -1,0 +1,181 @@
+import { useState, type FormEvent, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api, ApiError } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+interface AdminStatus {
+    setupRequired: boolean;
+    authenticated: boolean;
+}
+
+interface AdminAuthFormProps {
+    setupRequired: boolean;
+    onAuthenticated: () => void;
+}
+
+function AdminAuthForm({ setupRequired, onAuthenticated }: AdminAuthFormProps) {
+    const [password, setPassword] = useState("");
+    const [confirmation, setConfirmation] = useState("");
+    const [setupToken, setSetupToken] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setError(null);
+        setIsSubmitting(true);
+
+        try {
+            await api.post<{ authenticated: boolean }>(
+                setupRequired ? "/v1/admin/setup" : "/v1/admin/login",
+                setupRequired
+                    ? { password, confirmation, ...(setupToken ? { setupToken } : {}) }
+                    : { password },
+            );
+            setPassword("");
+            setConfirmation("");
+            setSetupToken("");
+            onAuthenticated();
+        } catch (cause) {
+            setError(cause instanceof ApiError ? cause.message : "Unable to authenticate");
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <main className="flex min-h-svh items-center justify-center bg-background px-4 py-8">
+            <Card className="w-full max-w-md">
+                <CardHeader>
+                    <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        SRouter control plane
+                    </p>
+                    <CardTitle>
+                        {setupRequired ? "Create your admin password" : "Sign in to SRouter"}
+                    </CardTitle>
+                    <CardDescription>
+                        {setupRequired
+                            ? "This password protects provider credentials, API keys, and gateway settings."
+                            : "Enter the admin password to open the gateway dashboard."}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+                        <label className="flex flex-col gap-1.5 text-xs font-medium">
+                            Password
+                            <Input
+                                autoFocus
+                                type="password"
+                                autoComplete={setupRequired ? "new-password" : "current-password"}
+                                value={password}
+                                onChange={(event) => setPassword(event.target.value)}
+                                placeholder={
+                                    setupRequired ? "At least 12 characters" : "Admin password"
+                                }
+                                required
+                            />
+                        </label>
+
+                        {setupRequired ? (
+                            <>
+                                <label className="flex flex-col gap-1.5 text-xs font-medium">
+                                    Confirm password
+                                    <Input
+                                        type="password"
+                                        autoComplete="new-password"
+                                        value={confirmation}
+                                        onChange={(event) => setConfirmation(event.target.value)}
+                                        placeholder="Repeat the password"
+                                        required
+                                    />
+                                </label>
+                                <label className="flex flex-col gap-1.5 text-xs font-medium">
+                                    Remote setup token
+                                    <Input
+                                        type="password"
+                                        autoComplete="off"
+                                        value={setupToken}
+                                        onChange={(event) => setSetupToken(event.target.value)}
+                                        placeholder="Only needed outside localhost"
+                                    />
+                                    <span className="text-[11px] font-normal text-muted-foreground">
+                                        Leave empty when opening SRouter on the same machine.
+                                    </span>
+                                </label>
+                            </>
+                        ) : null}
+
+                        {error ? (
+                            <p className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                                {error}
+                            </p>
+                        ) : null}
+
+                        <Button type="submit" disabled={isSubmitting} className="mt-1 w-full">
+                            {isSubmitting
+                                ? "Please wait…"
+                                : setupRequired
+                                  ? "Create password"
+                                  : "Sign in"}
+                        </Button>
+                    </form>
+                </CardContent>
+            </Card>
+        </main>
+    );
+}
+
+function AuthLoadingScreen() {
+    return (
+        <main className="flex min-h-svh items-center justify-center bg-background px-4">
+            <p className="font-mono text-xs text-muted-foreground">Checking admin session…</p>
+        </main>
+    );
+}
+
+function AuthUnavailableScreen({ onRetry }: { onRetry: () => void }) {
+    return (
+        <main className="flex min-h-svh items-center justify-center bg-background px-4 py-8">
+            <Card className="w-full max-w-md">
+                <CardHeader>
+                    <CardTitle>Gateway unavailable</CardTitle>
+                    <CardDescription>
+                        SRouter could not verify the admin session. Make sure the API is running and
+                        try again.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Button type="button" variant="outline" onClick={onRetry} className="w-full">
+                        Try again
+                    </Button>
+                </CardContent>
+            </Card>
+        </main>
+    );
+}
+
+export function AdminAuthGate({ children }: { children: ReactNode }) {
+    const statusQuery = useQuery({
+        queryKey: ["admin-auth-status"],
+        queryFn: () => api.get<AdminStatus>("/v1/admin/status"),
+        retry: false,
+        staleTime: 0,
+    });
+
+    if (statusQuery.isPending) return <AuthLoadingScreen />;
+    if (statusQuery.isError || !statusQuery.data) {
+        return <AuthUnavailableScreen onRetry={() => void statusQuery.refetch()} />;
+    }
+    if (!statusQuery.data.authenticated) {
+        return (
+            <AdminAuthForm
+                setupRequired={statusQuery.data.setupRequired}
+                onAuthenticated={() => void statusQuery.refetch()}
+            />
+        );
+    }
+
+    return <>{children}</>;
+}

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,8 +1,10 @@
 import { useMatches } from "@tanstack/react-router";
-import { Moon, Sun } from "lucide-react";
+import { LogOut, Moon, Sun } from "lucide-react";
+import { useState } from "react";
 import { useTheme } from "@/context/Theme";
 import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { api } from "@/lib/api";
 
 function usePageTitle(): string {
     const matches = useMatches();
@@ -13,6 +15,20 @@ function usePageTitle(): string {
 export function Topbar() {
     const title = usePageTitle();
     const { theme, toggleTheme } = useTheme();
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+    async function handleLogout() {
+        setIsLoggingOut(true);
+        try {
+            await api.post<void>("/v1/admin/logout");
+            window.location.reload();
+        } catch {
+            // An expired session should still return the user to the login screen.
+            window.location.reload();
+        } finally {
+            setIsLoggingOut(false);
+        }
+    }
 
     return (
         <header className="sticky top-0 z-30 flex h-12 min-h-12 shrink-0 items-center justify-between gap-4 border-b border-border/70 bg-background px-3 sm:px-4">
@@ -31,6 +47,17 @@ export function Topbar() {
                     className="rounded-none text-muted-foreground hover:bg-transparent hover:text-foreground"
                 >
                     {theme === "dark" ? <Sun /> : <Moon />}
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => void handleLogout()}
+                    disabled={isLoggingOut}
+                    aria-label="Sign out"
+                    className="rounded-none text-muted-foreground hover:bg-transparent hover:text-foreground"
+                >
+                    <LogOut />
                 </Button>
             </div>
         </header>

--- a/apps/web/src/hooks/usePlayground.ts
+++ b/apps/web/src/hooks/usePlayground.ts
@@ -359,7 +359,6 @@ export function usePlayground(initialModel: string, models: PlaygroundModel[]) {
                         "Content-Type": "application/json",
                         Accept: "text/event-stream",
                         "X-Chat-ID": activeChatId,
-                        "X-SRouter-Client": "playground",
                     },
                     signal: controller.signal,
                     body: JSON.stringify({
@@ -491,7 +490,6 @@ export function usePlayground(initialModel: string, models: PlaygroundModel[]) {
                             headers: {
                                 "Content-Type": "application/json",
                                 "X-Chat-ID": activeChatId,
-                                "X-SRouter-Client": "playground",
                             },
                             body: JSON.stringify({
                                 model: selectedModel.id,
@@ -604,7 +602,6 @@ export function usePlayground(initialModel: string, models: PlaygroundModel[]) {
                                 headers: {
                                     "Content-Type": "application/json",
                                     "X-Chat-ID": activeChatId,
-                                    "X-SRouter-Client": "playground",
                                 },
                                 body: JSON.stringify({
                                     model: selectedModel.id,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -9,6 +9,7 @@ export class ApiError extends Error {
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(path, {
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         ...init,
     });
@@ -81,4 +82,3 @@ export function getGatewayBaseUrl(): string {
 
     return "http://localhost:3000/v1";
 }
-

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { AppSidebar } from "@/components/layout/AppSidebar";
 import { Topbar } from "@/components/layout/Topbar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { AdminAuthGate } from "@/components/auth/AdminAuthGate";
 
 interface RouterContext {
     queryClient: QueryClient;
@@ -18,15 +19,17 @@ declare module "@tanstack/react-router" {
 export const Route = createRootRouteWithContext<RouterContext>()({
     component: () => (
         <TooltipProvider>
-            <SidebarProvider>
-                <AppSidebar />
-                <SidebarInset className="h-svh overflow-hidden">
-                    <Topbar />
-                    <main className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4 sm:p-5">
-                        <Outlet />
-                    </main>
-                </SidebarInset>
-            </SidebarProvider>
+            <AdminAuthGate>
+                <SidebarProvider>
+                    <AppSidebar />
+                    <SidebarInset className="h-svh overflow-hidden">
+                        <Topbar />
+                        <main className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4 sm:p-5">
+                            <Outlet />
+                        </main>
+                    </SidebarInset>
+                </SidebarProvider>
+            </AdminAuthGate>
         </TooltipProvider>
     ),
 });

--- a/packages/db/src/adminAuth.ts
+++ b/packages/db/src/adminAuth.ts
@@ -1,0 +1,92 @@
+import type { DatabaseSync } from "node:sqlite";
+import { db } from "./db.js";
+
+export interface AdminSession {
+    tokenHash: string;
+    createdAt: number;
+    expiresAt: number;
+}
+
+export class AdminAuthStore {
+    public constructor(private readonly database: DatabaseSync = db) {
+        this.database.exec(`
+            CREATE TABLE IF NOT EXISTS admin_account (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                password_hash TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS admin_sessions (
+                token_hash TEXT PRIMARY KEY,
+                created_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL
+            );
+        `);
+    }
+
+    public hasAdminAccount(): boolean {
+        const row = this.database
+            .prepare("SELECT 1 AS present FROM admin_account WHERE id = 1")
+            .get();
+        return Boolean(row);
+    }
+
+    public createAdminAccount(passwordHash: string, now = Date.now()): boolean {
+        const result = this.database
+            .prepare(
+                `INSERT OR IGNORE INTO admin_account (id, password_hash, created_at, updated_at)
+                 VALUES (1, ?, ?, ?)`,
+            )
+            .run(passwordHash, now, now);
+
+        return Number(result.changes ?? 0) > 0;
+    }
+
+    public getPasswordHash(): string | null {
+        const row = this.database
+            .prepare("SELECT password_hash FROM admin_account WHERE id = 1")
+            .get() as { password_hash?: string } | undefined;
+
+        return row?.password_hash ?? null;
+    }
+
+    public createSession(tokenHash: string, createdAt: number, expiresAt: number): void {
+        this.database
+            .prepare(
+                `INSERT INTO admin_sessions (token_hash, created_at, expires_at)
+                 VALUES (?, ?, ?)`,
+            )
+            .run(tokenHash, createdAt, expiresAt);
+    }
+
+    public getSession(tokenHash: string, now = Date.now()): AdminSession | null {
+        this.database.prepare("DELETE FROM admin_sessions WHERE expires_at <= ?").run(now);
+
+        const row = this.database
+            .prepare(
+                `SELECT token_hash, created_at, expires_at
+                 FROM admin_sessions
+                 WHERE token_hash = ? AND expires_at > ?`,
+            )
+            .get(tokenHash, now) as
+            { token_hash?: string; created_at?: number; expires_at?: number } | undefined;
+
+        if (!row) return null;
+
+        return {
+            tokenHash: String(row.token_hash),
+            createdAt: Number(row.created_at),
+            expiresAt: Number(row.expires_at),
+        };
+    }
+
+    public deleteSession(tokenHash: string): boolean {
+        const result = this.database
+            .prepare("DELETE FROM admin_sessions WHERE token_hash = ?")
+            .run(tokenHash);
+        return Number(result.changes ?? 0) > 0;
+    }
+}
+
+export const adminAuthStore = new AdminAuthStore();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./apiKeys.js";
+export * from "./adminAuth.js";
 export * from "./db.js";
 export * from "./logs.js";
 export * from "./oauthSessions.js";


### PR DESCRIPTION
## Why this is needed

SRouter currently has no authenticated control-plane boundary. Several dashboard endpoints—provider connections, virtual API keys, logs, quotas, settings, and credential imports—can be reached without proving administrative ownership.

The dashboard playground also relied on the `X-SRouter-Client` header to bypass API-key checks. Because callers can forge that header, it is an identity claim rather than authentication. Anyone who can reach the SRouter port could potentially modify gateway configuration or inspect operational data.

This PR establishes a real first-run ownership and session model while preserving the gateway’s existing API-key workflow.

## What changes

- Add a first-run setup flow: opening the dashboard on localhost presents a password-creation screen.
- Require an admin password between 12 and 128 characters and store only a salted scrypt hash.
- Create seven-day admin sessions using random tokens:
  - the browser receives an HttpOnly, SameSite=Lax cookie;
  - SQLite stores only a SHA-256 token digest;
  - logout revokes the server-side session.
- Protect dashboard/control-plane routes with the admin session.
- Accept an admin session for dashboard inference requests while continuing to accept valid SRouter API keys for external clients.
- Remove the spoofable `X-SRouter-Client` bypass.
- Add failed-login throttling.
- Add setup/login/logout UI and prevent protected dashboard content from rendering before authentication.

The 12-character minimum is a deliberately isolated policy choice in `validateAdminPassword`; maintainers can lower or remove that minimum later if the project prefers a less restrictive password policy.

## Safe first-run behavior

Local setup is allowed only when the direct client address is loopback.

For remote deployments, configure `SROUTER_SETUP_TOKEN`; the token is accepted only while no admin account exists. For HTTPS deployments, set `SROUTER_SECURE_COOKIES=true`.

This keeps the convenient localhost experience while preventing the first arbitrary network visitor from claiming a remotely exposed instance.

## Route policy

Admin authentication now protects:

- providers and provider connections;
- virtual API-key management;
- logs and quota data;
- settings;
- OAuth initiation, polling, and credential import.

Inference endpoints still support:

- admin-session access for the dashboard;
- valid enabled SRouter API keys for external clients;
- the existing open behavior when `require_api_key` is explicitly disabled.

OAuth callback receivers remain reachable for provider redirects and retain their existing OAuth-state validation.

## Scope

This PR establishes access control and session security. It does not yet encrypt provider secrets at rest, add multiple users/roles, or implement password recovery; those can be separate follow-ups once the ownership boundary is in place.

## Verification

- Full uncached test suite passes: 45 API tests plus provider, executor, and translator suites.
- `pnpm build` passes.
- End-to-end smoke test confirms fresh setup, HttpOnly session creation, protected settings access, logout, and post-logout rejection.
- The existing formatter check still reports six unrelated pre-existing files.