### PR TITLE
fix(models): speed up provider discovery

### DIFF
--- a/apps/api/src/controllers/models.controller.ts
+++ b/apps/api/src/controllers/models.controller.ts
@@ -7,13 +7,15 @@ export class ModelsController {
     public static async listModels(c: Context): Promise<Response> {
         const refreshParam = c.req.query("refresh") || c.req.query("force");
         const cacheControlReq = c.req.header("cache-control");
-        const forceRefresh =
-            refreshParam === "true" ||
-            refreshParam === "1" ||
-            cacheControlReq?.includes("no-cache") ||
-            cacheControlReq?.includes("no-store");
+        const explicitRefresh = refreshParam === "true" || refreshParam === "1";
+        const revalidate =
+            cacheControlReq?.includes("no-cache") || cacheControlReq?.includes("no-store");
 
-        const models = await ModelsLogic.getAllModels(undefined, forceRefresh);
+        if (revalidate && !explicitRefresh) {
+            void ModelsLogic.refreshModels(true).catch(() => undefined);
+        }
+
+        const models = await ModelsLogic.getAllModels(undefined, explicitRefresh);
         const response: ModelListResponse = {
             object: "list",
             data: models

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,6 +21,7 @@ import { quotaRoute } from "@/routes/v1/quota.js";
 import { settingsRoute } from "@/routes/v1/settings.js";
 import { startTokenRefreshSweeper } from "@/services/tokenRefresh.js";
 import { resolveWebDistPath } from "@/services/webDist.js";
+import { warmModelRegistry } from "@/services/registry.js";
 
 const app = new Hono();
 
@@ -86,6 +87,7 @@ serve(
     },
     (info) => {
         console.log(`🚀 SRouter API Server running at http://localhost:${info.port}`);
+        warmModelRegistry();
     }
 );
 

--- a/apps/api/src/logic/models.logic.ts
+++ b/apps/api/src/logic/models.logic.ts
@@ -17,6 +17,10 @@ export class ModelsLogic {
         return models.find((m) => m.id === modelId);
     }
 
+    public static refreshModels(forceRefresh = false): Promise<ModelObject[]> {
+        return registry.refreshModels(forceRefresh);
+    }
+
     public static clearCache(providerId?: string): void {
         registry.clearModelsCache(providerId);
     }

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -241,6 +241,15 @@ export function loadSavedProvidersFromDB(): void {
     }
 }
 
+/**
+ * Warm model discovery after the HTTP server starts. Keeping this outside the
+ * database reload helper avoids network side effects for provider mutations
+ * and keeps reloads lazy when a connection is added or removed.
+ */
+export function warmModelRegistry(): void {
+    void registry.refreshModels().catch(() => undefined);
+}
+
 // Seed built-in driver rows, then auto load saved DB providers
 seedDefaultProviders();
 loadSavedProvidersFromDB();

--- a/apps/api/tests/models-endpoint.test.ts
+++ b/apps/api/tests/models-endpoint.test.ts
@@ -11,12 +11,19 @@ app.route("/v1", modelsRoute);
 
 const mockProviderId = "mock";
 let fetchCount = 0;
+let slowRefresh = false;
+
+const delay = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
 
 const mockProvider: AIProvider = {
     id: mockProviderId,
     name: "Mock Models Cached Provider",
     listModels: async () => {
         fetchCount++;
+        if (slowRefresh) await delay(300);
         return [
             { id: `${mockProviderId}/gpt-5-turbo`, object: "model" },
             { id: `${mockProviderId}/claude-sonnet-4`, object: "model" }
@@ -32,6 +39,12 @@ const mockProvider: AIProvider = {
 
 beforeEach(() => {
     fetchCount = 0;
+    slowRefresh = false;
+    for (const providerId of registry.getAllProviders().keys()) {
+        if (providerId !== "default" && providerId !== mockProviderId) {
+            registry.unregisterProvider(providerId);
+        }
+    }
     registry.registerProvider(mockProvider);
     ModelsLogic.clearCache();
 });
@@ -75,7 +88,28 @@ test("GET /v1/models?refresh=true forces a fresh fetch bypassing cache", async (
         headers: { "Cache-Control": "no-cache" }
     });
     assert.equal(resNoCache.status, 200);
+    for (let i = 0; i < 20 && fetchCount < 3; i++) await delay(5);
     assert.equal(fetchCount, 3);
+});
+
+test("GET /v1/models revalidates no-cache requests without blocking", async () => {
+    await app.request("/v1/models", { method: "GET" });
+    slowRefresh = true;
+
+    const startedAt = Date.now();
+    const response = await app.request("/v1/models", {
+        method: "GET",
+        headers: { "Cache-Control": "no-cache" }
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    assert.equal(response.status, 200);
+    assert.ok(elapsedMs < 150, `no-cache request took ${elapsedMs}ms`);
+    const body = (await response.json()) as { data: Array<{ id: string }> };
+    assert.ok(body.data.some((model) => model.id.includes("gpt-5-turbo")));
+
+    for (let i = 0; i < 60 && fetchCount < 2; i++) await delay(10);
+    assert.equal(fetchCount, 2);
 });
 
 test("GET /v1/models/:model returns single model or 404", async () => {

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -33,12 +33,54 @@ interface CachedProviderModels {
     cachedAt: number;
 }
 
+interface ModelSnapshot {
+    models: ModelObject[];
+    cachedAt: number;
+    retryAt?: number;
+}
+
+interface ProviderModelResult {
+    providerId: string;
+    alias: string;
+    models: ModelObject[];
+}
+
+const DEFAULT_MODELS_FETCH_TIMEOUT_MS = 5_000;
+const INITIAL_MODELS_WAIT_MS = 1_000;
+const MODEL_REFRESH_CONCURRENCY = 4;
+const MODEL_FAILURE_COOLDOWN_MS = 30_000;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error(`Provider model discovery timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+
+        promise.then(
+            (value) => {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            (error: unknown) => {
+                clearTimeout(timer);
+                reject(error);
+            }
+        );
+    });
+}
+
 export class ProviderRegistry {
     private providers: Map<string, AIProvider> = new Map();
     private defaultProvider: AIProvider;
     private modelsCache: Map<string, CachedProviderModels> = new Map();
     private modelsInflight: Map<string, Promise<ModelObject[]>> = new Map();
+    private modelsFailures: Map<string, number> = new Map();
+    private modelsSnapshot?: ModelSnapshot;
+    private modelsRefreshInflight?: Promise<ModelObject[]>;
+    private modelsGeneration = 0;
+    private modelsRefreshPending = false;
     private modelsTtlMs: number = 5 * 60 * 1000; // 5 minutes default TTL
+    private modelsFetchTimeoutMs: number = DEFAULT_MODELS_FETCH_TIMEOUT_MS;
 
     constructor(defaultProvider?: AIProvider, modelsTtlMs?: number) {
         if (modelsTtlMs !== undefined) {
@@ -70,18 +112,34 @@ export class ProviderRegistry {
         this.modelsTtlMs = ttlMs;
     }
 
+    setModelsFetchTimeoutMs(timeoutMs: number): void {
+        this.modelsFetchTimeoutMs = Math.max(1, timeoutMs);
+    }
+
     clearModelsCache(providerId?: string): void {
         if (providerId) {
             this.modelsCache.delete(providerId);
             this.modelsInflight.delete(providerId);
+            this.modelsFailures.delete(providerId);
         } else {
             this.modelsCache.clear();
             this.modelsInflight.clear();
+            this.modelsFailures.clear();
+        }
+        this.modelsSnapshot = undefined;
+        this.modelsGeneration++;
+        if (this.modelsRefreshInflight) {
+            this.modelsRefreshPending = true;
         }
     }
 
     async getProviderModels(provider: AIProvider, forceRefresh = false): Promise<ModelObject[]> {
         if (!provider || provider.id === "default") return [];
+
+        const inflight = this.modelsInflight.get(provider.id);
+        if (inflight) {
+            return inflight;
+        }
 
         const now = Date.now();
         const cached = this.modelsCache.get(provider.id);
@@ -90,32 +148,131 @@ export class ProviderRegistry {
             return cached.models;
         }
 
-        const inflight = this.modelsInflight.get(provider.id);
-        if (inflight && !forceRefresh) {
-            return inflight;
+        const failureAt = this.modelsFailures.get(provider.id);
+        if (
+            !forceRefresh &&
+            failureAt !== undefined &&
+            now - failureAt < MODEL_FAILURE_COOLDOWN_MS
+        ) {
+            return cached?.models ?? [];
         }
 
         const fetchPromise = (async () => {
             try {
-                const models = await provider.listModels();
+                const models = await withTimeout(provider.listModels(), this.modelsFetchTimeoutMs);
                 const safeModels = Array.isArray(models) ? models : [];
                 this.modelsCache.set(provider.id, {
                     models: safeModels,
                     cachedAt: Date.now()
                 });
+                this.modelsFailures.delete(provider.id);
                 return safeModels;
             } catch (err) {
+                this.modelsFailures.set(provider.id, Date.now());
                 if (cached) {
                     return cached.models;
                 }
                 return [];
-            } finally {
-                this.modelsInflight.delete(provider.id);
             }
         })();
 
         this.modelsInflight.set(provider.id, fetchPromise);
+        void fetchPromise.then(
+            () => {
+                if (this.modelsInflight.get(provider.id) === fetchPromise) {
+                    this.modelsInflight.delete(provider.id);
+                }
+            },
+            () => {
+                if (this.modelsInflight.get(provider.id) === fetchPromise) {
+                    this.modelsInflight.delete(provider.id);
+                }
+            }
+        );
         return fetchPromise;
+    }
+
+    async refreshModels(forceRefresh = false): Promise<ModelObject[]> {
+        if (this.modelsRefreshInflight) {
+            return this.modelsRefreshInflight;
+        }
+
+        const generation = this.modelsGeneration;
+        const refreshPromise = this.refreshModelsInternal(forceRefresh, generation);
+        this.modelsRefreshInflight = refreshPromise;
+        void refreshPromise.then(
+            () => {
+                if (this.modelsRefreshInflight === refreshPromise) {
+                    this.modelsRefreshInflight = undefined;
+                    if (this.modelsRefreshPending || generation !== this.modelsGeneration) {
+                        this.modelsRefreshPending = false;
+                        void this.refreshModels(forceRefresh).catch(() => undefined);
+                    }
+                }
+            },
+            () => {
+                if (this.modelsRefreshInflight === refreshPromise) {
+                    this.modelsRefreshInflight = undefined;
+                    if (this.modelsRefreshPending || generation !== this.modelsGeneration) {
+                        this.modelsRefreshPending = false;
+                        void this.refreshModels(forceRefresh).catch(() => undefined);
+                    }
+                }
+            }
+        );
+        return refreshPromise;
+    }
+
+    private async refreshModelsInternal(
+        forceRefresh: boolean,
+        generation: number
+    ): Promise<ModelObject[]> {
+        const activeProviders = Array.from(this.providers.values()).filter(
+            (provider) => provider.id !== "default"
+        );
+        const results: Array<ProviderModelResult | undefined> = new Array(activeProviders.length);
+        let nextIndex = 0;
+
+        const refreshWorker = async (): Promise<void> => {
+            while (true) {
+                const index = nextIndex++;
+                const provider = activeProviders[index];
+                if (!provider) return;
+
+                results[index] = {
+                    providerId: provider.id,
+                    alias: getProviderAlias(provider.id),
+                    models: await this.getProviderModels(provider, forceRefresh)
+                };
+            }
+        };
+
+        const workerCount = Math.min(MODEL_REFRESH_CONCURRENCY, activeProviders.length);
+        await Promise.all(
+            Array.from({ length: workerCount }, () => refreshWorker())
+        );
+
+        const modelResults = results.filter(
+            (result): result is ProviderModelResult => result !== undefined
+        );
+        const models = this.buildModelList(modelResults);
+        if (generation !== this.modelsGeneration) {
+            return models;
+        }
+
+        const failureTimes = activeProviders
+            .map((provider) => this.modelsFailures.get(provider.id))
+            .filter((failureAt): failureAt is number => failureAt !== undefined);
+
+        this.modelsSnapshot = {
+            models,
+            cachedAt: Date.now(),
+            retryAt:
+                failureTimes.length > 0
+                    ? Math.min(...failureTimes) + MODEL_FAILURE_COOLDOWN_MS
+                    : undefined
+        };
+        return models;
     }
 
     registerProvider(provider: AIProvider): void {
@@ -236,46 +393,69 @@ export class ProviderRegistry {
         );
     }
 
-    async listAllModels(providerFilter?: string, forceRefresh = false): Promise<ModelObject[]> {
+    private buildModelList(results: ProviderModelResult[]): ModelObject[] {
         const allModels: ModelObject[] = [];
         const seenIds = new Set<string>();
 
-        const matchesFilter = (alias: string): boolean => {
-            if (!providerFilter) return true;
-            const filter = providerFilter.toLowerCase();
-            return alias.toLowerCase() === filter || alias.toLowerCase().startsWith(filter);
-        };
+        for (const { providerId, alias, models } of results) {
+            for (const model of models) {
+                const bareId = stripModelPrefix(model.id, alias, providerId);
+                const id = `${alias}/${bareId}`;
+                if (seenIds.has(id)) continue;
 
-        const addModel = (model: ModelObject, alias: string, providerId: string): void => {
-            if (!matchesFilter(alias)) return;
-            const bareId = stripModelPrefix(model.id, alias, providerId);
-            const id = `${alias}/${bareId}`;
-            if (!seenIds.has(id)) {
                 seenIds.add(id);
                 allModels.push({ id, object: "model", owned_by: alias });
-            }
-        };
-
-        const activeProviders = Array.from(this.providers.values()).filter(
-            (p) => p.id !== "default"
-        );
-
-        // Fetch / retrieve cached models concurrently across all active providers
-        const results = await Promise.all(
-            activeProviders.map(async (provider) => {
-                const alias = getProviderAlias(provider.id);
-                const liveModels = await this.getProviderModels(provider, forceRefresh);
-                return { providerId: provider.id, alias, liveModels };
-            })
-        );
-
-        for (const { providerId, alias, liveModels } of results) {
-            for (const model of liveModels) {
-                addModel(model, alias, providerId);
             }
         }
 
         return allModels;
+    }
+
+    private filterModels(models: ModelObject[], providerFilter?: string): ModelObject[] {
+        if (!providerFilter) return models;
+        const filter = providerFilter.toLowerCase();
+        return models.filter((model) => {
+            const owner = model.owned_by.toLowerCase();
+            return owner === filter || owner.startsWith(filter);
+        });
+    }
+
+    async listAllModels(providerFilter?: string, forceRefresh = false): Promise<ModelObject[]> {
+        const snapshot = this.modelsSnapshot;
+        const now = Date.now();
+        const snapshotNeedsRefresh =
+            !snapshot ||
+            now - snapshot.cachedAt >= this.modelsTtlMs ||
+            (snapshot.retryAt !== undefined && now >= snapshot.retryAt);
+
+        if (forceRefresh) {
+            await this.waitForInitialModels(true);
+        } else if (!snapshot) {
+            await this.waitForInitialModels(false);
+        } else if (snapshotNeedsRefresh) {
+            void this.refreshModels().catch(() => undefined);
+        }
+
+        return this.filterModels(this.modelsSnapshot?.models ?? [], providerFilter);
+    }
+
+    private async waitForInitialModels(forceRefresh: boolean): Promise<void> {
+        const deadline = Date.now() + INITIAL_MODELS_WAIT_MS;
+        while (forceRefresh || !this.modelsSnapshot) {
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) break;
+
+            try {
+                await withTimeout(this.refreshModels(forceRefresh), remainingMs);
+            } catch {
+                break;
+            }
+
+            if (this.modelsSnapshot) return;
+        }
+
+        // A refresh invalidated while it was running is automatically queued
+        // again. The loop above observes that second refresh before returning.
     }
 
     async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {

--- a/packages/providers/tests/registry.test.ts
+++ b/packages/providers/tests/registry.test.ts
@@ -3,6 +3,11 @@ import { test } from "node:test";
 import { getProviderAlias, ProviderRegistry } from "../src/registry.js";
 import type { AIProvider } from "@srouter/types";
 
+const delay = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
 const provider: AIProvider = {
     id: "kiro_test_runtime",
     name: "Kiro Runtime Test",
@@ -154,4 +159,120 @@ test("ProviderRegistry invalidates cache on register and unregister", async () =
     registry.unregisterProvider(testProvider.id);
     const models = await registry.listAllModels();
     assert.equal(models.length, 0);
+});
+
+test("ProviderRegistry serves a stale aggregate snapshot while refreshing", async () => {
+    let callCount = 0;
+    const testProvider: AIProvider = {
+        id: "test_snapshot_provider",
+        name: "Test Snapshot Provider",
+        listModels: async () => {
+            callCount++;
+            if (callCount === 2) await delay(120);
+            return [
+                {
+                    id: `test_snapshot_provider/${callCount === 1 ? "stale" : "fresh"}`,
+                    object: "model"
+                }
+            ];
+        },
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+
+    const registry = new ProviderRegistry(undefined, 100);
+    registry.registerProvider(testProvider);
+    await registry.listAllModels();
+    await delay(110);
+
+    const startedAt = Date.now();
+    const staleModels = await registry.listAllModels();
+    const elapsedMs = Date.now() - startedAt;
+
+    assert.ok(elapsedMs < 60, `stale read took ${elapsedMs}ms`);
+    assert.equal(staleModels[0]?.id, "test/stale");
+    assert.equal(callCount, 2);
+
+    await delay(140);
+    const freshModels = await registry.listAllModels();
+    assert.equal(freshModels[0]?.id, "test/fresh");
+    assert.equal(callCount, 2);
+});
+
+test("ProviderRegistry bounds slow refreshes and keeps cached models", async () => {
+    let callCount = 0;
+    const testProvider: AIProvider = {
+        id: "test_timeout_provider",
+        name: "Test Timeout Provider",
+        listModels: async () => {
+            callCount++;
+            if (callCount > 1) await delay(300);
+            return [
+                {
+                    id: `test_timeout_provider/${callCount === 1 ? "cached" : "fresh"}`,
+                    object: "model"
+                }
+            ];
+        },
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+
+    const registry = new ProviderRegistry();
+    registry.registerProvider(testProvider);
+    await registry.listAllModels();
+    registry.setModelsFetchTimeoutMs(20);
+
+    const startedAt = Date.now();
+    const models = await registry.listAllModels(undefined, true);
+    const elapsedMs = Date.now() - startedAt;
+
+    assert.ok(elapsedMs < 150, `timed out read took ${elapsedMs}ms`);
+    assert.equal(models[0]?.id, "test/cached");
+    assert.equal(callCount, 2);
+});
+
+test("ProviderRegistry coalesces concurrent forced refreshes", async () => {
+    let callCount = 0;
+    const pending: Array<() => void> = [];
+    const testProvider: AIProvider = {
+        id: "test_forced_refresh_provider",
+        name: "Test Forced Refresh Provider",
+        listModels: async () => {
+            callCount++;
+            if (callCount > 1) {
+                await new Promise<void>((resolve) => {
+                    pending.push(resolve);
+                });
+            }
+            return [{ id: "test_forced_refresh_provider/model", object: "model" }];
+        },
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+
+    const registry = new ProviderRegistry();
+    registry.registerProvider(testProvider);
+    await registry.listAllModels();
+
+    const firstRefresh = registry.listAllModels(undefined, true);
+    const secondRefresh = registry.listAllModels(undefined, true);
+    await delay(10);
+
+    assert.equal(callCount, 2);
+    pending.forEach((resolve) => resolve());
+    await Promise.all([firstRefresh, secondRefresh]);
+    assert.equal(callCount, 2);
 });


### PR DESCRIPTION
## Problem

The reported issue was:

> `/v1/models` responds very slowly.

The endpoint was synchronously discovering models from every active provider connection before sending a response. With multiple accounts configured, request latency was determined by the slowest upstream provider. A client `Cache-Control: no-cache` header or explicit refresh also forced another full discovery fan-out.

This was not limited to one provider. Different providers have different network and authentication costs, but they all pass through the same registry path. Some providers perform multiple upstream operations before returning their model list; others can hang or fail without a bounded timeout.

## What changed

- Added an aggregate last-known model snapshot in the shared provider registry.
- Normal `/v1/models` requests return the available snapshot immediately.
- Stale snapshots trigger background refresh instead of blocking the request.
- Coalesced concurrent refreshes into one shared operation to prevent duplicate upstream calls.
- Limited background discovery to four providers at a time.
- Added a five-second timeout per provider model-discovery call.
- Added a failure cooldown and stale per-provider fallback so one unhealthy provider does not delay or erase healthy models.
- Added refresh-generation protection so provider additions/removals cannot publish an outdated snapshot.
- Changed `Cache-Control: no-cache` and `no-store` handling to background revalidation.
- Kept explicit `refresh=1` and `force=1` support, with bounded waiting.
- Start model discovery after the API server starts so the registry is warm without delaying server startup.

## Provider scope

This fix applies to all active gateway providers and custom provider connections using the shared registry, including OpenAI-compatible providers, OAuth providers, Anthropic-compatible providers, Antigravity, Codex, Qoder, and multi-account setups.

Qoder is not treated as a special case. Its credential exchange and model discovery now run through the same bounded background refresh as every other provider.

## Behavior after this change

- Warm requests no longer wait for every provider's upstream model endpoint.
- A slow or unavailable provider does not block the whole model list.
- Existing model aliases, provider prefixes, deduplication, and provider filters are preserved.
- Immediately after a full restart, the first cold request may briefly return the current snapshot or an empty list while discovery completes; later requests use the warmed snapshot.

## Verification

- Root `pnpm test`: passed
- API suite: 56/56 tests passed
- Provider registry suite: 13/13 tests passed
- Root `pnpm build`: passed for all 9 packages
- `git diff --check`: passed

The `docs/` directory was intentionally excluded from the commit.