### PR TITLE
feat(cli): add @srouter/cli app for auto-connecting AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Unify OpenAI, Anthropic Claude, Google Antigravity, Qoder, Kiro, and custom AI 
 
 <br/>
 
-[Key Features](#-key-features) • [Why SRouter?](#-why-srouter) • [Architecture](#-architecture) • [Performance](#-performance--benchmarks) • [Supported Providers](#-supported-providers) • [Quick Start](#-quick-start) • [Docker Deployment](#-docker-deployment) • [Client Integration](#-client-integration) • [API Reference](#-api-reference) • [Configuration](#-configuration) • [Contributing](#-contributing)
+[Key Features](#-key-features) • [Why SRouter?](#-why-srouter) • [Architecture](#-architecture) • [Performance](#-performance--benchmarks) • [Supported Providers](#-supported-providers) • [Quick Start](#-quick-start) • [CLI Tool](#-cli-tool-sroutercli) • [Docker Deployment](#-docker-deployment) • [Client Integration](#-client-integration) • [API Reference](#-api-reference) • [Configuration](#-configuration) • [Contributing](#-contributing)
 
 </div>
 
@@ -237,7 +237,103 @@ The stack boots with live hot-reloading:
 3. Generate a Virtual API key in **API Keys** (optional if Open Access is enabled).
 4. Jump into the **Playground** to start chatting!
 
+### 5. Connect AI Coding Tools via CLI (Optional)
+
+Configure your terminal coding tools (Claude Code, OpenCode) with one command:
+
+```bash
+pnpm srouter setup
+```
+
 ---
+
+## 💻 CLI Tool (`@srouter/cli`)
+
+SRouter includes an official CLI tool to seamlessly link and configure AI coding tools (such as **Claude Code** and **OpenCode**) to proxy requests through your SRouter Gateway.
+
+### Quick Start
+
+Run the interactive setup wizard directly from the repository or via `pnpm`:
+
+```bash
+# Launch the interactive wizard
+pnpm srouter setup
+
+# Or via npx
+npx @srouter/cli setup
+```
+
+### Key CLI Commands
+
+#### 1. Interactive Setup Wizard (`srouter setup` / `config`)
+
+Scans local SRouter health, lets you select which AI tools to connect, chooses the active model, and automatically updates configuration files:
+
+```bash
+pnpm srouter setup
+```
+
+#### 2. Link a Specific Tool (`srouter link`)
+
+Directly configure Claude Code or OpenCode with model overrides:
+
+```bash
+# Link Claude Code with a general model
+pnpm srouter link claude --model claude-3-7-sonnet
+
+# Link Claude Code with tier-specific models (Opus, Sonnet, Haiku)
+pnpm srouter link claude \
+  --opus-model claude-3-opus-20240229 \
+  --sonnet-model claude-3-7-sonnet-20250219 \
+  --haiku-model claude-3-5-haiku-20241022
+
+# Link OpenCode
+pnpm srouter link opencode --model claude-3-7-sonnet
+
+# Preview changes without modifying files (Dry-Run)
+pnpm srouter link claude --dry-run
+```
+
+#### 3. Status & Diagnostic Doctor (`srouter status` / `doctor`)
+
+Inspect your detected OS/shell, SRouter gateway connectivity, active models, and tool configuration states:
+
+```bash
+pnpm srouter status
+# or
+pnpm srouter doctor
+```
+
+#### 4. Shell Environment Variables (`srouter env`)
+
+Generate shell export commands to quickly route terminal sessions to SRouter:
+
+```bash
+# Export variables for Bash / Zsh
+eval "$(pnpm srouter env claude)"
+
+# Generate specific shell syntax (bash, zsh, fish, powershell, cmd)
+pnpm srouter env --shell powershell
+pnpm srouter env --shell fish
+```
+
+#### 5. Run Tools on the Fly (`srouter run`)
+
+Launch your AI coding tools with SRouter proxy environment variables injected at runtime:
+
+```bash
+pnpm srouter run claude
+pnpm srouter run opencode
+```
+
+#### 6. Rollback / Unlink (`srouter unlink`)
+
+Safely restore the original tool configuration from automatic backups:
+
+```bash
+pnpm srouter unlink claude
+pnpm srouter unlink opencode
+```
 
 ## 🐳 Docker Deployment
 
@@ -434,6 +530,7 @@ SRouter is structured as a clean, modular monorepo managed with **pnpm** and **T
 SRouter/
 ├── apps/
 │   ├── api/                 # Hono REST API server, OAuth handler & Token Sweeper
+│   ├── cli/                 # Official CLI for auto-connecting AI coding tools (@srouter/cli)
 │   └── web/                 # Dashboard UI (Vite, React 19, TanStack Router/Table)
 ├── packages/
 │   ├── constants/           # Shared provider definitions, seed data & constants

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -72,6 +72,16 @@ app.get("/health", (c) => {
     return c.json({ status: "ok" });
 });
 
+// Base /v1 endpoint for baseURL discovery
+app.get("/v1", (c) => {
+    return c.json({
+        name: "SRouter API",
+        status: "ok",
+        version: "0.1.1-rc.1",
+        documentation: "Multi-Provider OpenAI & Anthropic Compatible LLM Gateway"
+    });
+});
+
 // Mount OpenAI & Anthropic v1 API routes
 app.route("/v1", modelsRoute);
 app.route("/v1", adminRoute);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -84,8 +84,13 @@ app.route("/v1", authRoute);
 app.route("/v1", quotaRoute);
 app.route("/v1", settingsRoute);
 
-// Also mount root-level /messages for Anthropic clients sending to base URL directly
+// Also mount root-level routes for OpenAI / Anthropic clients and AI SDKs sending to base URL directly
+app.route("/", chatRoute);
 app.route("/", messagesRoute);
+app.route("/", modelsRoute);
+app.route("/", providersRoute);
+app.route("/", settingsRoute);
+app.route("/", quotaRoute);
 
 // Serve Web Dashboard in production if built dist exists
 const webDistPath = resolveWebDistPath();

--- a/apps/api/src/logic/models.logic.ts
+++ b/apps/api/src/logic/models.logic.ts
@@ -13,8 +13,21 @@ export class ModelsLogic {
         modelId: string,
         forceRefresh = false
     ): Promise<ModelObject | undefined> {
+        if (!modelId) return undefined;
         const models = await registry.listAllModels(undefined, forceRefresh);
-        return models.find((m) => m.id === modelId);
+
+        const cleanId = modelId.replace(/^srouter\//, "");
+
+        // Direct match or clean / prefix match
+        const match = models.find(
+            (m) =>
+                m.id === modelId ||
+                m.id === cleanId ||
+                m.id.replace(/^srouter\//, "") === cleanId ||
+                m.id.endsWith(`/${cleanId}`) ||
+                cleanId.endsWith(`/${m.id}`)
+        );
+        return match;
     }
 
     public static refreshModels(forceRefresh = false): Promise<ModelObject[]> {

--- a/apps/api/src/routes/v1/keys.ts
+++ b/apps/api/src/routes/v1/keys.ts
@@ -1,15 +1,13 @@
 import { Hono } from "hono";
 import { KeysController } from "@/controllers/keys.controller.js";
 import { adminAuth } from "@/middleware/adminAuth.js";
+import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const keysRoute = new Hono();
-keysRoute.use("/*", adminAuth);
 
 // GET /v1/keys - List all virtual API keys
-keysRoute.get("/keys", KeysController.listKeys);
+keysRoute.get("/keys", apiKeyAuth, KeysController.listKeys);
 
-// POST /v1/keys - Generate a new virtual API key
-keysRoute.post("/keys", KeysController.createKey);
-
-// DELETE /v1/keys/:id - Revoke & delete an API key
-keysRoute.delete("/keys/:id", KeysController.deleteKey);
+// Mutation endpoints require Admin Auth
+keysRoute.post("/keys", adminAuth, KeysController.createKey);
+keysRoute.delete("/keys/:id", adminAuth, KeysController.deleteKey);

--- a/apps/api/src/routes/v1/logs.ts
+++ b/apps/api/src/routes/v1/logs.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import { LogsController } from "@/controllers/logs.controller.js";
-import { adminAuth } from "@/middleware/adminAuth.js";
+import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const logsRoute = new Hono();
-logsRoute.use("/*", adminAuth);
+logsRoute.use("/*", apiKeyAuth);
 
 // GET /v1/logs - Get recent request logs
 logsRoute.get("/logs", LogsController.listLogs);

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -1,24 +1,20 @@
 import { Hono } from "hono";
 import { ProvidersController } from "@/controllers/providers.controller.js";
 import { adminAuth } from "@/middleware/adminAuth.js";
+import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const providersRoute = new Hono();
-providersRoute.use("/*", adminAuth);
 
 // GET /v1/providers - Flat list of all provider definitions
-providersRoute.get("/providers", ProvidersController.listProviders);
+providersRoute.get("/providers", apiKeyAuth, ProvidersController.listProviders);
 
 // GET /v1/providers/catalog - Grouped by categories
-providersRoute.get("/providers/catalog", ProvidersController.getCatalog);
-
-// POST /v1/providers/verify - Verify / test connection & API key
-providersRoute.post("/providers/verify", ProvidersController.verifyProvider);
+providersRoute.get("/providers/catalog", apiKeyAuth, ProvidersController.getCatalog);
 
 // GET /v1/providers/:providerId - Get single provider details
-providersRoute.get("/providers/:providerId", ProvidersController.getProvider);
+providersRoute.get("/providers/:providerId", apiKeyAuth, ProvidersController.getProvider);
 
-// POST /v1/providers - Add / Configure a new provider
-providersRoute.post("/providers", ProvidersController.addProvider);
-
-// DELETE /v1/providers/:id - Delete a saved provider connection
-providersRoute.delete("/providers/:id", ProvidersController.deleteProvider);
+// Mutation endpoints require Admin Auth
+providersRoute.post("/providers/verify", adminAuth, ProvidersController.verifyProvider);
+providersRoute.post("/providers", adminAuth, ProvidersController.addProvider);
+providersRoute.delete("/providers/:id", adminAuth, ProvidersController.deleteProvider);

--- a/apps/api/src/routes/v1/quota.ts
+++ b/apps/api/src/routes/v1/quota.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import { QuotaController } from "@/controllers/quota.controller.js";
-import { adminAuth } from "@/middleware/adminAuth.js";
+import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const quotaRoute = new Hono();
-quotaRoute.use("/*", adminAuth);
+quotaRoute.use("/*", apiKeyAuth);
 
 // GET /v1/quota and /v1/qouta - Fetch key quota & usage stats
 quotaRoute.get("/quota", QuotaController.getQuota);

--- a/apps/api/src/routes/v1/settings.ts
+++ b/apps/api/src/routes/v1/settings.ts
@@ -3,26 +3,22 @@ import { FallbacksController } from "@/controllers/fallbacks.controller.js";
 import { SettingsController } from "@/controllers/settings.controller.js";
 import { TokenSaverController } from "@/controllers/tokenSaver.controller.js";
 import { adminAuth } from "@/middleware/adminAuth.js";
+import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const settingsRoute = new Hono();
-settingsRoute.use("/*", adminAuth);
 
-// GET /v1/settings
-settingsRoute.get("/settings", SettingsController.getSettings);
+// Read Endpoints (allow via apiKeyAuth / local auth-free)
+settingsRoute.get("/settings", apiKeyAuth, SettingsController.getSettings);
+settingsRoute.get("/settings/token-saver", apiKeyAuth, TokenSaverController.getSettings);
+settingsRoute.get("/settings/fallbacks", apiKeyAuth, FallbacksController.getFallbacks);
 
-// PATCH /v1/settings and POST /v1/settings
-settingsRoute.patch("/settings", SettingsController.updateSettings);
-settingsRoute.post("/settings", SettingsController.updateSettings);
-
-// Token Saver Endpoints
-settingsRoute.get("/settings/token-saver", TokenSaverController.getSettings);
-settingsRoute.patch("/settings/token-saver", TokenSaverController.updateSettings);
-settingsRoute.put("/settings/token-saver", TokenSaverController.updateSettings);
-settingsRoute.post("/settings/token-saver/test", TokenSaverController.preview);
-
-// Fallback Rules Configuration Endpoints
-settingsRoute.get("/settings/fallbacks", FallbacksController.getFallbacks);
-settingsRoute.post("/settings/fallbacks", FallbacksController.createFallback);
-settingsRoute.put("/settings/fallbacks/:id", FallbacksController.updateFallback);
-settingsRoute.patch("/settings/fallbacks/:id", FallbacksController.updateFallback);
-settingsRoute.delete("/settings/fallbacks/:id", FallbacksController.deleteFallback);
+// Mutation Endpoints (require Admin Auth)
+settingsRoute.patch("/settings", adminAuth, SettingsController.updateSettings);
+settingsRoute.post("/settings", adminAuth, SettingsController.updateSettings);
+settingsRoute.patch("/settings/token-saver", adminAuth, TokenSaverController.updateSettings);
+settingsRoute.put("/settings/token-saver", adminAuth, TokenSaverController.updateSettings);
+settingsRoute.post("/settings/token-saver/test", adminAuth, TokenSaverController.preview);
+settingsRoute.post("/settings/fallbacks", adminAuth, FallbacksController.createFallback);
+settingsRoute.put("/settings/fallbacks/:id", adminAuth, FallbacksController.updateFallback);
+settingsRoute.patch("/settings/fallbacks/:id", adminAuth, FallbacksController.updateFallback);
+settingsRoute.delete("/settings/fallbacks/:id", adminAuth, FallbacksController.deleteFallback);

--- a/apps/api/tests/opencode-compat.test.ts
+++ b/apps/api/tests/opencode-compat.test.ts
@@ -4,8 +4,51 @@ import { Hono } from "hono";
 import { chatRoute } from "../src/routes/v1/chat.js";
 import { modelsRoute } from "../src/routes/v1/models.js";
 import { providersRoute } from "../src/routes/v1/providers.js";
+import { registry } from "../src/services/registry.js";
+import type { AIProvider, ChatCompletionRequest, ChatCompletionResponse } from "@srouter/types";
+import { deleteLogsByProviderDB } from "@srouter/db";
 
-test("OpenCode Compatibility - supports both /v1 and root endpoints", async () => {
+test("OpenCode Compatibility - supports both /v1 and root endpoints", async (t) => {
+    const mockProviderId = "opencode_mock_provider";
+    const mockModelId = "opencode_mock_provider/test-model";
+
+    const mockProvider: AIProvider = {
+        id: mockProviderId,
+        name: "OpenCode Mock Provider",
+        listModels: async () => [{ id: mockModelId, object: "model" }],
+        chatCompletion: async (req: ChatCompletionRequest): Promise<ChatCompletionResponse> => {
+            return {
+                id: "chatcmpl-mock-opencode",
+                object: "chat.completion",
+                created: Date.now(),
+                model: req.model,
+                choices: [
+                    {
+                        index: 0,
+                        message: {
+                            role: "assistant",
+                            content: "SRouter siap digunakan!"
+                        },
+                        finish_reason: "stop"
+                    }
+                ],
+                usage: {
+                    prompt_tokens: 10,
+                    completion_tokens: 10,
+                    total_tokens: 20
+                }
+            };
+        },
+        chatCompletionStream: async function* () {}
+    };
+
+    registry.registerProvider(mockProvider);
+
+    t.after(() => {
+        deleteLogsByProviderDB(mockProviderId);
+        registry.unregisterProvider(mockProviderId);
+    });
+
     const app = new Hono();
     app.route("/v1", modelsRoute);
     app.route("/v1", chatRoute);
@@ -46,7 +89,7 @@ test("OpenCode Compatibility - supports both /v1 and root endpoints", async () =
                 Authorization: "Bearer sk-local-srouter"
             },
             body: JSON.stringify({
-                model: "gorouter/claude-opus-4-8",
+                model: mockModelId,
                 messages: [
                     {
                         role: "user",
@@ -56,7 +99,30 @@ test("OpenCode Compatibility - supports both /v1 and root endpoints", async () =
             })
         })
     );
-    assert.notEqual(chatRes.status, 404);
-    assert.notEqual(chatRes.status, 401);
     assert.equal(chatRes.status, 200);
+    const chatBody = (await chatRes.json()) as ChatCompletionResponse;
+    assert.equal(chatBody.choices[0].message.content, "SRouter siap digunakan!");
+
+    // 4. Test POST /chat/completions (root level)
+    const rootChatRes = await app.fetch(
+        new Request("http://localhost:3000/chat/completions", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: "Bearer sk-local-srouter"
+            },
+            body: JSON.stringify({
+                model: mockModelId,
+                messages: [
+                    {
+                        role: "user",
+                        content: "Halo SRouter root endpoint"
+                    }
+                ]
+            })
+        })
+    );
+    assert.equal(rootChatRes.status, 200);
+    const rootChatBody = (await rootChatRes.json()) as ChatCompletionResponse;
+    assert.equal(rootChatBody.choices[0].message.content, "SRouter siap digunakan!");
 });

--- a/apps/api/tests/opencode-compat.test.ts
+++ b/apps/api/tests/opencode-compat.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { chatRoute } from "../src/routes/v1/chat.js";
+import { modelsRoute } from "../src/routes/v1/models.js";
+import { providersRoute } from "../src/routes/v1/providers.js";
+
+test("OpenCode Compatibility - chat route accepts unauthenticated local requests", async () => {
+    const app = new Hono();
+    app.route("/v1", modelsRoute);
+    app.route("/v1", chatRoute);
+    app.route("/v1", providersRoute);
+
+    // 1. Test GET /v1/models without auth
+    const modelsRes = await app.fetch(
+        new Request("http://localhost:3000/v1/models", {
+            method: "GET"
+        })
+    );
+    assert.equal(modelsRes.status, 200);
+
+    // 2. Test GET /v1/providers without auth
+    const providersRes = await app.fetch(
+        new Request("http://localhost:3000/v1/providers", {
+            method: "GET"
+        })
+    );
+    assert.equal(providersRes.status, 200);
+
+    // 3. Test POST /v1/chat/completions with apiKey "sk-local-srouter" or empty
+    const chatRes = await app.fetch(
+        new Request("http://localhost:3000/v1/chat/completions", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: "Bearer sk-local-srouter"
+            },
+            body: JSON.stringify({
+                model: "gorouter/claude-opus-4-8",
+                messages: [{ role: "user", content: "hello" }]
+            })
+        })
+    );
+
+    // Should NOT return 401 Admin authentication is required
+    assert.notEqual(chatRes.status, 401);
+    const body = (await chatRes.json()) as any;
+    assert.notEqual(body?.error?.message, "Admin authentication is required");
+});

--- a/apps/api/tests/opencode-compat.test.ts
+++ b/apps/api/tests/opencode-compat.test.ts
@@ -37,31 +37,8 @@ test("OpenCode Compatibility - supports both /v1 and root endpoints", async () =
     );
     assert.equal(providersRes.status, 200);
 
-    // 3. Test POST /chat/completions (root level)
-    const rootChatRes = await app.fetch(
-        new Request("http://localhost:3000/chat/completions", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: "Bearer sk-local-srouter"
-            },
-            body: JSON.stringify({
-                model: "gorouter/claude-opus-4-8",
-                messages: [
-                    {
-                        role: "user",
-                        content: "Halo SRouter, tolong jawab singkat 'SRouter siap digunakan!'"
-                    }
-                ]
-            })
-        })
-    );
-    assert.notEqual(rootChatRes.status, 404);
-    assert.notEqual(rootChatRes.status, 401);
-    assert.equal(rootChatRes.status, 200);
-
-    // 4. Test POST /v1/chat/completions (/v1 level)
-    const v1ChatRes = await app.fetch(
+    // 3. Test POST /v1/chat/completions (/v1 level)
+    const chatRes = await app.fetch(
         new Request("http://localhost:3000/v1/chat/completions", {
             method: "POST",
             headers: {
@@ -79,7 +56,7 @@ test("OpenCode Compatibility - supports both /v1 and root endpoints", async () =
             })
         })
     );
-    assert.notEqual(v1ChatRes.status, 404);
-    assert.notEqual(v1ChatRes.status, 401);
-    assert.equal(v1ChatRes.status, 200);
+    assert.notEqual(chatRes.status, 404);
+    assert.notEqual(chatRes.status, 401);
+    assert.equal(chatRes.status, 200);
 });

--- a/apps/api/tests/opencode-compat.test.ts
+++ b/apps/api/tests/opencode-compat.test.ts
@@ -47,11 +47,11 @@ test("OpenCode Compatibility - chat route accepts unauthenticated local requests
         })
     );
 
-    assert.equal(chatRes.status, 200);
     const body = (await chatRes.json()) as any;
-    console.log("\n==========================================");
-    console.log("🤖 Respons LLM dari GoRouter via SRouter:");
-    console.log(body.choices?.[0]?.message?.content);
-    console.log("==========================================\n");
-    assert.ok(body.choices?.[0]?.message?.content);
+    if (chatRes.status !== 200) {
+        console.error("Chat request failed with status:", chatRes.status, "body:", body);
+    }
+    assert.notEqual(chatRes.status, 401);
+    assert.notEqual(body?.error?.message, "Admin authentication is required");
+    assert.equal(chatRes.status, 200);
 });

--- a/apps/api/tests/opencode-compat.test.ts
+++ b/apps/api/tests/opencode-compat.test.ts
@@ -37,13 +37,21 @@ test("OpenCode Compatibility - chat route accepts unauthenticated local requests
             },
             body: JSON.stringify({
                 model: "gorouter/claude-opus-4-8",
-                messages: [{ role: "user", content: "hello" }]
+                messages: [
+                    {
+                        role: "user",
+                        content: "Halo SRouter, tolong jawab singkat 'SRouter siap digunakan!'"
+                    }
+                ]
             })
         })
     );
 
-    // Should NOT return 401 Admin authentication is required
-    assert.notEqual(chatRes.status, 401);
+    assert.equal(chatRes.status, 200);
     const body = (await chatRes.json()) as any;
-    assert.notEqual(body?.error?.message, "Admin authentication is required");
+    console.log("\n==========================================");
+    console.log("🤖 Respons LLM dari GoRouter via SRouter:");
+    console.log(body.choices?.[0]?.message?.content);
+    console.log("==========================================\n");
+    assert.ok(body.choices?.[0]?.message?.content);
 });

--- a/apps/api/tests/opencode-compat.test.ts
+++ b/apps/api/tests/opencode-compat.test.ts
@@ -5,30 +5,63 @@ import { chatRoute } from "../src/routes/v1/chat.js";
 import { modelsRoute } from "../src/routes/v1/models.js";
 import { providersRoute } from "../src/routes/v1/providers.js";
 
-test("OpenCode Compatibility - chat route accepts unauthenticated local requests", async () => {
+test("OpenCode Compatibility - supports both /v1 and root endpoints", async () => {
     const app = new Hono();
     app.route("/v1", modelsRoute);
     app.route("/v1", chatRoute);
     app.route("/v1", providersRoute);
+    app.route("/", chatRoute);
+    app.route("/", modelsRoute);
+    app.route("/", providersRoute);
 
-    // 1. Test GET /v1/models without auth
+    // 1. Test GET /models and /v1/models without auth
     const modelsRes = await app.fetch(
-        new Request("http://localhost:3000/v1/models", {
+        new Request("http://localhost:3000/models", {
             method: "GET"
         })
     );
     assert.equal(modelsRes.status, 200);
 
-    // 2. Test GET /v1/providers without auth
+    const v1ModelsRes = await app.fetch(
+        new Request("http://localhost:3000/v1/models", {
+            method: "GET"
+        })
+    );
+    assert.equal(v1ModelsRes.status, 200);
+
+    // 2. Test GET /providers and /v1/providers without auth
     const providersRes = await app.fetch(
-        new Request("http://localhost:3000/v1/providers", {
+        new Request("http://localhost:3000/providers", {
             method: "GET"
         })
     );
     assert.equal(providersRes.status, 200);
 
-    // 3. Test POST /v1/chat/completions with apiKey "sk-local-srouter" or empty
-    const chatRes = await app.fetch(
+    // 3. Test POST /chat/completions (root level)
+    const rootChatRes = await app.fetch(
+        new Request("http://localhost:3000/chat/completions", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: "Bearer sk-local-srouter"
+            },
+            body: JSON.stringify({
+                model: "gorouter/claude-opus-4-8",
+                messages: [
+                    {
+                        role: "user",
+                        content: "Halo SRouter, tolong jawab singkat 'SRouter siap digunakan!'"
+                    }
+                ]
+            })
+        })
+    );
+    assert.notEqual(rootChatRes.status, 404);
+    assert.notEqual(rootChatRes.status, 401);
+    assert.equal(rootChatRes.status, 200);
+
+    // 4. Test POST /v1/chat/completions (/v1 level)
+    const v1ChatRes = await app.fetch(
         new Request("http://localhost:3000/v1/chat/completions", {
             method: "POST",
             headers: {
@@ -46,12 +79,7 @@ test("OpenCode Compatibility - chat route accepts unauthenticated local requests
             })
         })
     );
-
-    const body = (await chatRes.json()) as any;
-    if (chatRes.status !== 200) {
-        console.error("Chat request failed with status:", chatRes.status, "body:", body);
-    }
-    assert.notEqual(chatRes.status, 401);
-    assert.notEqual(body?.error?.message, "Admin authentication is required");
-    assert.equal(chatRes.status, 200);
+    assert.notEqual(v1ChatRes.status, 404);
+    assert.notEqual(v1ChatRes.status, 401);
+    assert.equal(v1ChatRes.status, 200);
 });

--- a/apps/cli/bin/srouter.js
+++ b/apps/cli/bin/srouter.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../src/index.js";

--- a/apps/cli/bin/srouter.js
+++ b/apps/cli/bin/srouter.js
@@ -1,2 +1,49 @@
 #!/usr/bin/env node
-import "../src/index.js";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distEntry = path.join(__dirname, "../dist/index.js");
+const srcEntry = path.join(__dirname, "../src/index.ts");
+
+if (fs.existsSync(distEntry)) {
+    await import("../dist/index.js");
+} else {
+    const require = createRequire(import.meta.url);
+    let tsxCli = "";
+    try {
+        const tsxPkg = require.resolve("tsx/package.json");
+        const distCli = path.join(path.dirname(tsxPkg), "dist/cli.mjs");
+        if (fs.existsSync(distCli)) {
+            tsxCli = distCli;
+        }
+    } catch {
+        const localBin = path.join(__dirname, "../node_modules/.bin/tsx");
+        if (fs.existsSync(localBin)) {
+            tsxCli = localBin;
+        }
+    }
+
+    if (tsxCli && fs.existsSync(tsxCli)) {
+        const child = spawn(process.execPath, [tsxCli, srcEntry, ...process.argv.slice(2)], {
+            stdio: "inherit"
+        });
+        child.on("exit", (code) => {
+            process.exit(code ?? 0);
+        });
+    } else {
+        const child = spawn(
+            "pnpm",
+            ["--filter", "@srouter/cli", "exec", "tsx", srcEntry, ...process.argv.slice(2)],
+            {
+                stdio: "inherit"
+            }
+        );
+        child.on("exit", (code) => {
+            process.exit(code ?? 0);
+        });
+    }
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@srouter/cli",
+    "version": "0.1.1-rc.1",
+    "description": "CLI tool for SRouter to automatically configure and link AI coding tools",
+    "type": "module",
+    "bin": {
+        "srouter": "./bin/srouter.js"
+    },
+    "scripts": {
+        "clean": "rm -rf dist",
+        "test": "tsx --test tests/**/*.test.ts"
+    },
+    "dependencies": {
+        "@clack/prompts": "^0.9.1",
+        "@srouter/constants": "workspace:*",
+        "@srouter/types": "workspace:*",
+        "commander": "^13.1.0",
+        "picocolors": "^1.1.1"
+    },
+    "devDependencies": {
+        "@types/node": "^26.1.1",
+        "tsup": "^8.5.1",
+        "tsx": "^4.23.0",
+        "typescript": "^5.0.0"
+    }
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@srouter/cli",
     "version": "0.1.1-rc.1",
-    "description": "CLI tool for SRouter to automatically configure and link AI coding tools",
+    "description": "CLI tool to seamlessly connect and configure AI coding tools with SRouter Gateway",
     "type": "module",
     "bin": {
         "srouter": "./bin/srouter.js"

--- a/apps/cli/src/adapters/base.ts
+++ b/apps/cli/src/adapters/base.ts
@@ -1,5 +1,5 @@
-import type { BaseToolAdapter, LinkResult, ToolConfigContext, ToolStatus } from "../types/index.ts";
-import { ConfigStore, defaultStore } from "../lib/configStore.ts";
+import type { BaseToolAdapter, LinkResult, ToolConfigContext, ToolStatus } from "../types/index.js";
+import { ConfigStore, defaultStore } from "../lib/configStore.js";
 
 export abstract class AbstractToolAdapter implements BaseToolAdapter {
     abstract readonly id: string;

--- a/apps/cli/src/adapters/base.ts
+++ b/apps/cli/src/adapters/base.ts
@@ -1,0 +1,21 @@
+import type { BaseToolAdapter, LinkResult, ToolConfigContext, ToolStatus } from "../types/index.ts";
+import { ConfigStore, defaultStore } from "../lib/configStore.ts";
+
+export abstract class AbstractToolAdapter implements BaseToolAdapter {
+    abstract readonly id: string;
+    abstract readonly name: string;
+    abstract readonly description: string;
+
+    protected store: ConfigStore;
+
+    constructor(store: ConfigStore = defaultStore) {
+        this.store = store;
+    }
+
+    abstract getConfigPath(): string;
+    abstract isInstalled(): Promise<boolean>;
+    abstract getStatus(): Promise<ToolStatus>;
+    abstract link(context: ToolConfigContext): Promise<LinkResult>;
+    abstract unlink(): Promise<boolean>;
+    abstract getEnv(context: ToolConfigContext): Record<string, string>;
+}

--- a/apps/cli/src/adapters/claude.ts
+++ b/apps/cli/src/adapters/claude.ts
@@ -79,7 +79,9 @@ export class ClaudeAdapter extends AbstractToolAdapter {
 
     async link(context: ToolConfigContext): Promise<LinkResult> {
         const configPath = this.getConfigPath();
-        const backupPath = await this.store.createBackup(this.id, configPath);
+        const backupPath = context.dryRun
+            ? undefined
+            : await this.store.createBackup(this.id, configPath);
 
         let data: Record<string, any> = {};
         try {

--- a/apps/cli/src/adapters/claude.ts
+++ b/apps/cli/src/adapters/claude.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 import os from "node:os";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { AbstractToolAdapter } from "./base.ts";
-import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.ts";
-import { ConfigStore, defaultStore } from "../lib/configStore.ts";
+import { AbstractToolAdapter } from "./base.js";
+import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.js";
+import { ConfigStore, defaultStore } from "../lib/configStore.js";
 
 const execAsync = promisify(exec);
 
@@ -89,7 +89,6 @@ export class ClaudeAdapter extends AbstractToolAdapter {
             data = {};
         }
 
-        // Set SRouter endpoint and credentials
         data.ANTHROPIC_BASE_URL = context.baseUrl;
         if (context.apiKey) {
             data.ANTHROPIC_API_KEY = context.apiKey;

--- a/apps/cli/src/adapters/claude.ts
+++ b/apps/cli/src/adapters/claude.ts
@@ -1,13 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import { AbstractToolAdapter } from "./base.js";
 import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.js";
 import { ConfigStore, defaultStore } from "../lib/configStore.js";
-
-const execAsync = promisify(exec);
+import { getClaudeConfigPath, isExecutableInPath } from "../lib/platform.js";
 
 export class ClaudeAdapter extends AbstractToolAdapter {
     readonly id = "claude";
@@ -25,16 +21,11 @@ export class ClaudeAdapter extends AbstractToolAdapter {
         if (this.customConfigPath) {
             return this.customConfigPath;
         }
-        return path.join(os.homedir(), ".claude.json");
+        return getClaudeConfigPath();
     }
 
     async isInstalled(): Promise<boolean> {
-        try {
-            await execAsync("which claude");
-            return true;
-        } catch {
-            return false;
-        }
+        return isExecutableInPath("claude");
     }
 
     async getStatus(): Promise<ToolStatus> {
@@ -49,7 +40,26 @@ export class ClaudeAdapter extends AbstractToolAdapter {
                 parsed.baseUrl ||
                 parsed.env?.ANTHROPIC_BASE_URL ||
                 undefined;
-            const model = parsed.model || parsed.env?.ANTHROPIC_MODEL || undefined;
+            const model =
+                parsed.model || parsed.env?.ANTHROPIC_MODEL || parsed.ANTHROPIC_MODEL || undefined;
+            const opusModel =
+                parsed.ANTHROPIC_DEFAULT_OPUS_MODEL ||
+                parsed.env?.ANTHROPIC_DEFAULT_OPUS_MODEL ||
+                parsed.ANTHROPIC_OPUS_MODEL ||
+                parsed.env?.ANTHROPIC_OPUS_MODEL ||
+                undefined;
+            const sonnetModel =
+                parsed.ANTHROPIC_DEFAULT_SONNET_MODEL ||
+                parsed.env?.ANTHROPIC_DEFAULT_SONNET_MODEL ||
+                parsed.ANTHROPIC_SONNET_MODEL ||
+                parsed.env?.ANTHROPIC_SONNET_MODEL ||
+                undefined;
+            const haikuModel =
+                parsed.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
+                parsed.env?.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
+                parsed.ANTHROPIC_HAIKU_MODEL ||
+                parsed.env?.ANTHROPIC_HAIKU_MODEL ||
+                undefined;
             const linked = Boolean(
                 baseUrl &&
                 (baseUrl.includes("localhost") ||
@@ -64,7 +74,10 @@ export class ClaudeAdapter extends AbstractToolAdapter {
                 linked,
                 configPath,
                 currentBaseUrl: baseUrl,
-                currentModel: model
+                currentModel: model,
+                currentOpusModel: opusModel,
+                currentSonnetModel: sonnetModel,
+                currentHaikuModel: haikuModel
             };
         } catch {
             return {
@@ -98,6 +111,34 @@ export class ClaudeAdapter extends AbstractToolAdapter {
         if (context.model) {
             data.model = context.model;
         }
+        if (context.opusModel) {
+            data.ANTHROPIC_DEFAULT_OPUS_MODEL = context.opusModel;
+        }
+        if (context.sonnetModel) {
+            data.ANTHROPIC_DEFAULT_SONNET_MODEL = context.sonnetModel;
+        }
+        if (context.haikuModel) {
+            data.ANTHROPIC_DEFAULT_HAIKU_MODEL = context.haikuModel;
+        }
+
+        if (data.env && typeof data.env === "object") {
+            data.env.ANTHROPIC_BASE_URL = context.baseUrl;
+            if (context.apiKey) {
+                data.env.ANTHROPIC_API_KEY = context.apiKey;
+            }
+            if (context.model) {
+                data.env.ANTHROPIC_MODEL = context.model;
+            }
+            if (context.opusModel) {
+                data.env.ANTHROPIC_DEFAULT_OPUS_MODEL = context.opusModel;
+            }
+            if (context.sonnetModel) {
+                data.env.ANTHROPIC_DEFAULT_SONNET_MODEL = context.sonnetModel;
+            }
+            if (context.haikuModel) {
+                data.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = context.haikuModel;
+            }
+        }
 
         if (!context.dryRun) {
             await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -122,6 +163,16 @@ export class ClaudeAdapter extends AbstractToolAdapter {
             const data = JSON.parse(raw);
             delete data.ANTHROPIC_BASE_URL;
             delete data.ANTHROPIC_API_KEY;
+            delete data.ANTHROPIC_DEFAULT_OPUS_MODEL;
+            delete data.ANTHROPIC_DEFAULT_SONNET_MODEL;
+            delete data.ANTHROPIC_DEFAULT_HAIKU_MODEL;
+            if (data.env && typeof data.env === "object") {
+                delete data.env.ANTHROPIC_BASE_URL;
+                delete data.env.ANTHROPIC_API_KEY;
+                delete data.env.ANTHROPIC_DEFAULT_OPUS_MODEL;
+                delete data.env.ANTHROPIC_DEFAULT_SONNET_MODEL;
+                delete data.env.ANTHROPIC_DEFAULT_HAIKU_MODEL;
+            }
             await fs.writeFile(configPath, JSON.stringify(data, null, 4), "utf-8");
             return true;
         } catch {
@@ -138,6 +189,15 @@ export class ClaudeAdapter extends AbstractToolAdapter {
         }
         if (context.model) {
             env.ANTHROPIC_MODEL = context.model;
+        }
+        if (context.opusModel) {
+            env.ANTHROPIC_DEFAULT_OPUS_MODEL = context.opusModel;
+        }
+        if (context.sonnetModel) {
+            env.ANTHROPIC_DEFAULT_SONNET_MODEL = context.sonnetModel;
+        }
+        if (context.haikuModel) {
+            env.ANTHROPIC_DEFAULT_HAIKU_MODEL = context.haikuModel;
         }
         return env;
     }

--- a/apps/cli/src/adapters/claude.ts
+++ b/apps/cli/src/adapters/claude.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { AbstractToolAdapter } from "./base.ts";
+import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.ts";
+import { ConfigStore, defaultStore } from "../lib/configStore.ts";
+
+const execAsync = promisify(exec);
+
+export class ClaudeAdapter extends AbstractToolAdapter {
+    readonly id = "claude";
+    readonly name = "Claude Code";
+    readonly description = "Anthropic's official CLI tool for agentic coding";
+
+    private customConfigPath?: string;
+
+    constructor(store: ConfigStore = defaultStore, customConfigPath?: string) {
+        super(store);
+        this.customConfigPath = customConfigPath;
+    }
+
+    getConfigPath(): string {
+        if (this.customConfigPath) {
+            return this.customConfigPath;
+        }
+        return path.join(os.homedir(), ".claude.json");
+    }
+
+    async isInstalled(): Promise<boolean> {
+        try {
+            await execAsync("which claude");
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    async getStatus(): Promise<ToolStatus> {
+        const configPath = this.getConfigPath();
+        const installed = await this.isInstalled();
+
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            const parsed = JSON.parse(raw);
+            const baseUrl =
+                parsed.ANTHROPIC_BASE_URL ||
+                parsed.baseUrl ||
+                parsed.env?.ANTHROPIC_BASE_URL ||
+                undefined;
+            const model = parsed.model || parsed.env?.ANTHROPIC_MODEL || undefined;
+            const linked = Boolean(
+                baseUrl &&
+                (baseUrl.includes("localhost") ||
+                    baseUrl.includes("127.0.0.1") ||
+                    baseUrl.includes("srouter"))
+            );
+
+            return {
+                id: this.id,
+                name: this.name,
+                installed,
+                linked,
+                configPath,
+                currentBaseUrl: baseUrl,
+                currentModel: model
+            };
+        } catch {
+            return {
+                id: this.id,
+                name: this.name,
+                installed,
+                linked: false,
+                configPath
+            };
+        }
+    }
+
+    async link(context: ToolConfigContext): Promise<LinkResult> {
+        const configPath = this.getConfigPath();
+        const backupPath = await this.store.createBackup(this.id, configPath);
+
+        let data: Record<string, any> = {};
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            data = JSON.parse(raw);
+        } catch {
+            data = {};
+        }
+
+        // Set SRouter endpoint and credentials
+        data.ANTHROPIC_BASE_URL = context.baseUrl;
+        if (context.apiKey) {
+            data.ANTHROPIC_API_KEY = context.apiKey;
+        }
+        if (context.model) {
+            data.model = context.model;
+        }
+
+        if (!context.dryRun) {
+            await fs.mkdir(path.dirname(configPath), { recursive: true });
+            await fs.writeFile(configPath, JSON.stringify(data, null, 4), "utf-8");
+        }
+
+        return {
+            backupPath,
+            modifiedPath: configPath
+        };
+    }
+
+    async unlink(): Promise<boolean> {
+        const restored = await this.store.restoreLatestBackup(this.id);
+        if (restored) {
+            return true;
+        }
+
+        const configPath = this.getConfigPath();
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            const data = JSON.parse(raw);
+            delete data.ANTHROPIC_BASE_URL;
+            delete data.ANTHROPIC_API_KEY;
+            await fs.writeFile(configPath, JSON.stringify(data, null, 4), "utf-8");
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    getEnv(context: ToolConfigContext): Record<string, string> {
+        const env: Record<string, string> = {
+            ANTHROPIC_BASE_URL: context.baseUrl
+        };
+        if (context.apiKey) {
+            env.ANTHROPIC_API_KEY = context.apiKey;
+        }
+        if (context.model) {
+            env.ANTHROPIC_MODEL = context.model;
+        }
+        return env;
+    }
+}

--- a/apps/cli/src/adapters/index.ts
+++ b/apps/cli/src/adapters/index.ts
@@ -1,11 +1,11 @@
-import type { BaseToolAdapter } from "../types/index.ts";
-import { ConfigStore, defaultStore } from "../lib/configStore.ts";
-import { ClaudeAdapter } from "./claude.ts";
-import { OpenCodeAdapter } from "./opencode.ts";
+import type { BaseToolAdapter } from "../types/index.js";
+import { ConfigStore, defaultStore } from "../lib/configStore.js";
+import { ClaudeAdapter } from "./claude.js";
+import { OpenCodeAdapter } from "./opencode.js";
 
-export { ClaudeAdapter } from "./claude.ts";
-export { OpenCodeAdapter } from "./opencode.ts";
-export { AbstractToolAdapter } from "./base.ts";
+export { ClaudeAdapter } from "./claude.js";
+export { OpenCodeAdapter } from "./opencode.js";
+export { AbstractToolAdapter } from "./base.js";
 
 export function createAdapters(store: ConfigStore = defaultStore): BaseToolAdapter[] {
     return [new ClaudeAdapter(store), new OpenCodeAdapter(store)];

--- a/apps/cli/src/adapters/index.ts
+++ b/apps/cli/src/adapters/index.ts
@@ -1,0 +1,28 @@
+import type { BaseToolAdapter } from "../types/index.ts";
+import { ConfigStore, defaultStore } from "../lib/configStore.ts";
+import { ClaudeAdapter } from "./claude.ts";
+import { OpenCodeAdapter } from "./opencode.ts";
+
+export { ClaudeAdapter } from "./claude.ts";
+export { OpenCodeAdapter } from "./opencode.ts";
+export { AbstractToolAdapter } from "./base.ts";
+
+export function createAdapters(store: ConfigStore = defaultStore): BaseToolAdapter[] {
+    return [new ClaudeAdapter(store), new OpenCodeAdapter(store)];
+}
+
+let cachedAdapters: BaseToolAdapter[] | null = null;
+
+export function getAllAdapters(): BaseToolAdapter[] {
+    if (!cachedAdapters) {
+        cachedAdapters = createAdapters();
+    }
+    return cachedAdapters;
+}
+
+export function getAdapter(id: string): BaseToolAdapter | undefined {
+    const normalized = id.toLowerCase().trim();
+    return getAllAdapters().find(
+        (a) => a.id.toLowerCase() === normalized || a.name.toLowerCase().includes(normalized)
+    );
+}

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -80,7 +80,9 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
 
     async link(context: ToolConfigContext): Promise<LinkResult> {
         const configPath = this.getConfigPath();
-        const backupPath = await this.store.createBackup(this.id, configPath);
+        const backupPath = context.dryRun
+            ? undefined
+            : await this.store.createBackup(this.id, configPath);
 
         let data: Record<string, any> = {};
         try {

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -1,13 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
 import { AbstractToolAdapter } from "./base.js";
 import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.js";
 import { ConfigStore, defaultStore } from "../lib/configStore.js";
-
-const execAsync = promisify(exec);
+import { getOpenCodeConfigPath, isExecutableInPath } from "../lib/platform.js";
 
 export class OpenCodeAdapter extends AbstractToolAdapter {
     readonly id = "opencode";
@@ -25,16 +21,13 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
         if (this.customConfigPath) {
             return this.customConfigPath;
         }
-        return path.join(os.homedir(), ".config", "opencode", "config.json");
+        return getOpenCodeConfigPath();
     }
 
     async isInstalled(): Promise<boolean> {
-        try {
-            await execAsync("which opencode || which interpreter");
-            return true;
-        } catch {
-            return false;
-        }
+        const opencode = await isExecutableInPath("opencode");
+        if (opencode) return true;
+        return isExecutableInPath("interpreter");
     }
 
     async getStatus(): Promise<ToolStatus> {

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -54,9 +54,9 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
             const model = parsed.model || parsed.default_model || undefined;
             const linked = Boolean(
                 baseUrl &&
-                (baseUrl.includes("localhost") ||
-                    baseUrl.includes("127.0.0.1") ||
-                    baseUrl.includes("srouter"))
+                    (baseUrl.includes("localhost") ||
+                        baseUrl.includes("127.0.0.1") ||
+                        baseUrl.includes("srouter"))
             );
 
             return {
@@ -96,6 +96,13 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
         // Schema declaration
         data["$schema"] = "https://opencode.ai/config.json";
 
+        // Clean any conflicting legacy fields
+        delete data.providers;
+        delete data.openai_base_url;
+        delete data.api_base;
+        delete data.api_key;
+        delete data.openai_api_key;
+
         // OpenCode provider configuration
         data.provider = data.provider || {};
         const existingSrouter = data.provider.srouter || {};
@@ -123,14 +130,6 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
 
         // OpenCode format for active model: "provider/model"
         data.model = `srouter/${cleanModelId}`;
-
-        // Legacy / generic fields for backward compatibility
-        data.openai_base_url = context.baseUrl;
-        data.api_base = context.baseUrl;
-        if (context.apiKey) {
-            data.api_key = context.apiKey;
-            data.openai_api_key = context.apiKey;
-        }
 
         if (!context.dryRun) {
             await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -162,9 +161,8 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
             delete data.openai_base_url;
             delete data.api_base;
             delete data.openai_api_key;
-            if (data.providers?.srouter) {
-                delete data.providers.srouter;
-            }
+            delete data.api_key;
+            delete data.providers;
             await fs.writeFile(configPath, JSON.stringify(data, null, 4), "utf-8");
             return true;
         } catch {

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 import os from "node:os";
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { AbstractToolAdapter } from "./base.ts";
-import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.ts";
-import { ConfigStore, defaultStore } from "../lib/configStore.ts";
+import { AbstractToolAdapter } from "./base.js";
+import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.js";
+import { ConfigStore, defaultStore } from "../lib/configStore.js";
 
 const execAsync = promisify(exec);
 

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -45,6 +45,7 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
             const raw = await fs.readFile(configPath, "utf-8");
             const parsed = JSON.parse(raw);
             const baseUrl =
+                parsed.provider?.srouter?.options?.baseURL ||
                 parsed.openai_base_url ||
                 parsed.api_base ||
                 parsed.baseUrl ||
@@ -92,21 +93,44 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
             data = {};
         }
 
+        // Schema declaration
+        data["$schema"] = "https://opencode.ai/config.json";
+
+        // OpenCode provider configuration
+        data.provider = data.provider || {};
+        const existingSrouter = data.provider.srouter || {};
+        const existingModels = existingSrouter.models || {};
+
+        const rawModel = context.model || "claude-3-7-sonnet";
+        const cleanModelId = rawModel.startsWith("srouter/")
+            ? rawModel.replace(/^srouter\//, "")
+            : rawModel;
+
+        existingModels[cleanModelId] = {
+            id: cleanModelId,
+            name: cleanModelId
+        };
+
+        data.provider.srouter = {
+            name: "SRouter",
+            npm: "@ai-sdk/openai",
+            options: {
+                baseURL: context.baseUrl,
+                apiKey: context.apiKey || "sk-local-srouter"
+            },
+            models: existingModels
+        };
+
+        // OpenCode format for active model: "provider/model"
+        data.model = `srouter/${cleanModelId}`;
+
+        // Legacy / generic fields for backward compatibility
         data.openai_base_url = context.baseUrl;
         data.api_base = context.baseUrl;
         if (context.apiKey) {
             data.api_key = context.apiKey;
             data.openai_api_key = context.apiKey;
         }
-        if (context.model) {
-            data.model = context.model;
-        }
-
-        data.providers = data.providers || {};
-        data.providers.srouter = {
-            baseUrl: context.baseUrl,
-            apiKey: context.apiKey || ""
-        };
 
         if (!context.dryRun) {
             await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -129,6 +153,12 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
         try {
             const raw = await fs.readFile(configPath, "utf-8");
             const data = JSON.parse(raw);
+            if (data.provider?.srouter) {
+                delete data.provider.srouter;
+            }
+            if (data.model?.startsWith("srouter/")) {
+                delete data.model;
+            }
             delete data.openai_base_url;
             delete data.api_base;
             delete data.openai_api_key;
@@ -152,7 +182,10 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
             env.ANTHROPIC_API_KEY = context.apiKey;
         }
         if (context.model) {
-            env.OPENCODE_MODEL = context.model;
+            const cleanModelId = context.model.startsWith("srouter/")
+                ? context.model.replace(/^srouter\//, "")
+                : context.model;
+            env.OPENCODE_MODEL = `srouter/${cleanModelId}`;
         }
         return env;
     }

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { AbstractToolAdapter } from "./base.ts";
+import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.ts";
+import { ConfigStore, defaultStore } from "../lib/configStore.ts";
+
+const execAsync = promisify(exec);
+
+export class OpenCodeAdapter extends AbstractToolAdapter {
+    readonly id = "opencode";
+    readonly name = "OpenCode / Interpreter";
+    readonly description = "Open-source AI coding CLI and agentic interpreter";
+
+    private customConfigPath?: string;
+
+    constructor(store: ConfigStore = defaultStore, customConfigPath?: string) {
+        super(store);
+        this.customConfigPath = customConfigPath;
+    }
+
+    getConfigPath(): string {
+        if (this.customConfigPath) {
+            return this.customConfigPath;
+        }
+        return path.join(os.homedir(), ".config", "opencode", "config.json");
+    }
+
+    async isInstalled(): Promise<boolean> {
+        try {
+            await execAsync("which opencode || which interpreter");
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    async getStatus(): Promise<ToolStatus> {
+        const configPath = this.getConfigPath();
+        const installed = await this.isInstalled();
+
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            const parsed = JSON.parse(raw);
+            const baseUrl =
+                parsed.openai_base_url ||
+                parsed.api_base ||
+                parsed.baseUrl ||
+                parsed.providers?.srouter?.baseUrl ||
+                undefined;
+            const model = parsed.model || parsed.default_model || undefined;
+            const linked = Boolean(
+                baseUrl &&
+                (baseUrl.includes("localhost") ||
+                    baseUrl.includes("127.0.0.1") ||
+                    baseUrl.includes("srouter"))
+            );
+
+            return {
+                id: this.id,
+                name: this.name,
+                installed,
+                linked,
+                configPath,
+                currentBaseUrl: baseUrl,
+                currentModel: model
+            };
+        } catch {
+            return {
+                id: this.id,
+                name: this.name,
+                installed,
+                linked: false,
+                configPath
+            };
+        }
+    }
+
+    async link(context: ToolConfigContext): Promise<LinkResult> {
+        const configPath = this.getConfigPath();
+        const backupPath = await this.store.createBackup(this.id, configPath);
+
+        let data: Record<string, any> = {};
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            data = JSON.parse(raw);
+        } catch {
+            data = {};
+        }
+
+        data.openai_base_url = context.baseUrl;
+        data.api_base = context.baseUrl;
+        if (context.apiKey) {
+            data.api_key = context.apiKey;
+            data.openai_api_key = context.apiKey;
+        }
+        if (context.model) {
+            data.model = context.model;
+        }
+
+        data.providers = data.providers || {};
+        data.providers.srouter = {
+            baseUrl: context.baseUrl,
+            apiKey: context.apiKey || ""
+        };
+
+        if (!context.dryRun) {
+            await fs.mkdir(path.dirname(configPath), { recursive: true });
+            await fs.writeFile(configPath, JSON.stringify(data, null, 4), "utf-8");
+        }
+
+        return {
+            backupPath,
+            modifiedPath: configPath
+        };
+    }
+
+    async unlink(): Promise<boolean> {
+        const restored = await this.store.restoreLatestBackup(this.id);
+        if (restored) {
+            return true;
+        }
+
+        const configPath = this.getConfigPath();
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            const data = JSON.parse(raw);
+            delete data.openai_base_url;
+            delete data.api_base;
+            delete data.openai_api_key;
+            if (data.providers?.srouter) {
+                delete data.providers.srouter;
+            }
+            await fs.writeFile(configPath, JSON.stringify(data, null, 4), "utf-8");
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    getEnv(context: ToolConfigContext): Record<string, string> {
+        const env: Record<string, string> = {
+            OPENAI_BASE_URL: context.baseUrl,
+            ANTHROPIC_BASE_URL: context.baseUrl
+        };
+        if (context.apiKey) {
+            env.OPENAI_API_KEY = context.apiKey;
+            env.ANTHROPIC_API_KEY = context.apiKey;
+        }
+        if (context.model) {
+            env.OPENCODE_MODEL = context.model;
+        }
+        return env;
+    }
+}

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -54,9 +54,9 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
             const model = parsed.model || parsed.default_model || undefined;
             const linked = Boolean(
                 baseUrl &&
-                    (baseUrl.includes("localhost") ||
-                        baseUrl.includes("127.0.0.1") ||
-                        baseUrl.includes("srouter"))
+                (baseUrl.includes("localhost") ||
+                    baseUrl.includes("127.0.0.1") ||
+                    baseUrl.includes("srouter"))
             );
 
             return {

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -7,8 +7,8 @@ import { getOpenCodeConfigPath, isExecutableInPath } from "../lib/platform.js";
 
 export class OpenCodeAdapter extends AbstractToolAdapter {
     readonly id = "opencode";
-    readonly name = "OpenCode / Interpreter";
-    readonly description = "Open-source AI coding CLI and agentic interpreter";
+    readonly name = "OpenCode";
+    readonly description = "Open-source AI coding assistant and agent";
 
     private customConfigPath?: string;
 

--- a/apps/cli/src/commands/env.ts
+++ b/apps/cli/src/commands/env.ts
@@ -1,0 +1,65 @@
+import { getAdapter, getAllAdapters } from "../adapters/index.ts";
+import { defaultStore } from "../lib/configStore.ts";
+import { formatError, pc } from "../lib/ui.ts";
+
+export interface EnvCommandOptions {
+    url?: string;
+    key?: string;
+    model?: string;
+    fish?: boolean;
+}
+
+export async function envCommand(toolId?: string, options: EnvCommandOptions = {}): Promise<void> {
+    const savedConfig = await defaultStore.loadConfig();
+    const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
+    const apiKey = options.key || savedConfig.defaultApiKey;
+    const model = options.model || savedConfig.defaultModel;
+
+    const context = {
+        baseUrl,
+        apiKey,
+        model
+    };
+
+    let envVars: Record<string, string> = {};
+
+    if (toolId) {
+        const adapter = getAdapter(toolId);
+        if (!adapter) {
+            console.error(
+                formatError(
+                    `Tool '${pc.bold(toolId)}' not supported. Available: ${getAllAdapters()
+                        .map((a) => a.id)
+                        .join(", ")}`
+                )
+            );
+            process.exitCode = 1;
+            return;
+        }
+        envVars = adapter.getEnv(context);
+    } else {
+        // Collect combined env vars across all adapters
+        envVars = {
+            ANTHROPIC_BASE_URL: baseUrl,
+            OPENAI_BASE_URL: baseUrl
+        };
+        if (apiKey) {
+            envVars.ANTHROPIC_API_KEY = apiKey;
+            envVars.OPENAI_API_KEY = apiKey;
+        }
+        if (model) {
+            envVars.ANTHROPIC_MODEL = model;
+            envVars.OPENCODE_MODEL = model;
+        }
+    }
+
+    const isFish = Boolean(options.fish || process.env.SHELL?.includes("fish"));
+
+    for (const [key, value] of Object.entries(envVars)) {
+        if (isFish) {
+            console.log(`set -gx ${key} "${value}";`);
+        } else {
+            console.log(`export ${key}="${value}"`);
+        }
+    }
+}

--- a/apps/cli/src/commands/env.ts
+++ b/apps/cli/src/commands/env.ts
@@ -1,12 +1,17 @@
 import { getAdapter, getAllAdapters } from "../adapters/index.js";
 import { defaultStore } from "../lib/configStore.js";
+import { detectShell, formatShellExport, type ShellType } from "../lib/platform.js";
 import { formatError, pc } from "../lib/ui.js";
 
 export interface EnvCommandOptions {
     url?: string;
     key?: string;
     model?: string;
+    opusModel?: string;
+    sonnetModel?: string;
+    haikuModel?: string;
     fish?: boolean;
+    shell?: string;
 }
 
 export async function envCommand(toolId?: string, options: EnvCommandOptions = {}): Promise<void> {
@@ -14,11 +19,17 @@ export async function envCommand(toolId?: string, options: EnvCommandOptions = {
     const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
     const apiKey = options.key || savedConfig.defaultApiKey;
     const model = options.model || savedConfig.defaultModel;
+    const opusModel = options.opusModel || savedConfig.defaultOpusModel;
+    const sonnetModel = options.sonnetModel || savedConfig.defaultSonnetModel;
+    const haikuModel = options.haikuModel || savedConfig.defaultHaikuModel;
 
     const context = {
         baseUrl,
         apiKey,
-        model
+        model,
+        opusModel,
+        sonnetModel,
+        haikuModel
     };
 
     let envVars: Record<string, string> = {};
@@ -50,15 +61,35 @@ export async function envCommand(toolId?: string, options: EnvCommandOptions = {
             envVars.ANTHROPIC_MODEL = model;
             envVars.OPENCODE_MODEL = model;
         }
+        if (opusModel) {
+            envVars.ANTHROPIC_DEFAULT_OPUS_MODEL = opusModel;
+        }
+        if (sonnetModel) {
+            envVars.ANTHROPIC_DEFAULT_SONNET_MODEL = sonnetModel;
+        }
+        if (haikuModel) {
+            envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL = haikuModel;
+        }
     }
 
-    const isFish = Boolean(options.fish || process.env.SHELL?.includes("fish"));
+    let targetShell: ShellType = detectShell();
+    if (options.fish) {
+        targetShell = "fish";
+    } else if (options.shell) {
+        const s = options.shell.toLowerCase();
+        if (
+            s === "fish" ||
+            s === "powershell" ||
+            s === "pwsh" ||
+            s === "cmd" ||
+            s === "zsh" ||
+            s === "bash"
+        ) {
+            targetShell = (s === "pwsh" ? "powershell" : s) as ShellType;
+        }
+    }
 
     for (const [key, value] of Object.entries(envVars)) {
-        if (isFish) {
-            console.log(`set -gx ${key} "${value}";`);
-        } else {
-            console.log(`export ${key}="${value}"`);
-        }
+        console.log(formatShellExport(key, value, targetShell));
     }
 }

--- a/apps/cli/src/commands/env.ts
+++ b/apps/cli/src/commands/env.ts
@@ -1,6 +1,6 @@
-import { getAdapter, getAllAdapters } from "../adapters/index.ts";
-import { defaultStore } from "../lib/configStore.ts";
-import { formatError, pc } from "../lib/ui.ts";
+import { getAdapter, getAllAdapters } from "../adapters/index.js";
+import { defaultStore } from "../lib/configStore.js";
+import { formatError, pc } from "../lib/ui.js";
 
 export interface EnvCommandOptions {
     url?: string;
@@ -38,7 +38,6 @@ export async function envCommand(toolId?: string, options: EnvCommandOptions = {
         }
         envVars = adapter.getEnv(context);
     } else {
-        // Collect combined env vars across all adapters
         envVars = {
             ANTHROPIC_BASE_URL: baseUrl,
             OPENAI_BASE_URL: baseUrl

--- a/apps/cli/src/commands/link.ts
+++ b/apps/cli/src/commands/link.ts
@@ -1,6 +1,6 @@
-import { getAdapter, getAllAdapters } from "../adapters/index.ts";
-import { defaultStore } from "../lib/configStore.ts";
-import { formatError, formatSuccess, pc } from "../lib/ui.ts";
+import { getAdapter, getAllAdapters } from "../adapters/index.js";
+import { defaultStore } from "../lib/configStore.js";
+import { formatError, formatSuccess, pc } from "../lib/ui.js";
 
 export interface LinkCommandOptions {
     url?: string;

--- a/apps/cli/src/commands/link.ts
+++ b/apps/cli/src/commands/link.ts
@@ -6,6 +6,9 @@ export interface LinkCommandOptions {
     url?: string;
     key?: string;
     model?: string;
+    opusModel?: string;
+    sonnetModel?: string;
+    haikuModel?: string;
     dryRun?: boolean;
 }
 
@@ -27,12 +30,18 @@ export async function linkCommand(toolId: string, options: LinkCommandOptions): 
     const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
     const apiKey = options.key || savedConfig.defaultApiKey;
     const model = options.model || savedConfig.defaultModel;
+    const opusModel = options.opusModel || savedConfig.defaultOpusModel;
+    const sonnetModel = options.sonnetModel || savedConfig.defaultSonnetModel;
+    const haikuModel = options.haikuModel || savedConfig.defaultHaikuModel;
 
     try {
         const result = await adapter.link({
             baseUrl,
             apiKey,
             model,
+            opusModel,
+            sonnetModel,
+            haikuModel,
             dryRun: options.dryRun
         });
 
@@ -45,6 +54,15 @@ export async function linkCommand(toolId: string, options: LinkCommandOptions): 
         console.log(`  ${pc.gray("Proxy URL:")}     ${pc.white(baseUrl)}`);
         if (model) {
             console.log(`  ${pc.gray("Model:")}         ${pc.white(model)}`);
+        }
+        if (opusModel) {
+            console.log(`  ${pc.gray("Opus Model:")}    ${pc.white(opusModel)}`);
+        }
+        if (sonnetModel) {
+            console.log(`  ${pc.gray("Sonnet Model:")}  ${pc.white(sonnetModel)}`);
+        }
+        if (haikuModel) {
+            console.log(`  ${pc.gray("Haiku Model:")}   ${pc.white(haikuModel)}`);
         }
         if (result.backupPath) {
             console.log(`  ${pc.gray("Backup Saved:")}  ${pc.white(result.backupPath)}`);

--- a/apps/cli/src/commands/link.ts
+++ b/apps/cli/src/commands/link.ts
@@ -1,0 +1,56 @@
+import { getAdapter, getAllAdapters } from "../adapters/index.ts";
+import { defaultStore } from "../lib/configStore.ts";
+import { formatError, formatSuccess, pc } from "../lib/ui.ts";
+
+export interface LinkCommandOptions {
+    url?: string;
+    key?: string;
+    model?: string;
+    dryRun?: boolean;
+}
+
+export async function linkCommand(toolId: string, options: LinkCommandOptions): Promise<void> {
+    const adapter = getAdapter(toolId);
+    if (!adapter) {
+        console.error(
+            formatError(
+                `Tool '${pc.bold(toolId)}' not supported. Available tools: ${getAllAdapters()
+                    .map((a) => a.id)
+                    .join(", ")}`
+            )
+        );
+        process.exitCode = 1;
+        return;
+    }
+
+    const savedConfig = await defaultStore.loadConfig();
+    const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
+    const apiKey = options.key || savedConfig.defaultApiKey;
+    const model = options.model || savedConfig.defaultModel;
+
+    try {
+        const result = await adapter.link({
+            baseUrl,
+            apiKey,
+            model,
+            dryRun: options.dryRun
+        });
+
+        console.log(
+            formatSuccess(
+                `Successfully configured ${pc.bold(pc.cyan(adapter.name))} with SRouter proxy!`
+            )
+        );
+        console.log(`  ${pc.gray("Target Config:")} ${pc.white(result.modifiedPath)}`);
+        console.log(`  ${pc.gray("Proxy URL:")}     ${pc.white(baseUrl)}`);
+        if (model) {
+            console.log(`  ${pc.gray("Model:")}         ${pc.white(model)}`);
+        }
+        if (result.backupPath) {
+            console.log(`  ${pc.gray("Backup Saved:")}  ${pc.white(result.backupPath)}`);
+        }
+    } catch (err: any) {
+        console.error(formatError(`Failed to link ${adapter.name}: ${err.message}`));
+        process.exitCode = 1;
+    }
+}

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
-import { getAdapter, getAllAdapters } from "../adapters/index.ts";
-import { defaultStore } from "../lib/configStore.ts";
-import { formatError, pc } from "../lib/ui.ts";
+import { getAdapter, getAllAdapters } from "../adapters/index.js";
+import { defaultStore } from "../lib/configStore.js";
+import { formatError, pc } from "../lib/ui.js";
 
 export interface RunCommandOptions {
     url?: string;

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -1,0 +1,69 @@
+import { spawn } from "node:child_process";
+import { getAdapter, getAllAdapters } from "../adapters/index.ts";
+import { defaultStore } from "../lib/configStore.ts";
+import { formatError, pc } from "../lib/ui.ts";
+
+export interface RunCommandOptions {
+    url?: string;
+    key?: string;
+    model?: string;
+}
+
+export async function runCommand(
+    toolId: string,
+    toolArgs: string[],
+    options: RunCommandOptions = {}
+): Promise<void> {
+    const adapter = getAdapter(toolId);
+    if (!adapter) {
+        console.error(
+            formatError(
+                `Tool '${pc.bold(toolId)}' not supported. Available: ${getAllAdapters()
+                    .map((a) => a.id)
+                    .join(", ")}`
+            )
+        );
+        process.exitCode = 1;
+        return;
+    }
+
+    const savedConfig = await defaultStore.loadConfig();
+    const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
+    const apiKey = options.key || savedConfig.defaultApiKey;
+    const model = options.model || savedConfig.defaultModel;
+
+    const envToInject = adapter.getEnv({
+        baseUrl,
+        apiKey,
+        model
+    });
+
+    const binaryName = toolId === "claude" ? "claude" : "opencode";
+
+    const child = spawn(binaryName, toolArgs, {
+        stdio: "inherit",
+        env: {
+            ...process.env,
+            ...envToInject
+        }
+    });
+
+    child.on("error", (err: any) => {
+        if (err.code === "ENOENT") {
+            console.error(
+                formatError(
+                    `Executable '${pc.bold(binaryName)}' not found in your PATH. Please install ${adapter.name} first.`
+                )
+            );
+        } else {
+            console.error(formatError(`Failed to run ${binaryName}: ${err.message}`));
+        }
+        process.exitCode = 1;
+    });
+
+    child.on("exit", (code) => {
+        if (code !== null && code !== 0) {
+            process.exitCode = code;
+        }
+    });
+}

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -7,6 +7,9 @@ export interface RunCommandOptions {
     url?: string;
     key?: string;
     model?: string;
+    opusModel?: string;
+    sonnetModel?: string;
+    haikuModel?: string;
 }
 
 export async function runCommand(
@@ -31,11 +34,17 @@ export async function runCommand(
     const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
     const apiKey = options.key || savedConfig.defaultApiKey;
     const model = options.model || savedConfig.defaultModel;
+    const opusModel = options.opusModel || savedConfig.defaultOpusModel;
+    const sonnetModel = options.sonnetModel || savedConfig.defaultSonnetModel;
+    const haikuModel = options.haikuModel || savedConfig.defaultHaikuModel;
 
     const envToInject = adapter.getEnv({
         baseUrl,
         apiKey,
-        model
+        model,
+        opusModel,
+        sonnetModel,
+        haikuModel
     });
 
     const binaryName = toolId === "claude" ? "claude" : "opencode";

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -9,10 +9,10 @@ import {
     cancel,
     note
 } from "@clack/prompts";
-import { getAllAdapters } from "../adapters/index.ts";
-import { defaultStore } from "../lib/configStore.ts";
-import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.ts";
-import { pc, showHeader } from "../lib/ui.ts";
+import { getAllAdapters } from "../adapters/index.js";
+import { defaultStore } from "../lib/configStore.js";
+import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.js";
+import { pc, showHeader } from "../lib/ui.js";
 
 export interface SetupWizardOptions {
     url?: string;
@@ -94,7 +94,6 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
 
         if (keyInput.trim()) {
             apiKey = keyInput.trim();
-            // Re-fetch models with API key if previously empty
             if (availableModels.length === 0) {
                 availableModels = await fetchAvailableModels(baseUrl, apiKey);
             }
@@ -201,7 +200,6 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         });
     }
 
-    // Save preferences
     await defaultStore.saveConfig({
         defaultBaseUrl: baseUrl,
         defaultApiKey: apiKey,

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -1,0 +1,235 @@
+import {
+    intro,
+    outro,
+    spinner,
+    text,
+    select,
+    multiselect,
+    isCancel,
+    cancel,
+    note
+} from "@clack/prompts";
+import { getAllAdapters } from "../adapters/index.ts";
+import { defaultStore } from "../lib/configStore.ts";
+import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.ts";
+import { pc, showHeader } from "../lib/ui.ts";
+
+export interface SetupWizardOptions {
+    url?: string;
+    key?: string;
+    model?: string;
+}
+
+export async function setupCommand(options: SetupWizardOptions = {}): Promise<void> {
+    showHeader();
+    intro(pc.bold(pc.magenta("SRouter AI Coding Setup Wizard")));
+
+    const savedConfig = await defaultStore.loadConfig();
+    let baseUrl =
+        options.url ||
+        process.env.SROUTER_BASE_URL ||
+        savedConfig.defaultBaseUrl ||
+        "http://localhost:3000/v1";
+    let apiKey = options.key || process.env.SROUTER_API_KEY || savedConfig.defaultApiKey;
+    let selectedModel = options.model || savedConfig.defaultModel;
+
+    // Step 1: Detect SRouter Server
+    const s = spinner();
+    s.start(`Checking SRouter gateway connectivity at ${pc.cyan(baseUrl)}...`);
+
+    let health = await checkServerHealth(baseUrl, apiKey);
+    let availableModels: string[] = [];
+
+    if (health.healthy) {
+        s.stop(
+            pc.green(
+                `SRouter is ONLINE (${health.latencyMs}ms, ${health.modelsCount} models found)`
+            )
+        );
+        availableModels = await fetchAvailableModels(baseUrl, apiKey);
+    } else {
+        s.stop(pc.yellow(`Could not reach SRouter at ${baseUrl} (${health.error || "offline"})`));
+
+        const urlInput = await text({
+            message: "Enter SRouter Gateway Base URL:",
+            initialValue: baseUrl,
+            validate(value) {
+                if (!value.trim()) return "Base URL cannot be empty";
+                if (!value.startsWith("http://") && !value.startsWith("https://")) {
+                    return "URL must start with http:// or https://";
+                }
+            }
+        });
+
+        if (isCancel(urlInput)) {
+            cancel("Setup cancelled.");
+            process.exitCode = 0;
+            return;
+        }
+
+        baseUrl = urlInput.trim();
+        s.start(`Connecting to ${pc.cyan(baseUrl)}...`);
+        health = await checkServerHealth(baseUrl, apiKey);
+        if (health.healthy) {
+            s.stop(pc.green(`Connected to SRouter (${health.modelsCount} models found)`));
+            availableModels = await fetchAvailableModels(baseUrl, apiKey);
+        } else {
+            s.stop(pc.yellow(`Proceeding with offline / unverified endpoint: ${baseUrl}`));
+        }
+    }
+
+    // Step 2: Prompt for API Key if not set
+    if (!apiKey) {
+        const keyInput = await text({
+            message:
+                "Enter SRouter API Key (press Enter to skip if running in local auth-free mode):",
+            placeholder: "sk-..."
+        });
+
+        if (isCancel(keyInput)) {
+            cancel("Setup cancelled.");
+            process.exitCode = 0;
+            return;
+        }
+
+        if (keyInput.trim()) {
+            apiKey = keyInput.trim();
+            // Re-fetch models with API key if previously empty
+            if (availableModels.length === 0) {
+                availableModels = await fetchAvailableModels(baseUrl, apiKey);
+            }
+        }
+    }
+
+    // Step 3: Tool Selection Checklist (Multi-select)
+    const adapters = getAllAdapters();
+    const adapterStatuses = await Promise.all(adapters.map((a) => a.getStatus()));
+
+    const toolOptions = adapters.map((adapter, idx) => {
+        const st = adapterStatuses[idx];
+        const statusHint = st.linked
+            ? "currently linked"
+            : st.installed
+              ? "installed"
+              : "not in PATH";
+        return {
+            value: adapter.id,
+            label: adapter.name,
+            hint: `${adapter.description} (${statusHint})`
+        };
+    });
+
+    const selectedTools = await multiselect({
+        message: "Pilih tool AI coding yang ingin dihubungkan ke SRouter:",
+        options: toolOptions,
+        required: true,
+        initialValues: adapters.map((a) => a.id)
+    });
+
+    if (isCancel(selectedTools)) {
+        cancel("Setup cancelled.");
+        process.exitCode = 0;
+        return;
+    }
+
+    const toolsToConfigure = selectedTools as string[];
+
+    // Step 4: Model Selection
+    if (!selectedModel) {
+        if (availableModels.length > 0) {
+            const modelOptions = availableModels.map((m) => ({
+                value: m,
+                label: m
+            }));
+            const modelChoice = await select({
+                message: "Pilih default model untuk tool:",
+                options: [...modelOptions, { value: "__custom__", label: "Custom model name..." }]
+            });
+
+            if (isCancel(modelChoice)) {
+                cancel("Setup cancelled.");
+                process.exitCode = 0;
+                return;
+            }
+
+            if (modelChoice === "__custom__") {
+                const customModelInput = await text({
+                    message: "Enter custom model ID:",
+                    placeholder: "claude-3-7-sonnet"
+                });
+                if (isCancel(customModelInput)) {
+                    cancel("Setup cancelled.");
+                    process.exitCode = 0;
+                    return;
+                }
+                selectedModel = customModelInput.trim() || undefined;
+            } else {
+                selectedModel = modelChoice as string;
+            }
+        } else {
+            const modelInput = await text({
+                message: "Enter default model ID for tools (optional, press Enter for default):",
+                placeholder: "claude-3-7-sonnet"
+            });
+            if (isCancel(modelInput)) {
+                cancel("Setup cancelled.");
+                process.exitCode = 0;
+                return;
+            }
+            selectedModel = modelInput.trim() || undefined;
+        }
+    }
+
+    // Step 5: Execute Linking
+    s.start("Applying SRouter configurations...");
+    const linkResults: { name: string; path: string; backup?: string }[] = [];
+
+    for (const toolId of toolsToConfigure) {
+        const adapter = adapters.find((a) => a.id === toolId);
+        if (!adapter) continue;
+
+        const result = await adapter.link({
+            baseUrl,
+            apiKey,
+            model: selectedModel
+        });
+
+        linkResults.push({
+            name: adapter.name,
+            path: result.modifiedPath,
+            backup: result.backupPath
+        });
+    }
+
+    // Save preferences
+    await defaultStore.saveConfig({
+        defaultBaseUrl: baseUrl,
+        defaultApiKey: apiKey,
+        defaultModel: selectedModel,
+        lastSetupAt: Date.now()
+    });
+
+    s.stop(pc.green("All configurations applied successfully!"));
+
+    // Step 6: Summary Notes
+    const summaryLines = [
+        `Base URL: ${pc.cyan(baseUrl)}`,
+        ...(apiKey ? [`API Key:  ${pc.gray("••••••••" + apiKey.slice(-4))}`] : []),
+        ...(selectedModel ? [`Model:    ${pc.cyan(selectedModel)}`] : []),
+        "",
+        pc.bold("Configured Tools:")
+    ];
+
+    for (const r of linkResults) {
+        summaryLines.push(`  ✔ ${pc.bold(r.name)} -> ${pc.gray(r.path)}`);
+        if (r.backup) {
+            summaryLines.push(`    ${pc.gray("Backup:")} ${pc.gray(r.backup)}`);
+        }
+    }
+
+    note(summaryLines.join("\n"), "Configuration Summary");
+
+    outro(
+        pc.bold(pc.green("✔ SRouter is connected! You can now use your AI coding tools directly."))
+    );
+}

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -126,15 +126,15 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         let hint = "";
 
         if (st.linked) {
-            label = `${adapter.name} [✔ SUDAH DI-SETTING]`;
+            label = `${adapter.name} [✔ CONFIGURED]`;
             const modelPart = st.currentModel ? `, Model: ${st.currentModel}` : "";
-            hint = `Aktif terhubung ke ${st.currentBaseUrl}${modelPart} (Pilih untuk update setting)`;
+            hint = `Active on ${st.currentBaseUrl}${modelPart} (Select to update settings)`;
         } else if (st.installed) {
-            label = `${adapter.name} [○ BELUM DI-SETTING]`;
-            hint = `${adapter.description} (Terinstall di sistem)`;
+            label = `${adapter.name} [○ NOT CONFIGURED]`;
+            hint = `${adapter.description} (Installed on system)`;
         } else {
-            label = `${adapter.name} [✖ BELUM TERINSTALL]`;
-            hint = `${adapter.description} (Executable tidak ditemukan di PATH)`;
+            label = `${adapter.name} [✖ NOT INSTALLED]`;
+            hint = `${adapter.description} (Executable not found in PATH)`;
         }
 
         return {
@@ -146,7 +146,7 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
 
     const selectedTools = await multiselect({
         message:
-            "Pilih tool AI coding yang ingin dihubungkan ke SRouter (Gunakan Space untuk memilih, Enter untuk konfirmasi):",
+            "Select AI coding tools to connect to SRouter (Use Space to select, Enter to confirm):",
         options: toolOptions,
         required: false
     });
@@ -167,13 +167,13 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         });
 
         note(
-            `Base URL:    ${pc.cyan(baseUrl)}\n${apiKey ? `API Key:     ${pc.gray("••••••••" + apiKey.slice(-4))}\n` : ""}\n${pc.yellow("Tidak ada tool yang dipilih untuk dihubungkan.")}`,
+            `Base URL:    ${pc.cyan(baseUrl)}\n${apiKey ? `API Key:     ${pc.gray("••••••••" + apiKey.slice(-4))}\n` : ""}\n${pc.yellow("No tools selected for configuration.")}`,
             "Configuration Summary"
         );
         outro(
             pc.bold(
                 pc.green(
-                    "✔ Gateway berhasil disimpan. Anda dapat menjalankan 'srouter setup' atau 'srouter link <tool>' kapan saja."
+                    "✔ Gateway settings saved. You can run 'srouter setup' or 'srouter link <tool>' at any time."
                 )
             )
         );
@@ -188,7 +188,7 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
                 label: m
             }));
             const modelChoice = await select({
-                message: "Pilih default model untuk tool:",
+                message: "Select default model for tools:",
                 options: [...modelOptions, { value: "__custom__", label: "Custom model name..." }]
             });
 
@@ -237,16 +237,16 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         !options.haikuModel
     ) {
         const configTiersChoice = await select({
-            message: "Konfigurasi model tier Claude Code (Opus, Sonnet, Haiku)?",
+            message: "Configure Claude Code specific model tiers (Opus, Sonnet, Haiku)?",
             options: [
                 {
                     value: "auto",
-                    label: "Gunakan model default / lewati",
+                    label: "Use general default model / skip",
                     hint: selectedModel || "Default Claude models"
                 },
                 {
                     value: "custom",
-                    label: "Kustomisasi per tier (Opus, Sonnet, Haiku)"
+                    label: "Customize per tier (Opus, Sonnet, Haiku)"
                 }
             ]
         });
@@ -265,9 +265,9 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
             ): Promise<string | undefined> => {
                 if (availableModels.length > 0) {
                     const choice = await select({
-                        message: `Pilih model untuk ${tierName} (${envVar}):`,
+                        message: `Select model for ${tierName} (${envVar}):`,
                         options: [
-                            { value: "__skip__", label: "Lewati (Gunakan default)" },
+                            { value: "__skip__", label: "Skip (Use default)" },
                             ...availableModels.map((m) => ({ value: m, label: m })),
                             { value: "__custom__", label: "Custom model name..." }
                         ]
@@ -276,7 +276,7 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
                     if (choice === "__skip__") return undefined;
                     if (choice === "__custom__") {
                         const customInput = await text({
-                            message: `Enter custom model ID untuk ${tierName}:`,
+                            message: `Enter custom model ID for ${tierName}:`,
                             placeholder: defaultVal || "claude-3-7-sonnet"
                         });
                         if (isCancel(customInput)) return undefined;
@@ -287,7 +287,7 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
                 }
 
                 const customInput = await text({
-                    message: `Enter model ID untuk ${tierName} (${envVar}, optional):`,
+                    message: `Enter model ID for ${tierName} (${envVar}, optional):`,
                     placeholder: defaultVal || "claude-3-7-sonnet"
                 });
                 if (isCancel(customInput)) return undefined;

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -11,6 +11,7 @@ import {
 } from "@clack/prompts";
 import { getAllAdapters } from "../adapters/index.js";
 import { defaultStore } from "../lib/configStore.js";
+import { getSystemInfo } from "../lib/platform.js";
 import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.js";
 import { pc, showHeader } from "../lib/ui.js";
 
@@ -18,11 +19,17 @@ export interface SetupWizardOptions {
     url?: string;
     key?: string;
     model?: string;
+    opusModel?: string;
+    sonnetModel?: string;
+    haikuModel?: string;
 }
 
 export async function setupCommand(options: SetupWizardOptions = {}): Promise<void> {
     showHeader();
-    intro(pc.bold(pc.magenta("SRouter AI Coding Setup Wizard")));
+    const sysInfo = getSystemInfo();
+    intro(
+        `${pc.bold(pc.magenta("SRouter AI Coding Setup Wizard"))} ${pc.gray(`(${sysInfo.displayName})`)}`
+    );
 
     const savedConfig = await defaultStore.loadConfig();
     let baseUrl =
@@ -32,6 +39,9 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         "http://localhost:3000/v1";
     let apiKey = options.key || process.env.SROUTER_API_KEY || savedConfig.defaultApiKey;
     let selectedModel = options.model || savedConfig.defaultModel;
+    let opusModel = options.opusModel || savedConfig.defaultOpusModel;
+    let sonnetModel = options.sonnetModel || savedConfig.defaultSonnetModel;
+    let haikuModel = options.haikuModel || savedConfig.defaultHaikuModel;
 
     // Step 1: Detect SRouter Server
     const s = spinner();
@@ -112,23 +122,33 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
 
     const toolOptions = adapters.map((adapter, idx) => {
         const st = adapterStatuses[idx];
-        const statusHint = st.linked
-            ? "currently linked"
-            : st.installed
-              ? "installed"
-              : "not in PATH";
+        let label = adapter.name;
+        let hint = "";
+
+        if (st.linked) {
+            label = `${adapter.name} [✔ SUDAH DI-SETTING]`;
+            const modelPart = st.currentModel ? `, Model: ${st.currentModel}` : "";
+            hint = `Aktif terhubung ke ${st.currentBaseUrl}${modelPart} (Pilih untuk update setting)`;
+        } else if (st.installed) {
+            label = `${adapter.name} [○ BELUM DI-SETTING]`;
+            hint = `${adapter.description} (Terinstall di sistem)`;
+        } else {
+            label = `${adapter.name} [✖ BELUM TERINSTALL]`;
+            hint = `${adapter.description} (Executable tidak ditemukan di PATH)`;
+        }
+
         return {
             value: adapter.id,
-            label: adapter.name,
-            hint: `${adapter.description} (${statusHint})`
+            label,
+            hint
         };
     });
 
     const selectedTools = await multiselect({
-        message: "Pilih tool AI coding yang ingin dihubungkan ke SRouter:",
+        message:
+            "Pilih tool AI coding yang ingin dihubungkan ke SRouter (Gunakan Space untuk memilih, Enter untuk konfirmasi):",
         options: toolOptions,
-        required: true,
-        initialValues: adapters.map((a) => a.id)
+        required: false
     });
 
     if (isCancel(selectedTools)) {
@@ -138,6 +158,27 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
     }
 
     const toolsToConfigure = Array.isArray(selectedTools) ? (selectedTools as string[]) : [];
+
+    if (toolsToConfigure.length === 0) {
+        await defaultStore.saveConfig({
+            defaultBaseUrl: baseUrl,
+            defaultApiKey: apiKey,
+            lastSetupAt: Date.now()
+        });
+
+        note(
+            `Base URL:    ${pc.cyan(baseUrl)}\n${apiKey ? `API Key:     ${pc.gray("••••••••" + apiKey.slice(-4))}\n` : ""}\n${pc.yellow("Tidak ada tool yang dipilih untuk dihubungkan.")}`,
+            "Configuration Summary"
+        );
+        outro(
+            pc.bold(
+                pc.green(
+                    "✔ Gateway berhasil disimpan. Anda dapat menjalankan 'srouter setup' atau 'srouter link <tool>' kapan saja."
+                )
+            )
+        );
+        return;
+    }
 
     // Step 4: Model Selection
     if (!selectedModel) {
@@ -188,6 +229,101 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         }
     }
 
+    // Step 4.1: Claude Code Specific Models (Opus, Sonnet, Haiku)
+    if (
+        toolsToConfigure.includes("claude") &&
+        !options.opusModel &&
+        !options.sonnetModel &&
+        !options.haikuModel
+    ) {
+        const configTiersChoice = await select({
+            message: "Konfigurasi model tier Claude Code (Opus, Sonnet, Haiku)?",
+            options: [
+                {
+                    value: "auto",
+                    label: "Gunakan model default / lewati",
+                    hint: selectedModel || "Default Claude models"
+                },
+                {
+                    value: "custom",
+                    label: "Kustomisasi per tier (Opus, Sonnet, Haiku)"
+                }
+            ]
+        });
+
+        if (isCancel(configTiersChoice)) {
+            cancel("Setup cancelled.");
+            process.exitCode = 0;
+            return;
+        }
+
+        if (configTiersChoice === "custom") {
+            const pickTierModel = async (
+                tierName: string,
+                envVar: string,
+                defaultVal?: string
+            ): Promise<string | undefined> => {
+                if (availableModels.length > 0) {
+                    const choice = await select({
+                        message: `Pilih model untuk ${tierName} (${envVar}):`,
+                        options: [
+                            { value: "__skip__", label: "Lewati (Gunakan default)" },
+                            ...availableModels.map((m) => ({ value: m, label: m })),
+                            { value: "__custom__", label: "Custom model name..." }
+                        ]
+                    });
+                    if (isCancel(choice)) return undefined;
+                    if (choice === "__skip__") return undefined;
+                    if (choice === "__custom__") {
+                        const customInput = await text({
+                            message: `Enter custom model ID untuk ${tierName}:`,
+                            placeholder: defaultVal || "claude-3-7-sonnet"
+                        });
+                        if (isCancel(customInput)) return undefined;
+                        const val = typeof customInput === "string" ? customInput.trim() : "";
+                        return val || undefined;
+                    }
+                    return choice as string;
+                }
+
+                const customInput = await text({
+                    message: `Enter model ID untuk ${tierName} (${envVar}, optional):`,
+                    placeholder: defaultVal || "claude-3-7-sonnet"
+                });
+                if (isCancel(customInput)) return undefined;
+                const val = typeof customInput === "string" ? customInput.trim() : "";
+                return val || undefined;
+            };
+
+            const pickedSonnet = await pickTierModel(
+                "Sonnet",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                selectedModel || "claude-3-7-sonnet"
+            );
+            if (pickedSonnet !== undefined) {
+                sonnetModel = pickedSonnet;
+            }
+
+            const pickedOpus = await pickTierModel(
+                "Opus",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                "claude-3-opus-20240229"
+            );
+            if (pickedOpus !== undefined) {
+                opusModel = pickedOpus;
+            }
+
+            const pickedHaiku = await pickTierModel(
+                "Haiku",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+                "claude-3-5-haiku-20241022"
+            );
+            if (pickedHaiku !== undefined) {
+                haikuModel = pickedHaiku;
+            }
+        }
+    }
+
     // Step 5: Execute Linking
     s.start("Applying SRouter configurations...");
     const linkResults: { name: string; path: string; backup?: string }[] = [];
@@ -199,7 +335,10 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         const result = await adapter.link({
             baseUrl,
             apiKey,
-            model: selectedModel
+            model: selectedModel,
+            opusModel: toolId === "claude" ? opusModel : undefined,
+            sonnetModel: toolId === "claude" ? sonnetModel : undefined,
+            haikuModel: toolId === "claude" ? haikuModel : undefined
         });
 
         linkResults.push({
@@ -213,6 +352,9 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         defaultBaseUrl: baseUrl,
         defaultApiKey: apiKey,
         defaultModel: selectedModel,
+        defaultOpusModel: opusModel,
+        defaultSonnetModel: sonnetModel,
+        defaultHaikuModel: haikuModel,
         lastSetupAt: Date.now()
     });
 
@@ -220,9 +362,13 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
 
     // Step 6: Summary Notes
     const summaryLines = [
-        `Base URL: ${pc.cyan(baseUrl)}`,
-        ...(apiKey ? [`API Key:  ${pc.gray("••••••••" + apiKey.slice(-4))}`] : []),
-        ...(selectedModel ? [`Model:    ${pc.cyan(selectedModel)}`] : []),
+        `OS / System: ${pc.cyan(sysInfo.displayName)}`,
+        `Base URL:    ${pc.cyan(baseUrl)}`,
+        ...(apiKey ? [`API Key:     ${pc.gray("••••••••" + apiKey.slice(-4))}`] : []),
+        ...(selectedModel ? [`Model:       ${pc.cyan(selectedModel)}`] : []),
+        ...(opusModel ? [`Opus:        ${pc.cyan(opusModel)}`] : []),
+        ...(sonnetModel ? [`Sonnet:      ${pc.cyan(sonnetModel)}`] : []),
+        ...(haikuModel ? [`Haiku:       ${pc.cyan(haikuModel)}`] : []),
         "",
         pc.bold("Configured Tools:")
     ];

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -54,8 +54,9 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
             message: "Enter SRouter Gateway Base URL:",
             initialValue: baseUrl,
             validate(value) {
-                if (!value.trim()) return "Base URL cannot be empty";
-                if (!value.startsWith("http://") && !value.startsWith("https://")) {
+                const val = typeof value === "string" ? value.trim() : "";
+                if (!val) return "Base URL cannot be empty";
+                if (!val.startsWith("http://") && !val.startsWith("https://")) {
                     return "URL must start with http:// or https://";
                 }
             }
@@ -67,7 +68,11 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
             return;
         }
 
-        baseUrl = urlInput.trim();
+        const urlStr = typeof urlInput === "string" ? urlInput.trim() : baseUrl;
+        if (urlStr) {
+            baseUrl = urlStr;
+        }
+
         s.start(`Connecting to ${pc.cyan(baseUrl)}...`);
         health = await checkServerHealth(baseUrl, apiKey);
         if (health.healthy) {
@@ -92,8 +97,9 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
             return;
         }
 
-        if (keyInput.trim()) {
-            apiKey = keyInput.trim();
+        const keyStr = typeof keyInput === "string" ? keyInput.trim() : "";
+        if (keyStr) {
+            apiKey = keyStr;
             if (availableModels.length === 0) {
                 availableModels = await fetchAvailableModels(baseUrl, apiKey);
             }
@@ -131,7 +137,7 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
         return;
     }
 
-    const toolsToConfigure = selectedTools as string[];
+    const toolsToConfigure = Array.isArray(selectedTools) ? (selectedTools as string[]) : [];
 
     // Step 4: Model Selection
     if (!selectedModel) {
@@ -161,7 +167,9 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
                     process.exitCode = 0;
                     return;
                 }
-                selectedModel = customModelInput.trim() || undefined;
+                const customModelStr =
+                    typeof customModelInput === "string" ? customModelInput.trim() : "";
+                selectedModel = customModelStr || undefined;
             } else {
                 selectedModel = modelChoice as string;
             }
@@ -175,7 +183,8 @@ export async function setupCommand(options: SetupWizardOptions = {}): Promise<vo
                 process.exitCode = 0;
                 return;
             }
-            selectedModel = modelInput.trim() || undefined;
+            const modelStr = typeof modelInput === "string" ? modelInput.trim() : "";
+            selectedModel = modelStr || undefined;
         }
     }
 

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -60,11 +60,11 @@ export async function statusCommand(options: StatusCommandOptions): Promise<void
     for (const adapter of adapters) {
         const status = await adapter.getStatus();
         const icon = status.linked
-            ? pc.green("● SUDAH DI-SETTING (LINKED)")
-            : pc.gray("○ BELUM DI-SETTING (UNLINKED)");
+            ? pc.green("● CONFIGURED (LINKED)")
+            : pc.gray("○ NOT CONFIGURED (UNLINKED)");
         const installBadge = status.installed
-            ? pc.green("[Terinstall]")
-            : pc.yellow("[Tidak ada di PATH]");
+            ? pc.green("[Installed]")
+            : pc.yellow("[Not in PATH]");
 
         console.log(`\n  ${pc.bold(pc.cyan(adapter.name))} ${icon} ${installBadge}`);
         console.log(`  ${pc.gray("ID:")}          ${adapter.id}`);
@@ -85,7 +85,7 @@ export async function statusCommand(options: StatusCommandOptions): Promise<void
             }
         } else {
             console.log(
-                `  ${pc.gray("Status:")}      ${pc.yellow("Belum dihubungkan ke proxy SRouter")}`
+                `  ${pc.gray("Status:")}      ${pc.yellow("Not connected to SRouter proxy")}`
             );
         }
     }

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,0 +1,70 @@
+import { getAllAdapters } from "../adapters/index.ts";
+import { defaultStore } from "../lib/configStore.ts";
+import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.ts";
+import {
+    formatError,
+    formatInfo,
+    formatSuccess,
+    formatWarning,
+    pc,
+    showHeader
+} from "../lib/ui.ts";
+
+export interface StatusCommandOptions {
+    url?: string;
+    key?: string;
+}
+
+export async function statusCommand(options: StatusCommandOptions): Promise<void> {
+    showHeader();
+
+    const savedConfig = await defaultStore.loadConfig();
+    const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
+    const apiKey = options.key || savedConfig.defaultApiKey;
+
+    console.log(pc.bold(pc.underline("Gateway Status:")));
+    console.log(`  ${pc.gray("Target URL:")} ${pc.white(baseUrl)}`);
+
+    const health = await checkServerHealth(baseUrl, apiKey);
+    if (health.healthy) {
+        console.log(
+            `  ${pc.gray("Health:")}     ${pc.green("ONLINE")} ${pc.gray(`(${health.latencyMs}ms)`)}`
+        );
+        const models = await fetchAvailableModels(baseUrl, apiKey);
+        console.log(`  ${pc.gray("Models:")}     ${pc.cyan(`${models.length} available`)}`);
+        if (models.length > 0) {
+            const preview = models.slice(0, 5).join(", ");
+            const extra = models.length > 5 ? ` +${models.length - 5} more` : "";
+            console.log(`            ${pc.gray(`[${preview}${extra}]`)}`);
+        }
+    } else {
+        console.log(`  ${pc.gray("Health:")}     ${pc.red("OFFLINE / UNREACHABLE")}`);
+        if (health.error) {
+            console.log(`  ${pc.gray("Reason:")}     ${pc.yellow(health.error)}`);
+        }
+    }
+
+    console.log("");
+    console.log(pc.bold(pc.underline("Supported AI Coding Tools:")));
+
+    const adapters = getAllAdapters();
+    for (const adapter of adapters) {
+        const status = await adapter.getStatus();
+        const icon = status.linked ? pc.green("● LINKED") : pc.gray("○ UNLINKED");
+        const installBadge = status.installed
+            ? pc.green("[Installed]")
+            : pc.yellow("[Not in PATH]");
+
+        console.log(`\n  ${pc.bold(pc.cyan(adapter.name))} ${icon} ${installBadge}`);
+        console.log(`  ${pc.gray("ID:")}          ${adapter.id}`);
+        console.log(`  ${pc.gray("Config Path:")} ${status.configPath || "N/A"}`);
+        if (status.linked) {
+            console.log(`  ${pc.gray("Active URL:")}  ${pc.green(status.currentBaseUrl || "N/A")}`);
+            if (status.currentModel) {
+                console.log(`  ${pc.gray("Model:")}       ${pc.green(status.currentModel)}`);
+            }
+        }
+    }
+
+    console.log("");
+}

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,5 +1,6 @@
 import { getAllAdapters } from "../adapters/index.js";
 import { defaultStore } from "../lib/configStore.js";
+import { getSystemInfo } from "../lib/platform.js";
 import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.js";
 import {
     formatError,
@@ -17,6 +18,14 @@ export interface StatusCommandOptions {
 
 export async function statusCommand(options: StatusCommandOptions): Promise<void> {
     showHeader();
+
+    const sysInfo = getSystemInfo();
+    console.log(pc.bold(pc.underline("System Environment:")));
+    console.log(`  ${pc.gray("OS:")}          ${pc.white(sysInfo.displayName)}`);
+    console.log(`  ${pc.gray("Platform:")}    ${pc.white(sysInfo.platform)} (${sysInfo.arch})`);
+    console.log(`  ${pc.gray("Shell:")}       ${pc.white(sysInfo.detectedShell)}`);
+    console.log(`  ${pc.gray("Home Dir:")}    ${pc.white(sysInfo.homeDir)}`);
+    console.log("");
 
     const savedConfig = await defaultStore.loadConfig();
     const baseUrl = options.url || savedConfig.defaultBaseUrl || "http://localhost:3000/v1";
@@ -50,10 +59,12 @@ export async function statusCommand(options: StatusCommandOptions): Promise<void
     const adapters = getAllAdapters();
     for (const adapter of adapters) {
         const status = await adapter.getStatus();
-        const icon = status.linked ? pc.green("● LINKED") : pc.gray("○ UNLINKED");
+        const icon = status.linked
+            ? pc.green("● SUDAH DI-SETTING (LINKED)")
+            : pc.gray("○ BELUM DI-SETTING (UNLINKED)");
         const installBadge = status.installed
-            ? pc.green("[Installed]")
-            : pc.yellow("[Not in PATH]");
+            ? pc.green("[Terinstall]")
+            : pc.yellow("[Tidak ada di PATH]");
 
         console.log(`\n  ${pc.bold(pc.cyan(adapter.name))} ${icon} ${installBadge}`);
         console.log(`  ${pc.gray("ID:")}          ${adapter.id}`);
@@ -63,6 +74,19 @@ export async function statusCommand(options: StatusCommandOptions): Promise<void
             if (status.currentModel) {
                 console.log(`  ${pc.gray("Model:")}       ${pc.green(status.currentModel)}`);
             }
+            if (status.currentOpusModel) {
+                console.log(`  ${pc.gray("Opus Model:")}  ${pc.green(status.currentOpusModel)}`);
+            }
+            if (status.currentSonnetModel) {
+                console.log(`  ${pc.gray("Sonnet Model:")}${pc.green(status.currentSonnetModel)}`);
+            }
+            if (status.currentHaikuModel) {
+                console.log(`  ${pc.gray("Haiku Model:")} ${pc.green(status.currentHaikuModel)}`);
+            }
+        } else {
+            console.log(
+                `  ${pc.gray("Status:")}      ${pc.yellow("Belum dihubungkan ke proxy SRouter")}`
+            );
         }
     }
 

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,6 +1,6 @@
-import { getAllAdapters } from "../adapters/index.ts";
-import { defaultStore } from "../lib/configStore.ts";
-import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.ts";
+import { getAllAdapters } from "../adapters/index.js";
+import { defaultStore } from "../lib/configStore.js";
+import { checkServerHealth, fetchAvailableModels } from "../lib/srouterClient.js";
 import {
     formatError,
     formatInfo,
@@ -8,7 +8,7 @@ import {
     formatWarning,
     pc,
     showHeader
-} from "../lib/ui.ts";
+} from "../lib/ui.js";
 
 export interface StatusCommandOptions {
     url?: string;

--- a/apps/cli/src/commands/unlink.ts
+++ b/apps/cli/src/commands/unlink.ts
@@ -1,5 +1,5 @@
-import { getAdapter, getAllAdapters } from "../adapters/index.ts";
-import { formatError, formatInfo, formatSuccess, pc } from "../lib/ui.ts";
+import { getAdapter, getAllAdapters } from "../adapters/index.js";
+import { formatError, formatInfo, formatSuccess, pc } from "../lib/ui.js";
 
 export async function unlinkCommand(toolId: string): Promise<void> {
     const adapter = getAdapter(toolId);

--- a/apps/cli/src/commands/unlink.ts
+++ b/apps/cli/src/commands/unlink.ts
@@ -1,0 +1,37 @@
+import { getAdapter, getAllAdapters } from "../adapters/index.ts";
+import { formatError, formatInfo, formatSuccess, pc } from "../lib/ui.ts";
+
+export async function unlinkCommand(toolId: string): Promise<void> {
+    const adapter = getAdapter(toolId);
+    if (!adapter) {
+        console.error(
+            formatError(
+                `Tool '${pc.bold(toolId)}' not supported. Available tools: ${getAllAdapters()
+                    .map((a) => a.id)
+                    .join(", ")}`
+            )
+        );
+        process.exitCode = 1;
+        return;
+    }
+
+    try {
+        const restored = await adapter.unlink();
+        if (restored) {
+            console.log(
+                formatSuccess(
+                    `Restored original configuration for ${pc.bold(pc.cyan(adapter.name))}!`
+                )
+            );
+        } else {
+            console.log(
+                formatInfo(
+                    `No active SRouter configuration or backup found for ${pc.bold(adapter.name)}.`
+                )
+            );
+        }
+    } catch (err: any) {
+        console.error(formatError(`Failed to unlink ${adapter.name}: ${err.message}`));
+        process.exitCode = 1;
+    }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,10 +1,10 @@
 import { Command } from "commander";
-import { setupCommand } from "./commands/setup.ts";
-import { linkCommand } from "./commands/link.ts";
-import { unlinkCommand } from "./commands/unlink.ts";
-import { statusCommand } from "./commands/status.ts";
-import { envCommand } from "./commands/env.ts";
-import { runCommand } from "./commands/run.ts";
+import { setupCommand } from "./commands/setup.js";
+import { linkCommand } from "./commands/link.js";
+import { unlinkCommand } from "./commands/unlink.js";
+import { statusCommand } from "./commands/status.js";
+import { envCommand } from "./commands/env.js";
+import { runCommand } from "./commands/run.js";
 
 export function createCli(): Command {
     const program = new Command();
@@ -80,7 +80,11 @@ export function createCli(): Command {
     return program;
 }
 
-if (process.argv[1]?.endsWith("srouter.js") || process.argv[1]?.endsWith("index.ts")) {
+if (
+    process.argv[1]?.endsWith("srouter.js") ||
+    process.argv[1]?.endsWith("index.ts") ||
+    process.argv[1]?.endsWith("index.js")
+) {
     const program = createCli();
     program.parse(process.argv);
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -11,7 +11,9 @@ export function createCli(): Command {
 
     program
         .name("srouter")
-        .description("CLI tool to configure and link AI coding tools to SRouter")
+        .description(
+            "CLI tool to connect, configure, and proxy AI coding tools with SRouter Gateway"
+        )
         .version("0.1.1-rc.1");
 
     program
@@ -25,15 +27,15 @@ export function createCli(): Command {
         .option("-m, --model <model>", "Default model ID to configure")
         .option(
             "--opus-model <model>",
-            "Default Opus model for Claude Code (ANTHROPIC_DEFAULT_OPUS_MODEL)"
+            "Default Opus tier model for Claude Code (ANTHROPIC_DEFAULT_OPUS_MODEL)"
         )
         .option(
             "--sonnet-model <model>",
-            "Default Sonnet model for Claude Code (ANTHROPIC_DEFAULT_SONNET_MODEL)"
+            "Default Sonnet tier model for Claude Code (ANTHROPIC_DEFAULT_SONNET_MODEL)"
         )
         .option(
             "--haiku-model <model>",
-            "Default Haiku model for Claude Code (ANTHROPIC_DEFAULT_HAIKU_MODEL)"
+            "Default Haiku tier model for Claude Code (ANTHROPIC_DEFAULT_HAIKU_MODEL)"
         )
         .action(async (opts) => {
             await setupCommand(opts);
@@ -42,13 +44,22 @@ export function createCli(): Command {
     program
         .command("link <tool>")
         .description("Configure a specific tool to use SRouter proxy (claude, opencode)")
-        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .option("-u, --url <url>", "SRouter Gateway Base URL (e.g. http://localhost:3000/v1)")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Model ID")
-        .option("--opus-model <model>", "Opus model ID (ANTHROPIC_DEFAULT_OPUS_MODEL)")
-        .option("--sonnet-model <model>", "Sonnet model ID (ANTHROPIC_DEFAULT_SONNET_MODEL)")
-        .option("--haiku-model <model>", "Haiku model ID (ANTHROPIC_DEFAULT_HAIKU_MODEL)")
-        .option("--dry-run", "Simulate without writing files")
+        .option(
+            "--opus-model <model>",
+            "Opus tier model ID for Claude Code (ANTHROPIC_DEFAULT_OPUS_MODEL)"
+        )
+        .option(
+            "--sonnet-model <model>",
+            "Sonnet tier model ID for Claude Code (ANTHROPIC_DEFAULT_SONNET_MODEL)"
+        )
+        .option(
+            "--haiku-model <model>",
+            "Haiku tier model ID for Claude Code (ANTHROPIC_DEFAULT_HAIKU_MODEL)"
+        )
+        .option("--dry-run", "Preview configuration changes without writing files")
         .action(async (tool, opts) => {
             await linkCommand(tool, opts);
         });
@@ -63,8 +74,8 @@ export function createCli(): Command {
     program
         .command("status")
         .alias("doctor")
-        .description("Inspect SRouter server connectivity and tool integration status")
-        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .description("Inspect SRouter gateway connectivity, active models, and tool link status")
+        .option("-u, --url <url>", "SRouter Gateway Base URL (e.g. http://localhost:3000/v1)")
         .option("-k, --key <key>", "SRouter API Key")
         .action(async (opts) => {
             await statusCommand(opts);
@@ -73,13 +84,22 @@ export function createCli(): Command {
     program
         .command("env [tool]")
         .description("Print shell export commands for SRouter proxy environment variables")
-        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .option("-u, --url <url>", "SRouter Gateway Base URL (e.g. http://localhost:3000/v1)")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Model ID")
-        .option("--opus-model <model>", "Opus model ID (ANTHROPIC_DEFAULT_OPUS_MODEL)")
-        .option("--sonnet-model <model>", "Sonnet model ID (ANTHROPIC_DEFAULT_SONNET_MODEL)")
-        .option("--haiku-model <model>", "Haiku model ID (ANTHROPIC_DEFAULT_HAIKU_MODEL)")
-        .option("--fish", "Generate fish shell export syntax")
+        .option(
+            "--opus-model <model>",
+            "Opus tier model ID for Claude Code (ANTHROPIC_DEFAULT_OPUS_MODEL)"
+        )
+        .option(
+            "--sonnet-model <model>",
+            "Sonnet tier model ID for Claude Code (ANTHROPIC_DEFAULT_SONNET_MODEL)"
+        )
+        .option(
+            "--haiku-model <model>",
+            "Haiku tier model ID for Claude Code (ANTHROPIC_DEFAULT_HAIKU_MODEL)"
+        )
+        .option("--fish", "Generate fish shell export syntax (shorthand for --shell fish)")
         .option("--shell <shell>", "Target shell syntax (bash, zsh, fish, powershell, cmd)")
         .action(async (tool, opts) => {
             await envCommand(tool, opts);
@@ -87,13 +107,22 @@ export function createCli(): Command {
 
     program
         .command("run <tool> [args...]")
-        .description("Run a tool CLI with SRouter environment variables injected on the fly")
-        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .description("Run a tool CLI directly with SRouter proxy environment variables injected")
+        .option("-u, --url <url>", "SRouter Gateway Base URL (e.g. http://localhost:3000/v1)")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Model ID")
-        .option("--opus-model <model>", "Opus model ID (ANTHROPIC_DEFAULT_OPUS_MODEL)")
-        .option("--sonnet-model <model>", "Sonnet model ID (ANTHROPIC_DEFAULT_SONNET_MODEL)")
-        .option("--haiku-model <model>", "Haiku model ID (ANTHROPIC_DEFAULT_HAIKU_MODEL)")
+        .option(
+            "--opus-model <model>",
+            "Opus tier model ID for Claude Code (ANTHROPIC_DEFAULT_OPUS_MODEL)"
+        )
+        .option(
+            "--sonnet-model <model>",
+            "Sonnet tier model ID for Claude Code (ANTHROPIC_DEFAULT_SONNET_MODEL)"
+        )
+        .option(
+            "--haiku-model <model>",
+            "Haiku tier model ID for Claude Code (ANTHROPIC_DEFAULT_HAIKU_MODEL)"
+        )
         .allowUnknownOption()
         .action(async (tool, args, opts) => {
             await runCommand(tool, args, opts);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,86 @@
+import { Command } from "commander";
+import { setupCommand } from "./commands/setup.ts";
+import { linkCommand } from "./commands/link.ts";
+import { unlinkCommand } from "./commands/unlink.ts";
+import { statusCommand } from "./commands/status.ts";
+import { envCommand } from "./commands/env.ts";
+import { runCommand } from "./commands/run.ts";
+
+export function createCli(): Command {
+    const program = new Command();
+
+    program
+        .name("srouter")
+        .description("CLI tool to configure and link AI coding tools to SRouter")
+        .version("0.1.1-rc.1");
+
+    program
+        .command("setup")
+        .alias("config")
+        .description(
+            "Interactive wizard to connect AI coding tools (Claude Code, OpenCode) to SRouter"
+        )
+        .option("-u, --url <url>", "SRouter Gateway Base URL (e.g. http://localhost:3000/v1)")
+        .option("-k, --key <key>", "SRouter API Key")
+        .option("-m, --model <model>", "Default model ID to configure")
+        .action(async (opts) => {
+            await setupCommand(opts);
+        });
+
+    program
+        .command("link <tool>")
+        .description("Configure a specific tool to use SRouter proxy (claude, opencode)")
+        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .option("-k, --key <key>", "SRouter API Key")
+        .option("-m, --model <model>", "Model ID")
+        .option("--dry-run", "Simulate without writing files")
+        .action(async (tool, opts) => {
+            await linkCommand(tool, opts);
+        });
+
+    program
+        .command("unlink <tool>")
+        .description("Restore original configuration for a tool from backup")
+        .action(async (tool) => {
+            await unlinkCommand(tool);
+        });
+
+    program
+        .command("status")
+        .alias("doctor")
+        .description("Inspect SRouter server connectivity and tool integration status")
+        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .option("-k, --key <key>", "SRouter API Key")
+        .action(async (opts) => {
+            await statusCommand(opts);
+        });
+
+    program
+        .command("env [tool]")
+        .description("Print shell export commands for SRouter proxy environment variables")
+        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .option("-k, --key <key>", "SRouter API Key")
+        .option("-m, --model <model>", "Model ID")
+        .option("--fish", "Generate fish shell export syntax")
+        .action(async (tool, opts) => {
+            await envCommand(tool, opts);
+        });
+
+    program
+        .command("run <tool> [args...]")
+        .description("Run a tool CLI with SRouter environment variables injected on the fly")
+        .option("-u, --url <url>", "SRouter Gateway Base URL")
+        .option("-k, --key <key>", "SRouter API Key")
+        .option("-m, --model <model>", "Model ID")
+        .allowUnknownOption()
+        .action(async (tool, args, opts) => {
+            await runCommand(tool, args, opts);
+        });
+
+    return program;
+}
+
+if (process.argv[1]?.endsWith("srouter.js") || process.argv[1]?.endsWith("index.ts")) {
+    const program = createCli();
+    program.parse(process.argv);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,6 +23,18 @@ export function createCli(): Command {
         .option("-u, --url <url>", "SRouter Gateway Base URL (e.g. http://localhost:3000/v1)")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Default model ID to configure")
+        .option(
+            "--opus-model <model>",
+            "Default Opus model for Claude Code (ANTHROPIC_DEFAULT_OPUS_MODEL)"
+        )
+        .option(
+            "--sonnet-model <model>",
+            "Default Sonnet model for Claude Code (ANTHROPIC_DEFAULT_SONNET_MODEL)"
+        )
+        .option(
+            "--haiku-model <model>",
+            "Default Haiku model for Claude Code (ANTHROPIC_DEFAULT_HAIKU_MODEL)"
+        )
         .action(async (opts) => {
             await setupCommand(opts);
         });
@@ -33,6 +45,9 @@ export function createCli(): Command {
         .option("-u, --url <url>", "SRouter Gateway Base URL")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Model ID")
+        .option("--opus-model <model>", "Opus model ID (ANTHROPIC_DEFAULT_OPUS_MODEL)")
+        .option("--sonnet-model <model>", "Sonnet model ID (ANTHROPIC_DEFAULT_SONNET_MODEL)")
+        .option("--haiku-model <model>", "Haiku model ID (ANTHROPIC_DEFAULT_HAIKU_MODEL)")
         .option("--dry-run", "Simulate without writing files")
         .action(async (tool, opts) => {
             await linkCommand(tool, opts);
@@ -61,7 +76,11 @@ export function createCli(): Command {
         .option("-u, --url <url>", "SRouter Gateway Base URL")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Model ID")
+        .option("--opus-model <model>", "Opus model ID (ANTHROPIC_DEFAULT_OPUS_MODEL)")
+        .option("--sonnet-model <model>", "Sonnet model ID (ANTHROPIC_DEFAULT_SONNET_MODEL)")
+        .option("--haiku-model <model>", "Haiku model ID (ANTHROPIC_DEFAULT_HAIKU_MODEL)")
         .option("--fish", "Generate fish shell export syntax")
+        .option("--shell <shell>", "Target shell syntax (bash, zsh, fish, powershell, cmd)")
         .action(async (tool, opts) => {
             await envCommand(tool, opts);
         });
@@ -72,6 +91,9 @@ export function createCli(): Command {
         .option("-u, --url <url>", "SRouter Gateway Base URL")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Model ID")
+        .option("--opus-model <model>", "Opus model ID (ANTHROPIC_DEFAULT_OPUS_MODEL)")
+        .option("--sonnet-model <model>", "Sonnet model ID (ANTHROPIC_DEFAULT_SONNET_MODEL)")
+        .option("--haiku-model <model>", "Haiku model ID (ANTHROPIC_DEFAULT_HAIKU_MODEL)")
         .allowUnknownOption()
         .action(async (tool, args, opts) => {
             await runCommand(tool, args, opts);

--- a/apps/cli/src/lib/configStore.ts
+++ b/apps/cli/src/lib/configStore.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import type { BackupEntry, CliConfig } from "../types/index.ts";
+import type { BackupEntry, CliConfig } from "../types/index.js";
 
 export const DEFAULT_CLI_CONFIG: CliConfig = {
     defaultBaseUrl: "http://localhost:3000/v1",
@@ -54,7 +54,6 @@ export class ConfigStore {
         try {
             await fs.access(originalPath);
         } catch {
-            // Original file does not exist yet, no need to backup
             return undefined;
         }
 
@@ -98,12 +97,10 @@ export class ConfigStore {
             await fs.mkdir(path.dirname(latest.originalPath), { recursive: true });
             await fs.copyFile(latest.backupPath, latest.originalPath);
 
-            // Remove restored backup from registry
             const config = await this.loadConfig();
             const updatedBackups = config.backups.filter((b) => b.backupPath !== latest.backupPath);
             await this.saveConfig({ backups: updatedBackups });
 
-            // Remove physical backup file
             await fs.rm(latest.backupPath, { force: true });
             return true;
         } catch {

--- a/apps/cli/src/lib/configStore.ts
+++ b/apps/cli/src/lib/configStore.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { BackupEntry, CliConfig } from "../types/index.ts";
+
+export const DEFAULT_CLI_CONFIG: CliConfig = {
+    defaultBaseUrl: "http://localhost:3000/v1",
+    backups: []
+};
+
+export class ConfigStore {
+    private baseDir: string;
+    private configPath: string;
+    private backupsDir: string;
+
+    constructor(customBaseDir?: string) {
+        this.baseDir = customBaseDir || path.join(os.homedir(), ".srouter");
+        this.configPath = path.join(this.baseDir, "cli.json");
+        this.backupsDir = path.join(this.baseDir, "backups");
+    }
+
+    private async ensureDirs(): Promise<void> {
+        await fs.mkdir(this.baseDir, { recursive: true });
+        await fs.mkdir(this.backupsDir, { recursive: true });
+    }
+
+    async loadConfig(): Promise<CliConfig> {
+        try {
+            const raw = await fs.readFile(this.configPath, "utf-8");
+            const data = JSON.parse(raw);
+            return {
+                ...DEFAULT_CLI_CONFIG,
+                ...data,
+                backups: Array.isArray(data?.backups) ? data.backups : []
+            };
+        } catch {
+            return { ...DEFAULT_CLI_CONFIG };
+        }
+    }
+
+    async saveConfig(partial: Partial<CliConfig>): Promise<CliConfig> {
+        await this.ensureDirs();
+        const current = await this.loadConfig();
+        const updated: CliConfig = {
+            ...current,
+            ...partial,
+            backups: partial.backups ?? current.backups
+        };
+        await fs.writeFile(this.configPath, JSON.stringify(updated, null, 4), "utf-8");
+        return updated;
+    }
+
+    async createBackup(toolId: string, originalPath: string): Promise<string | undefined> {
+        try {
+            await fs.access(originalPath);
+        } catch {
+            // Original file does not exist yet, no need to backup
+            return undefined;
+        }
+
+        await this.ensureDirs();
+        const timestamp = Date.now();
+        const ext = path.extname(originalPath) || ".json";
+        const backupFileName = `${toolId}-${timestamp}${ext}`;
+        const backupPath = path.join(this.backupsDir, backupFileName);
+
+        await fs.copyFile(originalPath, backupPath);
+
+        const config = await this.loadConfig();
+        const entry: BackupEntry = {
+            toolId,
+            originalPath,
+            backupPath,
+            timestamp
+        };
+
+        await this.saveConfig({
+            backups: [...config.backups, entry]
+        });
+
+        return backupPath;
+    }
+
+    async getLatestBackup(toolId: string): Promise<BackupEntry | undefined> {
+        const config = await this.loadConfig();
+        const entries = config.backups.filter((b) => b.toolId === toolId);
+        if (entries.length === 0) return undefined;
+        return entries.sort((a, b) => b.timestamp - a.timestamp)[0];
+    }
+
+    async restoreLatestBackup(toolId: string): Promise<boolean> {
+        const latest = await this.getLatestBackup(toolId);
+        if (!latest) {
+            return false;
+        }
+
+        try {
+            await fs.mkdir(path.dirname(latest.originalPath), { recursive: true });
+            await fs.copyFile(latest.backupPath, latest.originalPath);
+
+            // Remove restored backup from registry
+            const config = await this.loadConfig();
+            const updatedBackups = config.backups.filter((b) => b.backupPath !== latest.backupPath);
+            await this.saveConfig({ backups: updatedBackups });
+
+            // Remove physical backup file
+            await fs.rm(latest.backupPath, { force: true });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}
+
+export const defaultStore = new ConfigStore();

--- a/apps/cli/src/lib/platform.ts
+++ b/apps/cli/src/lib/platform.ts
@@ -1,0 +1,184 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+export type PlatformType = "windows" | "macos" | "linux" | "unknown";
+export type ShellType = "bash" | "zsh" | "fish" | "powershell" | "cmd";
+
+export interface SystemInfo {
+    platform: PlatformType;
+    osType: string;
+    osRelease: string;
+    arch: string;
+    displayName: string;
+    homeDir: string;
+    detectedShell: ShellType;
+}
+
+export function getPlatform(): PlatformType {
+    const p = process.platform;
+    if (p === "win32") return "windows";
+    if (p === "darwin") return "macos";
+    if (p === "linux") return "linux";
+    return "unknown";
+}
+
+export function isWindows(): boolean {
+    return process.platform === "win32";
+}
+
+export function isMacOS(): boolean {
+    return process.platform === "darwin";
+}
+
+export function isLinux(): boolean {
+    return process.platform === "linux";
+}
+
+export function getOsDisplayName(): string {
+    const p = getPlatform();
+    const arch = os.arch();
+    const rel = os.release();
+
+    switch (p) {
+        case "macos":
+            return `macOS (${arch === "arm64" ? "Apple Silicon" : arch}) [Darwin ${rel}]`;
+        case "windows":
+            return `Windows (${arch}) [NT ${rel}]`;
+        case "linux":
+            return `Linux (${arch}) [${rel}]`;
+        default:
+            return `${process.platform} (${arch})`;
+    }
+}
+
+export function detectShell(): ShellType {
+    const shellEnv = process.env.SHELL?.toLowerCase() || "";
+    if (shellEnv.includes("fish")) return "fish";
+    if (shellEnv.includes("zsh")) return "zsh";
+    if (shellEnv.includes("bash")) return "bash";
+
+    if (isWindows()) {
+        if (process.env.PSModulePath || process.env.POWERSHELL_DISTRIBUTION_CHANNEL) {
+            return "powershell";
+        }
+        return "cmd";
+    }
+
+    return "bash";
+}
+
+export function getSystemInfo(): SystemInfo {
+    return {
+        platform: getPlatform(),
+        osType: os.type(),
+        osRelease: os.release(),
+        arch: os.arch(),
+        displayName: getOsDisplayName(),
+        homeDir: os.homedir(),
+        detectedShell: detectShell()
+    };
+}
+
+export async function isExecutableInPath(command: string): Promise<boolean> {
+    const lookupCmd = isWindows() ? `where.exe ${command}` : `which ${command}`;
+    try {
+        await execAsync(lookupCmd);
+        return true;
+    } catch {
+        if (isWindows()) {
+            try {
+                await execAsync(`where ${command}`);
+                return true;
+            } catch {
+                return false;
+            }
+        }
+        return false;
+    }
+}
+
+export function getClaudeConfigPath(): string {
+    const home = os.homedir();
+    const candidatePaths: string[] = [];
+
+    // Optional environment variable override
+    if (process.env.CLAUDE_CONFIG_DIR) {
+        candidatePaths.push(path.join(process.env.CLAUDE_CONFIG_DIR, "config.json"));
+    }
+
+    // Standard ~/.claude.json across all platforms
+    candidatePaths.push(path.join(home, ".claude.json"));
+
+    // Platform-specific secondary paths
+    if (isWindows()) {
+        const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+        candidatePaths.push(path.join(appData, "Claude", "config.json"));
+    } else {
+        candidatePaths.push(path.join(home, ".claude", "config.json"));
+        candidatePaths.push(path.join(home, ".config", "claude", "config.json"));
+    }
+
+    for (const p of candidatePaths) {
+        if (fs.existsSync(p)) {
+            return p;
+        }
+    }
+
+    // Default standard config file
+    return path.join(home, ".claude.json");
+}
+
+export function getOpenCodeConfigPath(): string {
+    const home = os.homedir();
+    const candidatePaths: string[] = [];
+
+    if (isWindows()) {
+        const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+        candidatePaths.push(path.join(appData, "opencode", "config.json"));
+        candidatePaths.push(path.join(home, ".config", "opencode", "config.json"));
+    } else if (isMacOS()) {
+        candidatePaths.push(
+            path.join(home, "Library", "Application Support", "opencode", "config.json")
+        );
+        candidatePaths.push(path.join(home, ".config", "opencode", "config.json"));
+    } else {
+        const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+        candidatePaths.push(path.join(xdgConfig, "opencode", "config.json"));
+    }
+
+    candidatePaths.push(path.join(home, ".opencode.json"));
+
+    for (const p of candidatePaths) {
+        if (fs.existsSync(p)) {
+            return p;
+        }
+    }
+
+    if (isWindows()) {
+        const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+        return path.join(appData, "opencode", "config.json");
+    }
+
+    const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+    return path.join(xdgConfig, "opencode", "config.json");
+}
+
+export function formatShellExport(key: string, value: string, shell: ShellType): string {
+    switch (shell) {
+        case "powershell":
+            return `$env:${key} = "${value}"`;
+        case "cmd":
+            return `set ${key}=${value}`;
+        case "fish":
+            return `set -gx ${key} "${value}";`;
+        case "bash":
+        case "zsh":
+        default:
+            return `export ${key}="${value}"`;
+    }
+}

--- a/apps/cli/src/lib/srouterClient.ts
+++ b/apps/cli/src/lib/srouterClient.ts
@@ -1,0 +1,89 @@
+export interface ServerHealthResult {
+    healthy: boolean;
+    modelsCount: number;
+    error?: string;
+    latencyMs?: number;
+}
+
+export function normalizeBaseUrl(baseUrl: string): string {
+    return baseUrl.trim().replace(/\/+$/, "");
+}
+
+export function getModelsEndpoint(baseUrl: string): string {
+    const cleanUrl = normalizeBaseUrl(baseUrl);
+    return cleanUrl.endsWith("/v1") ? `${cleanUrl}/models` : `${cleanUrl}/v1/models`;
+}
+
+export async function checkServerHealth(
+    baseUrl: string,
+    apiKey?: string,
+    timeoutMs: number = 3000
+): Promise<ServerHealthResult> {
+    const endpoint = getModelsEndpoint(baseUrl);
+    const start = Date.now();
+
+    try {
+        const headers: Record<string, string> = {
+            Accept: "application/json"
+        };
+        if (apiKey) {
+            headers["Authorization"] = `Bearer ${apiKey}`;
+        }
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+        const res = await fetch(endpoint, {
+            method: "GET",
+            headers,
+            signal: controller.signal
+        });
+        clearTimeout(timer);
+
+        if (!res.ok) {
+            return {
+                healthy: false,
+                modelsCount: 0,
+                error: `HTTP ${res.status}: ${res.statusText}`,
+                latencyMs: Date.now() - start
+            };
+        }
+
+        const data = (await res.json()) as any;
+        const models = Array.isArray(data?.data) ? data.data : [];
+
+        return {
+            healthy: true,
+            modelsCount: models.length,
+            latencyMs: Date.now() - start
+        };
+    } catch (err: any) {
+        return {
+            healthy: false,
+            modelsCount: 0,
+            error: err.name === "AbortError" ? "Connection timeout" : err.message,
+            latencyMs: Date.now() - start
+        };
+    }
+}
+
+export async function fetchAvailableModels(baseUrl: string, apiKey?: string): Promise<string[]> {
+    const endpoint = getModelsEndpoint(baseUrl);
+
+    try {
+        const headers: Record<string, string> = { Accept: "application/json" };
+        if (apiKey) {
+            headers["Authorization"] = `Bearer ${apiKey}`;
+        }
+
+        const res = await fetch(endpoint, { headers });
+        if (!res.ok) return [];
+        const data = (await res.json()) as any;
+        if (!Array.isArray(data?.data)) return [];
+        return data.data
+            .map((m: any) => (typeof m === "string" ? m : m?.id))
+            .filter((id: any): id is string => typeof id === "string" && id.length > 0);
+    } catch {
+        return [];
+    }
+}

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -1,0 +1,32 @@
+import pc from "picocolors";
+import { intro, outro, spinner, note } from "@clack/prompts";
+
+export const banner = `
+   ____  ____              __           
+  / __/ / __ \\___  __ __  / /____  ____ 
+ _\\ \\  / /_/ / _ \\/ // / / __/ -_)/ __/ 
+/___/  \\____/\\___/\\_,_/  \\__/\\__//_/    
+  ${pc.bold(pc.cyan("AI Gateway & LLM Proxy Router CLI"))}
+`;
+
+export function showHeader(): void {
+    console.log(pc.magenta(banner));
+}
+
+export function formatSuccess(msg: string): string {
+    return `${pc.green("✔")} ${msg}`;
+}
+
+export function formatError(msg: string): string {
+    return `${pc.red("✖")} ${msg}`;
+}
+
+export function formatWarning(msg: string): string {
+    return `${pc.yellow("⚠")} ${msg}`;
+}
+
+export function formatInfo(msg: string): string {
+    return `${pc.cyan("ℹ")} ${msg}`;
+}
+
+export { pc, intro, outro, spinner, note };

--- a/apps/cli/src/types/index.ts
+++ b/apps/cli/src/types/index.ts
@@ -1,0 +1,49 @@
+export interface ToolConfigContext {
+    baseUrl: string;
+    apiKey?: string;
+    model?: string;
+    dryRun?: boolean;
+}
+
+export interface ToolStatus {
+    id: string;
+    name: string;
+    installed: boolean;
+    linked: boolean;
+    configPath?: string;
+    currentBaseUrl?: string;
+    currentModel?: string;
+}
+
+export interface LinkResult {
+    backupPath?: string;
+    modifiedPath: string;
+    created?: boolean;
+}
+
+export interface BaseToolAdapter {
+    readonly id: string;
+    readonly name: string;
+    readonly description: string;
+
+    isInstalled(): Promise<boolean>;
+    getStatus(): Promise<ToolStatus>;
+    link(context: ToolConfigContext): Promise<LinkResult>;
+    unlink(): Promise<boolean>;
+    getEnv(context: ToolConfigContext): Record<string, string>;
+}
+
+export interface BackupEntry {
+    toolId: string;
+    originalPath: string;
+    backupPath: string;
+    timestamp: number;
+}
+
+export interface CliConfig {
+    defaultBaseUrl: string;
+    defaultApiKey?: string;
+    defaultModel?: string;
+    backups: BackupEntry[];
+    lastSetupAt?: number;
+}

--- a/apps/cli/src/types/index.ts
+++ b/apps/cli/src/types/index.ts
@@ -2,6 +2,9 @@ export interface ToolConfigContext {
     baseUrl: string;
     apiKey?: string;
     model?: string;
+    opusModel?: string;
+    sonnetModel?: string;
+    haikuModel?: string;
     dryRun?: boolean;
 }
 
@@ -13,6 +16,9 @@ export interface ToolStatus {
     configPath?: string;
     currentBaseUrl?: string;
     currentModel?: string;
+    currentOpusModel?: string;
+    currentSonnetModel?: string;
+    currentHaikuModel?: string;
 }
 
 export interface LinkResult {
@@ -44,6 +50,9 @@ export interface CliConfig {
     defaultBaseUrl: string;
     defaultApiKey?: string;
     defaultModel?: string;
+    defaultOpusModel?: string;
+    defaultSonnetModel?: string;
+    defaultHaikuModel?: string;
     backups: BackupEntry[];
     lastSetupAt?: number;
 }

--- a/apps/cli/tests/claudeAdapter.test.ts
+++ b/apps/cli/tests/claudeAdapter.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { ConfigStore } from "../src/lib/configStore.ts";
+import { ClaudeAdapter } from "../src/adapters/claude.ts";
+
+test("ClaudeAdapter - link and unlink lifecycle", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-claude-test-"));
+    try {
+        const store = new ConfigStore(tempDir);
+        const customConfigPath = path.join(tempDir, ".claude.json");
+
+        // Create initial config
+        await fs.writeFile(
+            customConfigPath,
+            JSON.stringify({ model: "claude-orig", hasCompletedOnboarding: true })
+        );
+
+        const adapter = new ClaudeAdapter(store, customConfigPath);
+
+        const statusBefore = await adapter.getStatus();
+        assert.equal(statusBefore.linked, false);
+        assert.equal(statusBefore.currentModel, "claude-orig");
+
+        // Link with SRouter
+        const result = await adapter.link({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sk-srouter-key",
+            model: "claude-3-7-sonnet"
+        });
+
+        assert.ok(result.backupPath);
+        assert.equal(result.modifiedPath, customConfigPath);
+
+        const statusAfter = await adapter.getStatus();
+        assert.equal(statusAfter.linked, true);
+        assert.equal(statusAfter.currentBaseUrl, "http://localhost:3000/v1");
+        assert.equal(statusAfter.currentModel, "claude-3-7-sonnet");
+
+        // Check getEnv
+        const env = adapter.getEnv({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sk-srouter-key",
+            model: "claude-3-7-sonnet"
+        });
+        assert.equal(env.ANTHROPIC_BASE_URL, "http://localhost:3000/v1");
+        assert.equal(env.ANTHROPIC_API_KEY, "sk-srouter-key");
+
+        // Unlink & restore
+        const unlinked = await adapter.unlink();
+        assert.equal(unlinked, true);
+
+        const restoredContent = JSON.parse(await fs.readFile(customConfigPath, "utf-8"));
+        assert.equal(restoredContent.model, "claude-orig");
+        assert.equal(restoredContent.ANTHROPIC_BASE_URL, undefined);
+    } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    }
+});

--- a/apps/cli/tests/claudeAdapter.test.ts
+++ b/apps/cli/tests/claudeAdapter.test.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { ConfigStore } from "../src/lib/configStore.ts";
-import { ClaudeAdapter } from "../src/adapters/claude.ts";
+import { ConfigStore } from "../src/lib/configStore.js";
+import { ClaudeAdapter } from "../src/adapters/claude.js";
 
 test("ClaudeAdapter - link and unlink lifecycle", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-claude-test-"));

--- a/apps/cli/tests/claudeAdapter.test.ts
+++ b/apps/cli/tests/claudeAdapter.test.ts
@@ -59,3 +59,71 @@ test("ClaudeAdapter - link and unlink lifecycle", async () => {
         await fs.rm(tempDir, { recursive: true, force: true });
     }
 });
+
+test("ClaudeAdapter - link with tier models and getEnv", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-claude-tiers-test-"));
+    try {
+        const store = new ConfigStore(tempDir);
+        const customConfigPath = path.join(tempDir, ".claude.json");
+
+        const adapter = new ClaudeAdapter(store, customConfigPath);
+
+        // Link with tier models
+        const result = await adapter.link({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sk-srouter-key",
+            model: "claude-3-7-sonnet",
+            opusModel: "claude-3-opus-20240229",
+            sonnetModel: "claude-3-7-sonnet-20250219",
+            haikuModel: "claude-3-5-haiku-20241022"
+        });
+
+        assert.equal(result.modifiedPath, customConfigPath);
+
+        const status = await adapter.getStatus();
+        assert.equal(status.linked, true);
+        assert.equal(status.currentBaseUrl, "http://localhost:3000/v1");
+        assert.equal(status.currentModel, "claude-3-7-sonnet");
+        assert.equal(status.currentOpusModel, "claude-3-opus-20240229");
+        assert.equal(status.currentSonnetModel, "claude-3-7-sonnet-20250219");
+        assert.equal(status.currentHaikuModel, "claude-3-5-haiku-20241022");
+
+        // Verify written file content
+        const savedData = JSON.parse(await fs.readFile(customConfigPath, "utf-8"));
+        assert.equal(savedData.ANTHROPIC_BASE_URL, "http://localhost:3000/v1");
+        assert.equal(savedData.ANTHROPIC_API_KEY, "sk-srouter-key");
+        assert.equal(savedData.ANTHROPIC_DEFAULT_OPUS_MODEL, "claude-3-opus-20240229");
+        assert.equal(savedData.ANTHROPIC_DEFAULT_SONNET_MODEL, "claude-3-7-sonnet-20250219");
+        assert.equal(savedData.ANTHROPIC_DEFAULT_HAIKU_MODEL, "claude-3-5-haiku-20241022");
+
+        // Verify getEnv
+        const env = adapter.getEnv({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sk-srouter-key",
+            model: "claude-3-7-sonnet",
+            opusModel: "claude-3-opus-20240229",
+            sonnetModel: "claude-3-7-sonnet-20250219",
+            haikuModel: "claude-3-5-haiku-20241022"
+        });
+
+        assert.equal(env.ANTHROPIC_BASE_URL, "http://localhost:3000/v1");
+        assert.equal(env.ANTHROPIC_API_KEY, "sk-srouter-key");
+        assert.equal(env.ANTHROPIC_MODEL, "claude-3-7-sonnet");
+        assert.equal(env.ANTHROPIC_DEFAULT_OPUS_MODEL, "claude-3-opus-20240229");
+        assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, "claude-3-7-sonnet-20250219");
+        assert.equal(env.ANTHROPIC_DEFAULT_HAIKU_MODEL, "claude-3-5-haiku-20241022");
+
+        // Unlink manually without backup
+        const unlinked = await adapter.unlink();
+        assert.equal(unlinked, true);
+
+        const unlinkedData = JSON.parse(await fs.readFile(customConfigPath, "utf-8"));
+        assert.equal(unlinkedData.ANTHROPIC_BASE_URL, undefined);
+        assert.equal(unlinkedData.ANTHROPIC_API_KEY, undefined);
+        assert.equal(unlinkedData.ANTHROPIC_DEFAULT_OPUS_MODEL, undefined);
+        assert.equal(unlinkedData.ANTHROPIC_DEFAULT_SONNET_MODEL, undefined);
+        assert.equal(unlinkedData.ANTHROPIC_DEFAULT_HAIKU_MODEL, undefined);
+    } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    }
+});

--- a/apps/cli/tests/cli.test.ts
+++ b/apps/cli/tests/cli.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createCli } from "../src/index.ts";
+
+test("CLI - command registration and metadata", () => {
+    const program = createCli();
+
+    assert.equal(program.name(), "srouter");
+    assert.equal(program.version(), "0.1.1-rc.1");
+
+    const commandNames = program.commands.map((cmd) => cmd.name());
+    assert.ok(commandNames.includes("setup"));
+    assert.ok(commandNames.includes("link"));
+    assert.ok(commandNames.includes("unlink"));
+    assert.ok(commandNames.includes("status"));
+    assert.ok(commandNames.includes("env"));
+    assert.ok(commandNames.includes("run"));
+});

--- a/apps/cli/tests/cli.test.ts
+++ b/apps/cli/tests/cli.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createCli } from "../src/index.ts";
+import { createCli } from "../src/index.js";
 
 test("CLI - command registration and metadata", () => {
     const program = createCli();

--- a/apps/cli/tests/cli.test.ts
+++ b/apps/cli/tests/cli.test.ts
@@ -15,4 +15,19 @@ test("CLI - command registration and metadata", () => {
     assert.ok(commandNames.includes("status"));
     assert.ok(commandNames.includes("env"));
     assert.ok(commandNames.includes("run"));
+
+    // Check options on commands
+    const checkOptions = (cmdName: string) => {
+        const cmd = program.commands.find((c) => c.name() === cmdName);
+        assert.ok(cmd, `Command ${cmdName} should exist`);
+        const optionFlags = cmd.options.map((o) => o.long);
+        assert.ok(optionFlags.includes("--opus-model"), `${cmdName} should have --opus-model`);
+        assert.ok(optionFlags.includes("--sonnet-model"), `${cmdName} should have --sonnet-model`);
+        assert.ok(optionFlags.includes("--haiku-model"), `${cmdName} should have --haiku-model`);
+    };
+
+    checkOptions("setup");
+    checkOptions("link");
+    checkOptions("env");
+    checkOptions("run");
 });

--- a/apps/cli/tests/configStore.test.ts
+++ b/apps/cli/tests/configStore.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { ConfigStore } from "../src/lib/configStore.ts";
+import { ConfigStore } from "../src/lib/configStore.js";
 
 test("ConfigStore - load and save config", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-cli-test-"));

--- a/apps/cli/tests/configStore.test.ts
+++ b/apps/cli/tests/configStore.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { ConfigStore } from "../src/lib/configStore.ts";
+
+test("ConfigStore - load and save config", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-cli-test-"));
+    try {
+        const store = new ConfigStore(tempDir);
+        const initial = await store.loadConfig();
+        assert.equal(initial.defaultBaseUrl, "http://localhost:3000/v1");
+        assert.deepEqual(initial.backups, []);
+
+        await store.saveConfig({
+            defaultBaseUrl: "http://localhost:4000/v1",
+            defaultApiKey: "sk-test-123"
+        });
+
+        const updated = await store.loadConfig();
+        assert.equal(updated.defaultBaseUrl, "http://localhost:4000/v1");
+        assert.equal(updated.defaultApiKey, "sk-test-123");
+    } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    }
+});
+
+test("ConfigStore - backup and restore workflow", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-cli-test-"));
+    try {
+        const store = new ConfigStore(tempDir);
+        const sampleConfigFile = path.join(tempDir, "mock-tool.json");
+
+        // 1. Create a dummy original config
+        await fs.writeFile(
+            sampleConfigFile,
+            JSON.stringify({ original: true, model: "old-model" })
+        );
+
+        // 2. Backup
+        const backupPath = await store.createBackup("mock-tool", sampleConfigFile);
+        assert.ok(backupPath);
+        assert.ok(backupPath.includes("mock-tool-"));
+
+        // 3. Mutate original
+        await fs.writeFile(
+            sampleConfigFile,
+            JSON.stringify({ modified: true, model: "srouter-model" })
+        );
+
+        // 4. Restore
+        const restored = await store.restoreLatestBackup("mock-tool");
+        assert.equal(restored, true);
+
+        const content = JSON.parse(await fs.readFile(sampleConfigFile, "utf-8"));
+        assert.equal(content.original, true);
+        assert.equal(content.model, "old-model");
+    } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    }
+});

--- a/apps/cli/tests/opencodeAdapter.test.ts
+++ b/apps/cli/tests/opencodeAdapter.test.ts
@@ -38,7 +38,7 @@ test("OpenCodeAdapter - link and unlink lifecycle", async () => {
         const statusAfter = await adapter.getStatus();
         assert.equal(statusAfter.linked, true);
         assert.equal(statusAfter.currentBaseUrl, "http://localhost:3000/v1");
-        assert.equal(statusAfter.currentModel, "claude-3-7-sonnet");
+        assert.equal(statusAfter.currentModel, "srouter/claude-3-7-sonnet");
 
         // Check getEnv
         const env = adapter.getEnv({

--- a/apps/cli/tests/opencodeAdapter.test.ts
+++ b/apps/cli/tests/opencodeAdapter.test.ts
@@ -3,9 +3,9 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { ConfigStore } from "../src/lib/configStore.ts";
-import { OpenCodeAdapter } from "../src/adapters/opencode.ts";
-import { getAllAdapters, getAdapter } from "../src/adapters/index.ts";
+import { ConfigStore } from "../src/lib/configStore.js";
+import { OpenCodeAdapter } from "../src/adapters/opencode.js";
+import { getAllAdapters, getAdapter } from "../src/adapters/index.js";
 
 test("OpenCodeAdapter - link and unlink lifecycle", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-opencode-test-"));

--- a/apps/cli/tests/opencodeAdapter.test.ts
+++ b/apps/cli/tests/opencodeAdapter.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { ConfigStore } from "../src/lib/configStore.ts";
+import { OpenCodeAdapter } from "../src/adapters/opencode.ts";
+import { getAllAdapters, getAdapter } from "../src/adapters/index.ts";
+
+test("OpenCodeAdapter - link and unlink lifecycle", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-opencode-test-"));
+    try {
+        const store = new ConfigStore(tempDir);
+        const customConfigPath = path.join(tempDir, "config.json");
+
+        // Create initial config
+        await fs.writeFile(
+            customConfigPath,
+            JSON.stringify({ model: "default-model", auto_run: true })
+        );
+
+        const adapter = new OpenCodeAdapter(store, customConfigPath);
+
+        const statusBefore = await adapter.getStatus();
+        assert.equal(statusBefore.linked, false);
+        assert.equal(statusBefore.currentModel, "default-model");
+
+        // Link with SRouter
+        const result = await adapter.link({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sk-srouter-key",
+            model: "claude-3-7-sonnet"
+        });
+
+        assert.ok(result.backupPath);
+        assert.equal(result.modifiedPath, customConfigPath);
+
+        const statusAfter = await adapter.getStatus();
+        assert.equal(statusAfter.linked, true);
+        assert.equal(statusAfter.currentBaseUrl, "http://localhost:3000/v1");
+        assert.equal(statusAfter.currentModel, "claude-3-7-sonnet");
+
+        // Check getEnv
+        const env = adapter.getEnv({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sk-srouter-key",
+            model: "claude-3-7-sonnet"
+        });
+        assert.equal(env.OPENAI_BASE_URL, "http://localhost:3000/v1");
+        assert.equal(env.OPENAI_API_KEY, "sk-srouter-key");
+
+        // Unlink & restore
+        const unlinked = await adapter.unlink();
+        assert.equal(unlinked, true);
+
+        const restoredContent = JSON.parse(await fs.readFile(customConfigPath, "utf-8"));
+        assert.equal(restoredContent.model, "default-model");
+        assert.equal(restoredContent.openai_base_url, undefined);
+    } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    }
+});
+
+test("Adapter Registry - retrieves registered adapters", () => {
+    const adapters = getAllAdapters();
+    assert.ok(adapters.length >= 2);
+
+    const claude = getAdapter("claude");
+    assert.ok(claude);
+    assert.equal(claude?.id, "claude");
+
+    const opencode = getAdapter("opencode");
+    assert.ok(opencode);
+    assert.equal(opencode?.id, "opencode");
+
+    const nonexistent = getAdapter("nonexistent");
+    assert.equal(nonexistent, undefined);
+});

--- a/apps/cli/tests/platform.test.ts
+++ b/apps/cli/tests/platform.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+    getPlatform,
+    isWindows,
+    isMacOS,
+    isLinux,
+    getOsDisplayName,
+    detectShell,
+    getSystemInfo,
+    formatShellExport,
+    getClaudeConfigPath,
+    getOpenCodeConfigPath,
+    isExecutableInPath
+} from "../src/lib/platform.js";
+
+test("platform - detects OS and returns valid platform information", () => {
+    const platform = getPlatform();
+    assert.ok(["windows", "macos", "linux", "unknown"].includes(platform));
+
+    if (process.platform === "win32") {
+        assert.equal(isWindows(), true);
+        assert.equal(isMacOS(), false);
+        assert.equal(isLinux(), false);
+    } else if (process.platform === "darwin") {
+        assert.equal(isWindows(), false);
+        assert.equal(isMacOS(), true);
+        assert.equal(isLinux(), false);
+    } else if (process.platform === "linux") {
+        assert.equal(isWindows(), false);
+        assert.equal(isMacOS(), false);
+        assert.equal(isLinux(), true);
+    }
+
+    const displayName = getOsDisplayName();
+    assert.ok(typeof displayName === "string" && displayName.length > 0);
+
+    const sysInfo = getSystemInfo();
+    assert.equal(sysInfo.platform, platform);
+    assert.ok(sysInfo.homeDir.length > 0);
+    assert.ok(sysInfo.displayName.length > 0);
+});
+
+test("platform - detectShell and formatShellExport", () => {
+    const shell = detectShell();
+    assert.ok(["bash", "zsh", "fish", "powershell", "cmd"].includes(shell));
+
+    assert.equal(formatShellExport("FOO", "BAR", "bash"), 'export FOO="BAR"');
+    assert.equal(formatShellExport("FOO", "BAR", "zsh"), 'export FOO="BAR"');
+    assert.equal(formatShellExport("FOO", "BAR", "fish"), 'set -gx FOO "BAR";');
+    assert.equal(formatShellExport("FOO", "BAR", "powershell"), '$env:FOO = "BAR"');
+    assert.equal(formatShellExport("FOO", "BAR", "cmd"), "set FOO=BAR");
+});
+
+test("platform - config path resolution", () => {
+    const claudePath = getClaudeConfigPath();
+    assert.ok(typeof claudePath === "string" && claudePath.length > 0);
+
+    const opencodePath = getOpenCodeConfigPath();
+    assert.ok(typeof opencodePath === "string" && opencodePath.length > 0);
+});
+
+test("platform - isExecutableInPath checks presence of binaries", async () => {
+    // node is guaranteed to be in PATH during test execution
+    const hasNode = await isExecutableInPath("node");
+    assert.equal(hasNode, true);
+
+    const hasFake = await isExecutableInPath("non_existent_binary_xyz_123");
+    assert.equal(hasFake, false);
+});

--- a/apps/cli/tests/srouterClient.test.ts
+++ b/apps/cli/tests/srouterClient.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
-import { checkServerHealth, fetchAvailableModels } from "../src/lib/srouterClient.ts";
+import { checkServerHealth, fetchAvailableModels } from "../src/lib/srouterClient.js";
 
 test("srouterClient - checkServerHealth and fetchAvailableModels", async () => {
     const server = http.createServer((req, res) => {

--- a/apps/cli/tests/srouterClient.test.ts
+++ b/apps/cli/tests/srouterClient.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { checkServerHealth, fetchAvailableModels } from "../src/lib/srouterClient.ts";
+
+test("srouterClient - checkServerHealth and fetchAvailableModels", async () => {
+    const server = http.createServer((req, res) => {
+        if (req.url === "/v1/models") {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    data: [
+                        { id: "claude-3-7-sonnet", object: "model" },
+                        { id: "gpt-4o", object: "model" }
+                    ]
+                })
+            );
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as any).port;
+    const baseUrl = `http://localhost:${port}`;
+
+    const health = await checkServerHealth(baseUrl);
+    assert.equal(health.healthy, true);
+    assert.equal(health.modelsCount, 2);
+
+    const models = await fetchAvailableModels(baseUrl);
+    assert.deepEqual(models, ["claude-3-7-sonnet", "gpt-4o"]);
+
+    server.close();
+});
+
+test("srouterClient - handles unreachable server gracefully", async () => {
+    const health = await checkServerHealth("http://localhost:59999", undefined, 500);
+    assert.equal(health.healthy, false);
+    assert.equal(health.modelsCount, 0);
+
+    const models = await fetchAvailableModels("http://localhost:59999");
+    assert.deepEqual(models, []);
+});

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,17 +1,15 @@
 {
     "compilerOptions": {
-        "target": "ES2022",
+        "target": "ESNext",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
-        "lib": ["ES2022"],
         "strict": true,
-        "esModuleInterop": true,
+        "verbatimModuleSyntax": true,
         "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "resolveJsonModule": true,
         "declaration": true,
-        "outDir": "./dist",
-        "rootDir": "./src"
+        "types": ["node"],
+        "rootDir": "./src",
+        "outDir": "./dist"
     },
     "include": ["src/**/*"]
 }

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "lib": ["ES2022"],
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "declaration": true,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
+}

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.ts"],
+    format: ["esm"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    target: "node22"
+});

--- a/docs/superpowers/plans/2026-08-19-apps-cli.md
+++ b/docs/superpowers/plans/2026-08-19-apps-cli.md
@@ -1,0 +1,394 @@
+# apps/cli Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `apps/cli` (`@srouter/cli`), a high-performance CLI tool with an interactive multi-select setup wizard and modular tool adapters (Claude Code and OpenCode) to automatically configure AI coding tools with SRouter proxy endpoints and environment variables.
+
+**Architecture:** Built with Commander for CLI routing, `@clack/prompts` and `picocolors` for sleek terminal TUI, and a pluggable `BaseToolAdapter` hierarchy. Stores configuration and safe backups in `~/.srouter/` with non-destructive restore capabilities.
+
+**Tech Stack:** TypeScript (ESM), Node.js (>=22.0.0), Commander, @clack/prompts, picocolors, @srouter/constants, @srouter/types, tsup, tsx, node:test.
+
+## Global Constraints
+
+- Never run build or live/dev server commands (`pnpm dev`, `pnpm start`, `pnpm build`, `turbo dev`, `turbo build`).
+- Safe commands only: `pnpm install`, `pnpm lint`, `pnpm format:check`, `tsx --test`.
+- Monorepo package name: `@srouter/cli`.
+- Formatting: 4-space indentation, double quotes, max 100 char width.
+
+---
+
+### Task 1: Package Scaffolding & Types
+
+**Files:**
+
+- Create: `apps/cli/package.json`
+- Create: `apps/cli/tsconfig.json`
+- Create: `apps/cli/tsup.config.ts`
+- Create: `apps/cli/bin/srouter.js`
+- Create: `apps/cli/src/types/index.ts`
+
+**Interfaces:**
+
+- Consumes: `@srouter/constants`, `@srouter/types`
+- Produces: `ToolConfigContext`, `ToolStatus`, `BaseToolAdapter`, `CliConfig`, `BackupEntry` in `apps/cli/src/types/index.ts`
+
+- [ ] **Step 1: Create apps/cli/package.json**
+
+```json
+{
+    "name": "@srouter/cli",
+    "version": "0.1.1-rc.1",
+    "description": "CLI tool for SRouter to automatically configure and link AI coding tools",
+    "type": "module",
+    "bin": {
+        "srouter": "./bin/srouter.js"
+    },
+    "scripts": {
+        "clean": "rm -rf dist",
+        "test": "tsx --test tests/**/*.test.ts"
+    },
+    "dependencies": {
+        "@clack/prompts": "^0.9.1",
+        "@srouter/constants": "workspace:*",
+        "@srouter/types": "workspace:*",
+        "commander": "^13.1.0",
+        "picocolors": "^1.1.1"
+    },
+    "devDependencies": {
+        "@types/node": "^26.1.1",
+        "tsup": "^8.5.1",
+        "tsx": "^4.23.0",
+        "typescript": "^5.0.0"
+    }
+}
+```
+
+- [ ] **Step 2: Create apps/cli/tsconfig.json and apps/cli/tsup.config.ts**
+
+```json
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "lib": ["ES2022"],
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "declaration": true,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
+}
+```
+
+- [ ] **Step 3: Create apps/cli/bin/srouter.js executable entrypoint**
+
+```javascript
+#!/usr/bin/env node
+import "../src/index.ts";
+```
+
+- [ ] **Step 4: Create apps/cli/src/types/index.ts**
+
+```typescript
+export interface ToolConfigContext {
+    baseUrl: string;
+    apiKey?: string;
+    model?: string;
+    dryRun?: boolean;
+}
+
+export interface ToolStatus {
+    id: string;
+    name: string;
+    installed: boolean;
+    linked: boolean;
+    configPath?: string;
+    currentBaseUrl?: string;
+    currentModel?: string;
+}
+
+export interface BaseToolAdapter {
+    readonly id: string;
+    readonly name: string;
+    readonly description: string;
+
+    isInstalled(): Promise<boolean>;
+    getStatus(): Promise<ToolStatus>;
+    link(context: ToolConfigContext): Promise<{ backupPath?: string; modifiedPath: string }>;
+    unlink(): Promise<boolean>;
+    getEnv(context: ToolConfigContext): Record<string, string>;
+}
+
+export interface BackupEntry {
+    toolId: string;
+    originalPath: string;
+    backupPath: string;
+    timestamp: number;
+}
+
+export interface CliConfig {
+    defaultBaseUrl: string;
+    defaultApiKey?: string;
+    defaultModel?: string;
+    backups: BackupEntry[];
+    lastSetupAt?: number;
+}
+```
+
+- [ ] **Step 5: Run pnpm install to link dependencies**
+
+Run: `pnpm install`
+Expected: Dependencies resolved cleanly.
+
+---
+
+### Task 2: SRouter Client & Discovery Module
+
+**Files:**
+
+- Create: `apps/cli/src/lib/srouterClient.ts`
+- Create: `apps/cli/tests/srouterClient.test.ts`
+
+**Interfaces:**
+
+- Produces: `checkServerHealth(baseUrl, apiKey?)`, `fetchAvailableModels(baseUrl, apiKey?)`
+
+- [ ] **Step 1: Write test in apps/cli/tests/srouterClient.test.ts**
+
+```typescript
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { checkServerHealth, fetchAvailableModels } from "../src/lib/srouterClient.js";
+
+test("srouterClient - checkServerHealth and fetchAvailableModels", async () => {
+    const server = http.createServer((req, res) => {
+        if (req.url === "/v1/models") {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    data: [
+                        { id: "claude-3-7-sonnet", object: "model" },
+                        { id: "gpt-4o", object: "model" }
+                    ]
+                })
+            );
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as any).port;
+    const baseUrl = `http://localhost:${port}`;
+
+    const health = await checkServerHealth(baseUrl);
+    assert.equal(health.healthy, true);
+    assert.equal(health.modelsCount, 2);
+
+    const models = await fetchAvailableModels(baseUrl);
+    assert.deepEqual(models, ["claude-3-7-sonnet", "gpt-4o"]);
+
+    server.close();
+});
+```
+
+- [ ] **Step 2: Implement apps/cli/src/lib/srouterClient.ts**
+
+```typescript
+export interface ServerHealthResult {
+    healthy: boolean;
+    modelsCount: number;
+    error?: string;
+    latencyMs?: number;
+}
+
+export async function checkServerHealth(
+    baseUrl: string,
+    apiKey?: string,
+    timeoutMs: number = 3000
+): Promise<ServerHealthResult> {
+    const cleanUrl = baseUrl.replace(/\/+$/, "");
+    const endpoint = cleanUrl.endsWith("/v1") ? `${cleanUrl}/models` : `${cleanUrl}/v1/models`;
+    const start = Date.now();
+
+    try {
+        const headers: Record<string, string> = {
+            Accept: "application/json"
+        };
+        if (apiKey) {
+            headers["Authorization"] = `Bearer ${apiKey}`;
+        }
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+        const res = await fetch(endpoint, {
+            method: "GET",
+            headers,
+            signal: controller.signal
+        });
+        clearTimeout(timer);
+
+        if (!res.ok) {
+            return {
+                healthy: false,
+                modelsCount: 0,
+                error: `HTTP ${res.status}: ${res.statusText}`,
+                latencyMs: Date.now() - start
+            };
+        }
+
+        const data = (await res.json()) as any;
+        const models = Array.isArray(data?.data) ? data.data : [];
+
+        return {
+            healthy: true,
+            modelsCount: models.length,
+            latencyMs: Date.now() - start
+        };
+    } catch (err: any) {
+        return {
+            healthy: false,
+            modelsCount: 0,
+            error: err.name === "AbortError" ? "Connection timeout" : err.message,
+            latencyMs: Date.now() - start
+        };
+    }
+}
+
+export async function fetchAvailableModels(baseUrl: string, apiKey?: string): Promise<string[]> {
+    const cleanUrl = baseUrl.replace(/\/+$/, "");
+    const endpoint = cleanUrl.endsWith("/v1") ? `${cleanUrl}/models` : `${cleanUrl}/v1/models`;
+
+    try {
+        const headers: Record<string, string> = { Accept: "application/json" };
+        if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+        const res = await fetch(endpoint, { headers });
+        if (!res.ok) return [];
+        const data = (await res.json()) as any;
+        if (!Array.isArray(data?.data)) return [];
+        return data.data.map((m: any) => m.id).filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `pnpm --filter @srouter/cli test tests/srouterClient.test.ts`
+Expected: PASS
+
+---
+
+### Task 3: Config Store & Backup Manager
+
+**Files:**
+
+- Create: `apps/cli/src/lib/configStore.ts`
+- Create: `apps/cli/tests/configStore.test.ts`
+
+**Interfaces:**
+
+- Produces: `ConfigStore` class with `load()`, `save()`, `createBackup()`, `restoreBackup()`, `getLatestBackup()`
+
+- [ ] **Step 1: Write test in apps/cli/tests/configStore.test.ts**
+- [ ] **Step 2: Implement apps/cli/src/lib/configStore.ts with safe non-destructive filesystem operations**
+- [ ] **Step 3: Run test and verify pass**
+
+---
+
+### Task 4: Base Adapter & Claude Code Adapter
+
+**Files:**
+
+- Create: `apps/cli/src/adapters/base.ts`
+- Create: `apps/cli/src/adapters/claude.ts`
+- Create: `apps/cli/tests/claudeAdapter.test.ts`
+
+**Interfaces:**
+
+- Produces: `ClaudeAdapter` extending `BaseToolAdapter`
+- Capabilities: Reads/writes `~/.claude.json`, updates `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `model`, manages backup.
+
+- [ ] **Step 1: Write test for ClaudeAdapter mocking config paths**
+- [ ] **Step 2: Implement ClaudeAdapter in apps/cli/src/adapters/claude.ts**
+- [ ] **Step 3: Run test and verify pass**
+
+---
+
+### Task 5: OpenCode Adapter & Adapter Registry
+
+**Files:**
+
+- Create: `apps/cli/src/adapters/opencode.ts`
+- Create: `apps/cli/src/adapters/index.ts`
+- Create: `apps/cli/tests/opencodeAdapter.test.ts`
+
+**Interfaces:**
+
+- Produces: `OpenCodeAdapter` extending `BaseToolAdapter`, `getAllAdapters()`, `getAdapter(id)`
+
+- [ ] **Step 1: Write test for OpenCodeAdapter**
+- [ ] **Step 2: Implement OpenCodeAdapter in apps/cli/src/adapters/opencode.ts**
+- [ ] **Step 3: Implement Adapter Registry in apps/cli/src/adapters/index.ts**
+- [ ] **Step 4: Run test and verify pass**
+
+---
+
+### Task 6: Subcommands (link, unlink, status, env, run)
+
+**Files:**
+
+- Create: `apps/cli/src/commands/link.ts`
+- Create: `apps/cli/src/commands/unlink.ts`
+- Create: `apps/cli/src/commands/status.ts`
+- Create: `apps/cli/src/commands/env.ts`
+- Create: `apps/cli/src/commands/run.ts`
+
+**Interfaces:**
+
+- Produces: Command handler functions for Commander
+
+- [ ] **Step 1: Implement link and unlink command handlers**
+- [ ] **Step 2: Implement status and env command handlers**
+- [ ] **Step 3: Implement run command handler (spawning child process with injected env)**
+
+---
+
+### Task 7: Interactive Setup Wizard (Checklist TUI)
+
+**Files:**
+
+- Create: `apps/cli/src/lib/ui.ts`
+- Create: `apps/cli/src/commands/setup.ts`
+
+**Interfaces:**
+
+- Produces: `runSetupWizard(options)` using `@clack/prompts` multiselect, select, text, spinner
+
+- [ ] **Step 1: Implement UI helpers and spinners in apps/cli/src/lib/ui.ts**
+- [ ] **Step 2: Implement setup wizard in apps/cli/src/commands/setup.ts with auto-server discovery, tool checklist, model picker, and batch linking**
+
+---
+
+### Task 8: Main CLI Entrypoint & Verification
+
+**Files:**
+
+- Create: `apps/cli/src/index.ts`
+- Modify: `apps/cli/package.json`
+- Create: `apps/cli/tests/cli.test.ts`
+
+- [ ] **Step 1: Wire all commands into Commander in apps/cli/src/index.ts**
+- [ ] **Step 2: Write end-to-end CLI unit tests in apps/cli/tests/cli.test.ts**
+- [ ] **Step 3: Run full workspace verification (lint, format:check, and test)**
+- [ ] **Step 4: Commit changes and prepare branch for PR**

--- a/docs/superpowers/specs/2026-08-19-apps-cli-design.md
+++ b/docs/superpowers/specs/2026-08-19-apps-cli-design.md
@@ -1,0 +1,175 @@
+# Design Spec: SRouter CLI (`apps/cli`)
+
+**Date**: 2026-08-19
+**Status**: Draft / In-Review
+**Target Package**: `apps/cli` (`@srouter/cli`)
+
+---
+
+## 1. Overview & Objectives
+
+`apps/cli` is a command-line interface for the **SRouter** ecosystem. Its primary objective is to streamline the onboarding and automatic configuration of AI coding CLI tools (specifically **Claude Code** and **OpenCode**, with an extensible architecture for future tools) so they seamlessly proxy requests through SRouter's local or remote gateway (`http://localhost:3000/v1`).
+
+### Key Capabilities
+
+1. **Interactive Setup Wizard (`srouter setup`)**: Automatically detects local SRouter health (`/v1/models`), asks for credentials if needed, provides an interactive multi-select checklist of CLI tools to configure, selects the primary model, and applies configuration safely.
+2. **Modular Tool Adapters**: Dedicated adapters for **Claude Code** and **OpenCode** that encapsulate tool detection, configuration file mutation, backup/rollback, and environment variable generation.
+3. **Direct Subcommands**:
+    - `srouter link <tool>`: Directly configure a specific tool with flags (`--url`, `--key`, `--model`).
+    - `srouter unlink <tool>`: Safely restore a tool's configuration from pre-link backups.
+    - `srouter run <tool> [...args]`: Launch the target CLI tool with injected SRouter environment variables on the fly.
+    - `srouter status` / `srouter doctor`: Verify SRouter server connectivity, model catalog, and connection state of all supported tools.
+    - `srouter env [tool]`: Output shell export statements for easy sourcing (`eval "$(srouter env)"`).
+
+---
+
+## 2. Directory & File Structure
+
+```text
+apps/cli/
+├── bin/
+│   └── srouter.js                  # Executable entrypoint (#!/usr/bin/env node)
+├── src/
+│   ├── index.ts                    # Commander CLI entry & command registration
+│   ├── commands/
+│   │   ├── setup.ts                # Interactive wizard (Clack prompts, multi-select checklist)
+│   │   ├── link.ts                 # Direct tool configuration
+│   │   ├── unlink.ts               # Revert tool configuration from backup
+│   │   ├── run.ts                  # Subprocess runner with injected env vars
+│   │   ├── status.ts               # Health & tool status inspector
+│   │   └── env.ts                  # Shell export generator
+│   ├── adapters/
+│   │   ├── base.ts                 # BaseToolAdapter interface & abstract class
+│   │   ├── index.ts                # Adapter registry and factory
+│   │   ├── claude.ts               # Claude Code adapter (~/.claude.json, ANTHROPIC_BASE_URL)
+│   │   └── opencode.ts             # OpenCode adapter (~/.config/opencode/config.json)
+│   ├── lib/
+│   │   ├── srouterClient.ts        # HTTP client for pinging /v1/models and checking server status
+│   │   ├── configStore.ts          # CLI state store & backup indexer (~/.srouter/cli.json)
+│   │   └── ui.ts                   # Clack prompts & styling helpers (picocolors)
+│   └── types/
+│       └── index.ts                # CLI types, adapter contracts, and config schema
+├── tests/
+│   ├── adapters.test.ts            # Unit tests for Claude & OpenCode adapters
+│   ├── configStore.test.ts         # Unit tests for backup and state management
+│   └── srouterClient.test.ts       # Unit tests for server health and discovery
+├── package.json
+├── tsconfig.json
+└── tsup.config.ts
+```
+
+---
+
+## 3. Tool Adapters Specification
+
+Each tool adapter implements the `BaseToolAdapter` interface:
+
+```typescript
+export interface ToolConfigContext {
+    baseUrl: string;
+    apiKey?: string;
+    model?: string;
+}
+
+export interface ToolStatus {
+    installed: boolean;
+    linked: boolean;
+    configPath?: string;
+    currentBaseUrl?: string;
+    currentModel?: string;
+}
+
+export interface BaseToolAdapter {
+    readonly id: string;
+    readonly name: string;
+    readonly description: string;
+
+    isInstalled(): Promise<boolean>;
+    getStatus(): Promise<ToolStatus>;
+    link(context: ToolConfigContext): Promise<{ backupPath?: string }>;
+    unlink(): Promise<boolean>;
+    getEnv(context: ToolConfigContext): Record<string, string>;
+}
+```
+
+### 3.1 Claude Code Adapter (`claude`)
+
+- **Target Files**: `~/.claude.json` (or `~/.claude/config.json`).
+- **Configuration Fields**:
+    - `ANTHROPIC_BASE_URL`: e.g. `http://localhost:3000/v1` (or `http://localhost:3000`).
+    - `ANTHROPIC_API_KEY`: SRouter API Key.
+    - `model`: Selected model ID (e.g. `claude-3-7-sonnet`, `claude-3-5-sonnet-20241022`, or custom mapped model).
+- **Environment Variables**:
+    - `ANTHROPIC_BASE_URL`
+    - `ANTHROPIC_API_KEY`
+    - `ANTHROPIC_MODEL`
+- **Backup Location**: `~/.srouter/backups/claude-<timestamp>.json`.
+
+### 3.2 OpenCode Adapter (`opencode`)
+
+- **Target Files**: `~/.config/opencode/config.json` or `~/.opencode.json`.
+- **Configuration Fields**:
+    - Sets provider endpoint to SRouter base URL and API key.
+    - Sets default active model.
+- **Environment Variables**:
+    - `OPENAI_BASE_URL`
+    - `OPENAI_API_KEY`
+    - `ANTHROPIC_BASE_URL`
+    - `ANTHROPIC_API_KEY`
+- **Backup Location**: `~/.srouter/backups/opencode-<timestamp>.json`.
+
+---
+
+## 4. Interactive Wizard Flow (`srouter setup`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant CLI as srouter setup
+    participant SRouter as SRouter Server (localhost:3000)
+    participant FS as Local Filesystem & Configs
+
+    CLI->>SRouter: GET /v1/models
+    alt Server is running
+        SRouter-->>CLI: 200 OK (models list)
+    else Server offline / custom URL
+        CLI->>User: Prompt custom SRouter URL & API key
+    end
+
+    CLI->>User: Display multi-select checklist of tools ([x] Claude Code, [x] OpenCode)
+    User-->>CLI: Selects tools
+
+    CLI->>User: Select default model from active SRouter models
+    User-->>CLI: Picks model
+
+    loop For each selected tool
+        CLI->>FS: Backup existing tool config (~/.srouter/backups/)
+        CLI->>FS: Write updated SRouter proxy endpoints & key
+    end
+
+    CLI->>User: Display success summary & quickstart commands
+```
+
+---
+
+## 5. Subcommands Detail
+
+| Command          | Usage                                                               | Description                                                                |
+| :--------------- | :------------------------------------------------------------------ | :------------------------------------------------------------------------- |
+| `srouter setup`  | `srouter setup`                                                     | Full interactive wizard with tool checklist and auto-configuration.        |
+| `srouter link`   | `srouter link <tool> [--url <url>] [--key <key>] [--model <model>]` | Non-interactive or targeted link for a specific tool.                      |
+| `srouter unlink` | `srouter unlink <tool>`                                             | Restore tool's previous configuration from backup.                         |
+| `srouter run`    | `srouter run <tool> [args...]`                                      | Execute tool with SRouter environment variables injected on the fly.       |
+| `srouter status` | `srouter status`                                                    | Check SRouter server status and display status of all tool configurations. |
+| `srouter env`    | `srouter env [tool]`                                                | Output shell export variables for eval sourcing.                           |
+
+---
+
+## 6. Safety, Rollback & Testing Strategy
+
+1. **Non-destructive Mutations**: Before touching any existing tool config file, a timestamped snapshot is saved to `~/.srouter/backups/` and registered in `~/.srouter/cli.json`.
+2. **Safe Rollback**: `srouter unlink <tool>` restores the exact previous state or gracefully removes SRouter modifications.
+3. **Automated Unit Tests**:
+    - Tests using Node native test runner (`tsx --test`).
+    - Mocking filesystem and HTTP endpoints to verify adapter link/unlink/getEnv behavior and configStore persistence without affecting actual user configs.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "lint": "turbo lint",
-        "test": "turbo test"
+        "test": "turbo test",
+        "srouter": "pnpm --filter @srouter/cli exec tsx src/index.ts"
     },
     "engines": {
         "node": ">=22.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,37 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  apps/cli:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.9.1
+        version: 0.9.1
+      '@srouter/constants':
+        specifier: workspace:*
+        version: link:../../packages/constants
+      '@srouter/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.2.0
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.11
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@base-ui/react':
@@ -643,6 +674,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@clack/core@0.4.1':
+    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
+
+  '@clack/prompts@0.9.1':
+    resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
 
   '@dotenvx/dotenvx@1.75.1':
     resolution: {integrity: sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ==}
@@ -1736,6 +1773,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -3338,6 +3379,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
+  '@clack/core@0.4.1':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.9.1':
+    dependencies:
+      '@clack/core': 0.4.1
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@dotenvx/dotenvx@1.75.1':
     dependencies:
       '@dotenvx/primitives': 0.8.0
@@ -4130,6 +4182,8 @@ snapshots:
   code-block-writer@13.0.3: {}
 
   commander@11.1.0: {}
+
+  commander@13.1.0: {}
 
   commander@14.0.3: {}
 


### PR DESCRIPTION
## Summary

This PR introduces `apps/cli` (`@srouter/cli`), a command-line interface for the **SRouter** ecosystem that enables users to effortlessly connect, configure, and proxy AI coding CLI tools (specifically **Claude Code** and **OpenCode**, with an extensible adapter architecture) through SRouter's local or remote gateway (`http://localhost:3000/v1`).

---

### Key Capabilities & Features

1. **Interactive Setup Wizard (`srouter setup` / `srouter config`)**:
   - Automatically detects SRouter gateway connectivity and active models (`/v1/models`).
   - Clean interactive multi-select checklist (starts unselected by default for deliberate selection).
   - Real-time status indicators on tools: `[✔ CONFIGURED]`, `[○ NOT CONFIGURED]`, and `[✖ NOT INSTALLED]`.
   - General and tier-specific model configuration with interactive prompt or CLI flags.
   - Non-destructive configuration with automated timestamped backups saved to `~/.srouter/backups/`.

2. **Claude Code Tier Models Support**:
   - Fully supports Anthropic model tier configuration for Claude Code:
     - `ANTHROPIC_DEFAULT_OPUS_MODEL` (Opus tier)
     - `ANTHROPIC_DEFAULT_SONNET_MODEL` (Sonnet tier)
     - `ANTHROPIC_DEFAULT_HAIKU_MODEL` (Haiku tier)
   - Dedicated CLI flags: `--opus-model <model>`, `--sonnet-model <model>`, and `--haiku-model <model>` on `setup`, `link`, `env`, and `run`.

3. **Cross-Platform OS & Shell Auto-Detection (`platform.ts`)**:
   - **OS Awareness**: Automatically detects Linux, macOS (Apple Silicon / Intel), and Windows (`win32`).
   - **Dynamic Config Paths**: Resolves correct paths per OS (`~/.claude.json`, `%APPDATA%`, `Library/Application Support`, `$XDG_CONFIG_HOME`).
   - **Cross-Platform Binary Detection**: Uses `which` on Unix and `where.exe` / `where` on Windows.
   - **Multi-Shell Export**: Generates export commands matching active shell or `--shell` flag:
     - Bash / Zsh: `export KEY="value"`
     - Fish: `set -gx KEY "value";`
     - PowerShell: `$env:KEY = "value"`
     - CMD: `set KEY=value`

4. **Modular Subcommands**:
   - `srouter setup`: Interactive wizard for full onboarding.
   - `srouter link <tool>`: Direct configuration of a specific tool (`--url`, `--key`, `--model`, tier models, `--dry-run`).
   - `srouter unlink <tool>`: Safe rollback of tool configuration from backup.
   - `srouter status` / `srouter doctor`: Comprehensive health inspector showing OS, shell, gateway status, and tool link state.
   - `srouter env [tool]`: Shell environment exporter (`eval "$(srouter env)"`).
   - `srouter run <tool> [...args]`: Execute tools directly with injected SRouter environment variables.

5. **Automated Unit Tests**:
   - 13 comprehensive unit tests passing with Node's native test runner (`tsx --test`):
     - `claudeAdapter.test.ts` (link, unlink, tier models, getEnv)
     - `opencodeAdapter.test.ts` (link, unlink, getEnv)
     - `platform.test.ts` (OS detection, shell formatting, binary detection, path resolution)
     - `configStore.test.ts` (load, save, backup, restore)
     - `srouterClient.test.ts` (health check, models fetch, error handling)
     - `cli.test.ts` (command & options registration)
