### PR TITLE
feat(security): harden public API access and add security headers

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import {
     authRoute,
     handleAntigravityOAuthCallback,
@@ -26,6 +27,28 @@ import { warmModelRegistry } from "@/services/registry.js";
 import { HTTPException } from "hono/http-exception";
 
 const app = new Hono();
+
+// Security Headers Middleware
+app.use("/*", async (c, next) => {
+    await next();
+    c.header("X-Powered-By", "Seaavey");
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("X-Frame-Options", "DENY");
+    c.header("X-XSS-Protection", "1; mode=block");
+    c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+});
+
+// Enable CORS with sensible defaults
+app.use(
+    "/*",
+    cors({
+        origin: (origin) => origin || "*",
+        allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allowHeaders: ["Content-Type", "Authorization", "x-api-key", "anthropic-version"],
+        exposeHeaders: ["Content-Length", "X-Request-Id"],
+        credentials: true
+    })
+);
 
 // Global Error Handler
 app.onError((err, c) => {
@@ -200,16 +223,18 @@ oauthApp.route("/v1", chatRoute);
 oauthApp.route("/v1", modelsRoute);
 
 const oauthPort = Number(process.env.OAUTH_PORT) || 1455;
+const oauthHost = process.env.OAUTH_HOST || "127.0.0.1";
 
 try {
     serve(
         {
             fetch: oauthApp.fetch,
-            port: oauthPort
+            port: oauthPort,
+            hostname: oauthHost
         },
         (info) => {
             console.log(
-                `🔑 OAuth Callback Server running at http://localhost:${info.port}/auth/callback & /auth/antigravity/callback & /auth/claude/callback`
+                `🔑 OAuth Callback Server running at http://${info.address}:${info.port}/auth/callback & /auth/antigravity/callback & /auth/claude/callback`
             );
         }
     );

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,7 +42,17 @@ app.use("/*", async (c, next) => {
 app.use(
     "/*",
     cors({
-        origin: (origin) => origin || "*",
+        origin: (origin) => {
+            // Allow requests with no origin (mobile apps, curl, server-to-server)
+            if (!origin) return "*";
+            // Allow localhost/loopback development origins
+            if (/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(origin)) {
+                return origin;
+            }
+            // For public origins, return origin without wildcard when credentials are needed,
+            // or return origin if explicitly running as API gateway
+            return origin;
+        },
         allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allowHeaders: ["Content-Type", "Authorization", "x-api-key", "anthropic-version"],
         exposeHeaders: ["Content-Length", "X-Request-Id"],

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -28,10 +28,13 @@ import { HTTPException } from "hono/http-exception";
 
 const app = new Hono();
 
-// Security Headers Middleware
+const SROUTER_VERSION = "0.1.1-rc.2";
+
+// Security Headers & Version Middleware
 app.use("/*", async (c, next) => {
     await next();
     c.header("X-Powered-By", "Seaavey");
+    c.header("X-Version", SROUTER_VERSION);
     c.header("X-Content-Type-Options", "nosniff");
     c.header("X-Frame-Options", "DENY");
     c.header("X-XSS-Protection", "1; mode=block");
@@ -55,7 +58,7 @@ app.use(
         },
         allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allowHeaders: ["Content-Type", "Authorization", "x-api-key", "anthropic-version"],
-        exposeHeaders: ["Content-Length", "X-Request-Id"],
+        exposeHeaders: ["Content-Length", "X-Request-Id", "X-Version"],
         credentials: true
     })
 );

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -354,6 +354,17 @@ export class ProvidersLogic {
                         message: "URL endpoint harus berformat HTTP atau HTTPS."
                     };
                 }
+                const hostname = url.hostname.toLowerCase();
+                const isInternalHost =
+                    hostname === "169.254.169.254" ||
+                    hostname === "metadata.google.internal" ||
+                    hostname === "instance-data";
+                if (isInternalHost) {
+                    return {
+                        success: false,
+                        message: "Target URL tidak diizinkan untuk verifikasi (metadata endpoint diblokir)."
+                    };
+                }
             } catch {
                 return { success: false, message: "Format Endpoint Base URL tidak valid." };
             }

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -358,11 +358,16 @@ export class ProvidersLogic {
                 const isInternalHost =
                     hostname === "169.254.169.254" ||
                     hostname === "metadata.google.internal" ||
-                    hostname === "instance-data";
+                    hostname === "instance-data" ||
+                    hostname === "localhost" ||
+                    hostname === "127.0.0.1" ||
+                    hostname === "::1" ||
+                    hostname.startsWith("127.") ||
+                    hostname.startsWith("169.254.");
                 if (isInternalHost) {
                     return {
                         success: false,
-                        message: "Target URL tidak diizinkan untuk verifikasi (metadata endpoint diblokir)."
+                        message: "Target URL tidak diizinkan untuk verifikasi (endpoint internal/metadata diblokir)."
                     };
                 }
             } catch {

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import { getCookie } from "hono/cookie";
+import { getConnInfo } from "@hono/node-server/conninfo";
 import {
     adminAuthStore,
     getAPIKeyByKeyDB,
@@ -7,16 +8,50 @@ import {
     type AdminAuthStore
 } from "@srouter/db";
 import { err } from "@/utils/response.js";
-import { ADMIN_SESSION_COOKIE, verifyAdminSession } from "@/services/adminAuth.js";
+import {
+    ADMIN_SESSION_COOKIE,
+    isLoopbackAddress,
+    verifyAdminSession
+} from "@/services/adminAuth.js";
 
 export interface ApiKeyAuthOptions {
     store?: AdminAuthStore;
     now?: () => number;
+    getClientAddress?: (c: Context) => string | undefined;
+}
+
+function getDirectClientAddress(c: Context): string | undefined {
+    try {
+        const info = getConnInfo(c);
+        if (info.remote?.address) return info.remote.address;
+    } catch {
+        // Fallback for tests or environments without node-server conninfo
+    }
+
+    try {
+        const url = new URL(c.req.url);
+        if (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") {
+            return "127.0.0.1";
+        }
+    } catch {}
+
+    const host = c.req.header("host") || "";
+    if (
+        !host ||
+        host.startsWith("localhost") ||
+        host.startsWith("127.0.0.1") ||
+        host.startsWith("[::1]")
+    ) {
+        return "127.0.0.1";
+    }
+
+    return undefined;
 }
 
 export function createApiKeyAuth(options: ApiKeyAuthOptions = {}) {
     const store = options.store ?? adminAuthStore;
     const now = options.now ?? (() => Date.now());
+    const getClientAddress = options.getClientAddress ?? getDirectClientAddress;
 
     return async function apiKeyAuth(c: Context, next: Next) {
         if (verifyAdminSession(store, getCookie(c, ADMIN_SESSION_COOKIE), now())) {
@@ -24,7 +59,10 @@ export function createApiKeyAuth(options: ApiKeyAuthOptions = {}) {
             return await next();
         }
 
-        const isRequired = getRequireApiKeyDB();
+        const clientAddress = getClientAddress(c);
+        const isLoopback = isLoopbackAddress(clientAddress);
+        // If requireApiKey is true in DB OR request comes from non-localhost (public network)
+        const isRequired = getRequireApiKeyDB() || !isLoopback;
         const authHeader = c.req.header("Authorization") || c.req.header("authorization");
         const xApiKey =
             c.req.header("x-api-key") || c.req.header("X-Api-Key") || c.req.header("X-API-KEY");
@@ -52,7 +90,7 @@ export function createApiKeyAuth(options: ApiKeyAuthOptions = {}) {
                 return await next();
             }
 
-            // If a key was provided but not found in DB and auth is required
+            // If a key was provided but not found in DB
             if (isRequired) {
                 return err(c, "Invalid SRouter API Key", 401, {
                     type: "invalid_request_error",
@@ -61,10 +99,12 @@ export function createApiKeyAuth(options: ApiKeyAuthOptions = {}) {
             }
         }
 
-        if (isRequired && !bearerKey) {
+        if (isRequired) {
             return err(
                 c,
-                "Missing SRouter API Key. Please provide a valid key via 'Authorization: Bearer <key>' header or disable 'Require API Key' in Settings.",
+                !isLoopback
+                    ? "Remote/public requests require a valid SRouter API Key. Please provide your key via 'Authorization: Bearer <API_KEY>' or 'x-api-key'."
+                    : "Missing SRouter API Key. Please provide a valid key via 'Authorization: Bearer ***' header or disable 'Require API Key' in Settings.",
                 401,
                 {
                     type: "invalid_request_error",

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -22,28 +22,20 @@ export interface ApiKeyAuthOptions {
 
 function getDirectClientAddress(c: Context): string | undefined {
     try {
-        const info = getConnInfo(c);
-        if (info.remote?.address) return info.remote.address;
+        const addr = getConnInfo(c).remote.address;
+        if (addr) return addr;
     } catch {
-        // Fallback for tests or environments without node-server conninfo
+        // Fallback when request is invoked via Hono in-memory app.request()
     }
 
+    // If running in test / in-memory environment where conninfo is not available,
+    // infer from URL hostname
     try {
         const url = new URL(c.req.url);
         if (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") {
             return "127.0.0.1";
         }
     } catch {}
-
-    const host = c.req.header("host") || "";
-    if (
-        !host ||
-        host.startsWith("localhost") ||
-        host.startsWith("127.0.0.1") ||
-        host.startsWith("[::1]")
-    ) {
-        return "127.0.0.1";
-    }
 
     return undefined;
 }

--- a/apps/api/tests/settings-auth.test.ts
+++ b/apps/api/tests/settings-auth.test.ts
@@ -7,7 +7,7 @@ import {
     getRequireApiKeyDB,
     setRequireApiKeyDB
 } from "@srouter/db";
-import { apiKeyAuth } from "../src/middleware/apiKeyAuth.js";
+import { apiKeyAuth, createApiKeyAuth } from "../src/middleware/apiKeyAuth.js";
 
 const createdKeyIds: string[] = [];
 
@@ -74,11 +74,51 @@ test("apiKeyAuth middleware allows unauthenticated requests when require_api_key
     setRequireApiKeyDB(false);
 
     const testApp = new Hono();
-    testApp.use("/*", apiKeyAuth);
+    testApp.use("/*", createApiKeyAuth({ getClientAddress: () => "127.0.0.1" }));
     testApp.post("/chat/completions", (c) => c.json({ ok: true }));
 
     const res = await testApp.request("/chat/completions", {
         method: "POST"
+    });
+
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { ok: boolean };
+    assert.equal(body.ok, true);
+});
+
+test("apiKeyAuth middleware rejects non-loopback requests when require_api_key is false and no key provided", async () => {
+    setRequireApiKeyDB(false);
+
+    const testApp = new Hono();
+    testApp.use("/*", createApiKeyAuth({ getClientAddress: () => "192.168.1.50" }));
+    testApp.post("/chat/completions", (c) => c.json({ ok: true }));
+
+    const res = await testApp.request("/chat/completions", {
+        method: "POST"
+    });
+
+    assert.equal(res.status, 401);
+    const body = (await res.json()) as { error: { message: string; code: string } };
+    assert.equal(body.error.code, "missing_api_key");
+});
+
+test("apiKeyAuth middleware accepts non-loopback requests with valid API key", async () => {
+    setRequireApiKeyDB(false);
+
+    const created = createAPIKeyDB({
+        name: "Remote Auth Key"
+    });
+    createdKeyIds.push(created.id);
+
+    const testApp = new Hono();
+    testApp.use("/*", createApiKeyAuth({ getClientAddress: () => "192.168.1.50" }));
+    testApp.post("/chat/completions", (c) => c.json({ ok: true }));
+
+    const res = await testApp.request("/chat/completions", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${created.key}`
+        }
     });
 
     assert.equal(res.status, 200);

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -76,7 +76,15 @@ function ensureColumns(table: string, columns: Array<{ name: string; definition:
     );
     for (const col of columns) {
         if (existing.has(col.name)) continue;
-        db.exec(`ALTER TABLE ${table} ADD COLUMN ${col.definition};`);
+        try {
+            db.exec(`ALTER TABLE ${table} ADD COLUMN ${col.definition};`);
+            existing.add(col.name);
+        } catch (error) {
+            const message = (error as Error).message || "";
+            if (!message.includes("duplicate column name")) {
+                throw error;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Security hardening for the SRouter API, driven by a manual security audit. Public deployments (e.g. behind Cloudflare) previously allowed unauthenticated chat completion requests when `require_api_key` was disabled; this PR closes that gap plus several defense-in-depth improvements.

## Changes

### 1. Mandatory API key for non-localhost requests
- `apiKeyAuth` middleware now resolves the client address via `getConnInfo` and **requires a valid SRouter API key** for any request originating outside loopback (`127.0.0.1` / `::1`).
- Localhost behavior is unchanged: it still follows the "Require API Key" toggle in Settings.
- Returns a clear 401 with code `missing_api_key` / `invalid_api_key` depending on the failure.

### 2. SSRF guard on provider verification
- `verifyConnection` now rejects base URLs pointing at cloud metadata endpoints (`169.254.169.254`, `metadata.google.internal`, `instance-data`) in addition to the existing HTTP/HTTPS scheme check.

### 3. OAuth listener bound to loopback by default
- The secondary port-1455 OAuth callback server now binds to `127.0.0.1` instead of all interfaces. Override via `OAUTH_HOST` env var if external binding is needed.

### 4. Security headers + CORS
- Global middleware sets `X-Powered-By`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection`, and `Referrer-Policy`.
- CORS enabled with an explicit allowlist of methods/headers (`Content-Type`, `Authorization`, `x-api-key`, `anthropic-version`) and credentials support.

## Testing
- All 79 unit/integration tests pass (`pnpm test` in apps/api).
- `tsup` build succeeds.