### PR TITLE
fix(web): unbreak dashboard build + make first-run admin setup understandable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 11
+              # No explicit version: pnpm/action-setup reads the
+              # `packageManager` field from package.json (pnpm@11.20.0).
+              # Pinning `version: 11` here conflicts with package.json and
+              # makes the action fail with "Multiple versions of pnpm specified".
 
             - name: Setup Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4

--- a/apps/api/src/routes/v1/admin.ts
+++ b/apps/api/src/routes/v1/admin.ts
@@ -76,7 +76,14 @@ export function createAdminRoute(options: AdminRouteOptions = {}): Hono {
 
     route.get("/admin/status", (c) => {
         const authenticated = verifyAdminSession(store, getCookie(c, ADMIN_SESSION_COOKIE), now());
-        return ok(c, { setupRequired: !store.hasAdminAccount(), authenticated });
+        const address = getClientAddress(c);
+        const configuredSetupToken = getSetupToken();
+        return ok(c, {
+            setupRequired: !store.hasAdminAccount(),
+            authenticated,
+            setupTokenConfigured: Boolean(configuredSetupToken),
+            clientIsLoopback: isLoopbackAddress(address)
+        });
     });
 
     route.post("/admin/setup", async (c) => {

--- a/apps/api/tests/admin-auth-route.test.ts
+++ b/apps/api/tests/admin-auth-route.test.ts
@@ -32,7 +32,32 @@ test("admin status reports setup and authentication state", async () => {
 
     const initial = await app.request("/v1/admin/status");
     assert.equal(initial.status, 200);
-    assert.deepEqual(await initial.json(), { setupRequired: true, authenticated: false });
+    assert.deepEqual(await initial.json(), {
+        setupRequired: true,
+        authenticated: false,
+        setupTokenConfigured: false,
+        clientIsLoopback: false
+    });
+});
+
+test("admin status reports loopback and setup token configuration", async () => {
+    const local = createTestApp({ address: "127.0.0.1" });
+    const localStatus = await local.app.request("/v1/admin/status");
+    assert.deepEqual(await localStatus.json(), {
+        setupRequired: true,
+        authenticated: false,
+        setupTokenConfigured: false,
+        clientIsLoopback: true
+    });
+
+    const remote = createTestApp({ address: "192.168.1.10", setupToken: "setup-secret" });
+    const remoteStatus = await remote.app.request("/v1/admin/status");
+    assert.deepEqual(await remoteStatus.json(), {
+        setupRequired: true,
+        authenticated: false,
+        setupTokenConfigured: true,
+        clientIsLoopback: false
+    });
 });
 
 test("local setup creates an account and establishes a session", async () => {
@@ -54,7 +79,12 @@ test("local setup creates an account and establishes a session", async () => {
     const status = await app.request("/v1/admin/status", {
         headers: { Cookie: getSessionCookie(setup) }
     });
-    assert.deepEqual(await status.json(), { setupRequired: false, authenticated: true });
+    assert.deepEqual(await status.json(), {
+        setupRequired: false,
+        authenticated: true,
+        setupTokenConfigured: false,
+        clientIsLoopback: true
+    });
 });
 
 test("remote setup requires the configured one-time setup token", async () => {
@@ -118,7 +148,12 @@ test("login and logout manage the admin session", async () => {
     assert.equal(logout.status, 204);
 
     const status = await app.request("/v1/admin/status", { headers: { Cookie: cookie } });
-    assert.deepEqual(await status.json(), { setupRequired: false, authenticated: false });
+    assert.deepEqual(await status.json(), {
+        setupRequired: false,
+        authenticated: false,
+        setupTokenConfigured: false,
+        clientIsLoopback: true
+    });
 });
 
 test("repeated failed logins are throttled", async () => {

--- a/apps/web/src/components/auth/AdminAuthGate.tsx
+++ b/apps/web/src/components/auth/AdminAuthGate.tsx
@@ -8,19 +8,30 @@ import { Input } from "@/components/ui/input";
 interface AdminStatus {
     setupRequired: boolean;
     authenticated: boolean;
+    setupTokenConfigured: boolean;
+    clientIsLoopback: boolean;
 }
 
 interface AdminAuthFormProps {
     setupRequired: boolean;
+    setupTokenConfigured: boolean;
+    clientIsLoopback: boolean;
     onAuthenticated: () => void;
 }
 
-function AdminAuthForm({ setupRequired, onAuthenticated }: AdminAuthFormProps) {
+function AdminAuthForm({
+    setupRequired,
+    setupTokenConfigured,
+    clientIsLoopback,
+    onAuthenticated
+}: AdminAuthFormProps) {
     const [password, setPassword] = useState("");
     const [confirmation, setConfirmation] = useState("");
     const [setupToken, setSetupToken] = useState("");
     const [error, setError] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const remoteSetupLocked = setupRequired && !clientIsLoopback && !setupTokenConfigured;
 
     async function handleSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -91,19 +102,42 @@ function AdminAuthForm({ setupRequired, onAuthenticated }: AdminAuthFormProps) {
                                         required
                                     />
                                 </label>
-                                <label className="flex flex-col gap-1.5 text-xs font-medium">
-                                    Remote setup token
-                                    <Input
-                                        type="password"
-                                        autoComplete="off"
-                                        value={setupToken}
-                                        onChange={(event) => setSetupToken(event.target.value)}
-                                        placeholder="Only needed outside localhost"
-                                    />
-                                    <span className="text-[11px] font-normal text-muted-foreground">
-                                        Leave empty when opening SRouter on the same machine.
-                                    </span>
-                                </label>
+
+                                {clientIsLoopback ? (
+                                    <p className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-[11px] font-normal text-emerald-600 dark:text-emerald-400">
+                                        You are on the server machine — no setup token needed.
+                                    </p>
+                                ) : remoteSetupLocked ? (
+                                    <p className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-[11px] font-normal text-destructive">
+                                        Remote setup is not enabled on this server. Ask your server
+                                        administrator to configure the{" "}
+                                        <code className="rounded bg-destructive/10 px-1 py-0.5 font-mono text-[10px]">
+                                            SROUTER_SETUP_TOKEN
+                                        </code>{" "}
+                                        environment variable, or open SRouter from the server
+                                        machine to finish setup.
+                                    </p>
+                                ) : (
+                                    <>
+                                        <label className="flex flex-col gap-1.5 text-xs font-medium">
+                                            Setup token
+                                            <Input
+                                                type="password"
+                                                autoComplete="off"
+                                                value={setupToken}
+                                                onChange={(event) =>
+                                                    setSetupToken(event.target.value)
+                                                }
+                                                placeholder="Provided by your server administrator"
+                                            />
+                                            <span className="text-[11px] font-normal text-muted-foreground">
+                                                This server requires a setup token for first-time
+                                                setup from outside the server machine. Ask your
+                                                server administrator for it.
+                                            </span>
+                                        </label>
+                                    </>
+                                )}
                             </>
                         ) : null}
 
@@ -172,6 +206,8 @@ export function AdminAuthGate({ children }: { children: ReactNode }) {
         return (
             <AdminAuthForm
                 setupRequired={statusQuery.data.setupRequired}
+                setupTokenConfigured={statusQuery.data.setupTokenConfigured}
+                clientIsLoopback={statusQuery.data.clientIsLoopback}
                 onAuthenticated={() => void statusQuery.refetch()}
             />
         );

--- a/apps/web/src/routes/providers/$providerId.tsx
+++ b/apps/web/src/routes/providers/$providerId.tsx
@@ -403,6 +403,7 @@ function ProviderDetailPage() {
                                 key={m.id}
                                 model={m}
                                 copied={copied === m.id}
+                                onCopy={(id) => void copy(id)}
                                 onDelete={handleDeleteModel}
                             />
                         ))}


### PR DESCRIPTION
Two small web fixes, one PR:

## 1. Fix: dashboard build is broken on main (TS2741)

`ProviderModelCard` now requires an `onCopy` prop (copy-model-ID button), but the card view on the provider page never passes it — only the table view does. Any Docker/deploy build of `main` fails at `pnpm build` → `web#build` with:

```
apps/web/src/routes/providers/$providerId.tsx(402,30): error TS2741:
Property 'onCopy' is missing ... but required in type 'ProviderModelCardProps'.
```

**Fix:** pass `onCopy={(id) => void copy(id)}` to the card view — one line, matches the table view's usage.

## 2. Feat: first-run admin setup that non-technical users can actually follow

The setup screen always shows a "Remote setup token" field with developer-facing hints ("Leave empty when opening SRouter on the same machine"), and a remote user gets a cryptic 403 if the server has no token configured — with no explanation of what a token is or where to get one.

**Backend:** `GET /v1/admin/status` now also reports `setupTokenConfigured` (whether the server has `SROUTER_SETUP_TOKEN` set — boolean only, never leaks the token) and `clientIsLoopback`, so the UI knows the setup context instead of guessing.

**Frontend:** `AdminAuthGate` adapts based on that context:
- **Loopback client** → token field hidden, friendly "you're on the server machine — no token needed" note.
- **Remote + token configured** → token field with plain-language "ask your server administrator for it" guidance.
- **Remote + no token configured** → clear explanation instead of a form that can never succeed (no mystery 403).

**Tests:** admin route tests updated for the new status shape + new coverage for loopback/token-configured reporting.

## Verification

- `pnpm --filter api exec tsx --test --test-concurrency=1 tests/admin-auth-route.test.ts` → 7/7 pass
- Full admin suite (route/store/service/middleware) → 15/15 pass
- `tsc -p apps/web/tsconfig.json --noEmit` → clean
- Both changes verified against the live Coolify deployment (fork branch) before opening this PR
