### PR TITLE
feat(providers): add OpenCode Zen free tier and free models

### DIFF
--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -21,6 +21,7 @@ import {
     CommandCodeExecutor,
     GoRouterExecutor,
     KiroExecutor,
+    OpenCodeZenExecutor,
     OpenAIExecutor,
     QoderExecutor,
     SeekAIExecutor,
@@ -223,6 +224,19 @@ export function loadSavedProvidersFromDB(): void {
                     })
                 );
                 break;
+            case isProviderBaseId(p.id, "opencode_zen") ||
+                isProviderBaseId(p.id, "zen") ||
+                providerType === "opencode_zen":
+                registry.registerProvider(
+                    new OpenCodeZenExecutor({
+                        id: p.id || p.providerId,
+                        name: p.name,
+                        baseUrl: baseUrl || OPENCODE_ZEN_BASE_URL,
+                        apiKey: p.apiKey,
+                        accessToken: p.accessToken
+                    })
+                );
+                break;
             case isProviderBaseId(p.id, "qoder"):
                 registry.registerProvider(
                     new QoderExecutor({
@@ -279,6 +293,25 @@ export function loadSavedProvidersFromDB(): void {
                 break;
             default:
                 break;
+        }
+    }
+
+    // Auto-register built-in free tier providers so users can immediately use them out of the box
+    const freeTierSeeds = DEFAULT_PROVIDERS.filter((s) => s.category === "free_tier");
+    for (const seed of freeTierSeeds) {
+        const hasExplicitConnection = savedProviders.some(
+            (p) => (p.id === seed.id || p.providerId === seed.id) && !isSeedProvider(p)
+        );
+        if (!hasExplicitConnection) {
+            if (seed.id === "opencode_zen") {
+                registry.registerProvider(
+                    new OpenCodeZenExecutor({
+                        id: seed.id,
+                        name: seed.name,
+                        baseUrl: seed.baseUrl || OPENCODE_ZEN_BASE_URL
+                    })
+                );
+            }
         }
     }
 }

--- a/packages/constants/src/providers.ts
+++ b/packages/constants/src/providers.ts
@@ -24,6 +24,24 @@ export const CODEBUDDY_AUTH_REFRESH_URL = "https://www.codebuddy.ai/v2/plugin/au
 export const CODEBUDDY_AUTH_USER_AGENT = "IDE/2.63.2 CodeBuddy/2.63.2";
 export const CODEBUDDY_AUTH_PLATFORM = "ide";
 
+export const OPENCODE_ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+
+export interface OpenCodeZenModelDefinition {
+    id: string;
+    name: string;
+}
+
+export const OPENCODE_ZEN_MODELS: OpenCodeZenModelDefinition[] = [
+    { id: "x-preview-f-free", name: "Ox Alpha Free (Unlimited)" },
+    { id: "big-pickle", name: "Big Pickle (Free)" },
+    { id: "laguna-s-2.1-free", name: "Poolside Laguna S 2.1 (Free)" },
+    { id: "nemotron-3.5-lightning-free", name: "Nemotron 3.5 Lightning (Free)" },
+    { id: "nemotron-3-ultra-free", name: "Nemotron 3 Ultra (Free)" },
+    { id: "mimo-v2.5-free", name: "Xiaomi MiMo V2.5 (Free)" }
+];
+
+export const OPENCODE_ZEN_MODEL_IDS: string[] = OPENCODE_ZEN_MODELS.map((m) => m.id);
+
 export interface CodeBuddyModelDefinition {
     id: string;
     name: string;
@@ -367,6 +385,19 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
         requiresOAuth: true,
         supportsCustomUrl: true,
         statusMessage: "CodeBuddy OAuth token missing"
+    },
+    {
+        id: "opencode_zen",
+        name: "OpenCode Zen",
+        category: "free_tier",
+        protocol: "openai",
+        alias: "zen",
+        baseUrl: OPENCODE_ZEN_BASE_URL,
+        websiteUrl: "https://opencode.ai/zen",
+        requiresApiKey: false,
+        requiresOAuth: false,
+        supportsCustomUrl: true,
+        statusMessage: "Free Tier Ready (Unlimited)"
     }
 ];
 

--- a/packages/executors/src/index.ts
+++ b/packages/executors/src/index.ts
@@ -7,6 +7,7 @@ export * from "./codex.js";
 export * from "./kiro.js";
 export * from "./commandcode.js";
 export * from "./gorouter.js";
+export * from "./opencode.js";
 export * from "./openai.js";
 export * from "./qoder.js";
 export * from "./retry.js";

--- a/packages/executors/src/opencode.ts
+++ b/packages/executors/src/opencode.ts
@@ -1,6 +1,22 @@
-import { OPENCODE_ZEN_BASE_URL, OPENCODE_ZEN_MODELS } from "@srouter/constants";
+import { OPENCODE_ZEN_BASE_URL } from "@srouter/constants";
 import type { ModelObject } from "@srouter/types";
 import { OpenAIExecutor, type OpenAIExecutorOptions } from "./openai.js";
+
+export interface OpenCodeZenModelDefinition {
+    id: string;
+    name: string;
+}
+
+export const OPENCODE_ZEN_MODELS: OpenCodeZenModelDefinition[] = [
+    { id: "x-preview-f-free", name: "Ox Alpha Free (Unlimited)" },
+    { id: "big-pickle", name: "Big Pickle (Free)" },
+    { id: "laguna-s-2.1-free", name: "Poolside Laguna S 2.1 (Free)" },
+    { id: "nemotron-3.5-lightning-free", name: "Nemotron 3.5 Lightning (Free)" },
+    { id: "nemotron-3-ultra-free", name: "Nemotron 3 Ultra (Free)" },
+    { id: "mimo-v2.5-free", name: "Xiaomi MiMo V2.5 (Free)" }
+];
+
+export const OPENCODE_ZEN_MODEL_IDS: string[] = OPENCODE_ZEN_MODELS.map((m) => m.id);
 
 export interface OpenCodeZenExecutorOptions extends OpenAIExecutorOptions {}
 

--- a/packages/executors/src/opencode.ts
+++ b/packages/executors/src/opencode.ts
@@ -1,0 +1,26 @@
+import { OPENCODE_ZEN_BASE_URL, OPENCODE_ZEN_MODELS } from "@srouter/constants";
+import type { ModelObject } from "@srouter/types";
+import { OpenAIExecutor, type OpenAIExecutorOptions } from "./openai.js";
+
+export interface OpenCodeZenExecutorOptions extends OpenAIExecutorOptions {}
+
+export class OpenCodeZenExecutor extends OpenAIExecutor {
+    constructor(options: OpenCodeZenExecutorOptions = {}) {
+        super({
+            id: options.id ?? "opencode_zen",
+            name: options.name ?? "OpenCode Zen (Free)",
+            baseUrl: options.baseUrl ?? OPENCODE_ZEN_BASE_URL,
+            apiKey: options.apiKey ?? "",
+            accessToken: options.accessToken ?? ""
+        });
+    }
+
+    override async listModels(): Promise<ModelObject[]> {
+        const baseId = this.id.split("_")[0]?.split("-")[0] ?? this.id;
+        return OPENCODE_ZEN_MODELS.map((m) => ({
+            id: `${baseId}/${m.id}`,
+            object: "model",
+            owned_by: baseId
+        }));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **OpenCode Zen** as a default `free_tier` provider without requiring API keys.
- Adds active free models including **Ox Alpha** (`x-preview-f-free`), `big-pickle`, `laguna-s-2.1-free`, `nemotron-3.5-lightning-free`, `nemotron-3-ultra-free`, and `mimo-v2.5-free`.
- Implements `OpenCodeZenExecutor` in `@srouter/executors`.
- Auto-registers free tier providers in `registry.ts` on startup.

## Testing
- Verified endpoint responsiveness and streaming for free models directly via OpenCode Zen API.
- Executed `pnpm build` across all monorepo packages (10/10 tasks successful).