### PR TITLE
feat(tunnel): built-in Cloudflare Tunnel management with token auth and custom domain

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,8 @@ import { modelsRoute } from "@/routes/v1/models.js";
 import { providersRoute } from "@/routes/v1/providers.js";
 import { quotaRoute } from "@/routes/v1/quota.js";
 import { settingsRoute } from "@/routes/v1/settings.js";
+import { tunnelRoute } from "@/routes/v1/tunnel.js";
+import { adminAuth } from "@/middleware/adminAuth.js";
 import { startTokenRefreshSweeper } from "@/services/tokenRefresh.js";
 import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry } from "@/services/registry.js";
@@ -93,6 +95,12 @@ app.route("/v1", logsRoute);
 app.route("/v1", authRoute);
 app.route("/v1", quotaRoute);
 app.route("/v1", settingsRoute);
+
+// Cloudflare Tunnel management (admin-only; status readable via API key too)
+app.route("/v1", tunnelRoute);
+app.use("/v1/tunnel/start", adminAuth);
+app.use("/v1/tunnel/stop", adminAuth);
+app.use("/v1/tunnel/config", adminAuth);
 
 // Mount /v1/v1 compatibility routes for SDKs that append /v1 to a baseURL containing /v1
 app.route("/v1/v1", messagesRoute);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -110,6 +110,7 @@ app.route("/v1", tunnelRoute);
 app.use("/v1/tunnel/start", adminAuth);
 app.use("/v1/tunnel/stop", adminAuth);
 app.use("/v1/tunnel/config", adminAuth);
+app.use("/v1/tunnel/install", adminAuth);
 
 // Mount /v1/v1 compatibility routes for SDKs that append /v1 to a baseURL containing /v1
 app.route("/v1/v1", messagesRoute);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,10 +24,19 @@ import { adminAuth } from "@/middleware/adminAuth.js";
 import { startTokenRefreshSweeper } from "@/services/tokenRefresh.js";
 import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry } from "@/services/registry.js";
+import { ensureDefaultAdminAccount } from "@/services/adminAuth.js";
+import { autostartTunnelIfEnabled } from "@/services/cloudflareTunnel.js";
+import { adminAuthStore } from "@srouter/db";
 
 import { HTTPException } from "hono/http-exception";
 
 const app = new Hono();
+
+// Ensure an admin account exists on first run (default password: 12345678).
+ensureDefaultAdminAccount(adminAuthStore);
+
+// Re-launch the Cloudflare Tunnel if it was left running when the server last stopped.
+autostartTunnelIfEnabled();
 
 // Global Error Handler
 app.onError((err, c) => {

--- a/apps/api/src/routes/v1/tunnel.ts
+++ b/apps/api/src/routes/v1/tunnel.ts
@@ -1,9 +1,12 @@
 import { Hono } from "hono";
 import { err, ok } from "@/utils/response.js";
 import {
+    getInstallStatus,
     getTunnelDomain,
-    getTunnelToken,
     getTunnelStatus,
+    getTunnelToken,
+    installCloudflared,
+    onTunnelUpdate,
     setTunnelDomain,
     setTunnelToken,
     startTunnel,
@@ -16,6 +19,53 @@ export const tunnelRoute = new Hono();
 tunnelRoute.get("/tunnel/status", (c) => {
     const status = getTunnelStatus();
     return ok(c, { ...status, tokenConfigured: Boolean(getTunnelToken()) });
+});
+
+// GET /v1/tunnel/events - Server-Sent Events stream of live tunnel/install state.
+tunnelRoute.get("/tunnel/events", (c) => {
+    const encoder = new TextEncoder();
+    let unsubscribe: (() => void) | null = null;
+    let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+    const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            const send = (data: unknown) => {
+                try {
+                    controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+                } catch {
+                    // Controller already closed.
+                }
+            };
+            // Initial snapshot so clients render instantly.
+            send({ ...getTunnelStatus(), tokenConfigured: Boolean(getTunnelToken()) });
+
+            unsubscribe = onTunnelUpdate((status) => {
+                send({ ...status, tokenConfigured: Boolean(getTunnelToken()) });
+            });
+
+            // Keep the connection alive so proxies don't drop it.
+            heartbeat = setInterval(() => {
+                try {
+                    controller.enqueue(encoder.encode(`: ping\n\n`));
+                } catch {
+                    // ignore
+                }
+            }, 25_000);
+        },
+        cancel() {
+            if (heartbeat) clearInterval(heartbeat);
+            if (unsubscribe) unsubscribe();
+            unsubscribe = null;
+            heartbeat = null;
+        }
+    });
+
+    return c.body(stream, 200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no"
+    });
 });
 
 // POST /v1/tunnel/start - start the tunnel with the stored token
@@ -54,4 +104,15 @@ tunnelRoute.put("/tunnel/config", async (c) => {
         message: "Tunnel configuration updated",
         domain: getTunnelDomain() || undefined
     });
+});
+
+// POST /v1/tunnel/install - download & install the cloudflared binary for this machine
+tunnelRoute.post("/tunnel/install", (c) => {
+    const result = installCloudflared();
+    return result.success ? ok(c, result) : err(c, result.message, 400);
+});
+
+// GET /v1/tunnel/install - installation progress/state
+tunnelRoute.get("/tunnel/install", (c) => {
+    return ok(c, getInstallStatus());
 });

--- a/apps/api/src/routes/v1/tunnel.ts
+++ b/apps/api/src/routes/v1/tunnel.ts
@@ -1,0 +1,57 @@
+import { Hono } from "hono";
+import { err, ok } from "@/utils/response.js";
+import {
+    getTunnelDomain,
+    getTunnelToken,
+    getTunnelStatus,
+    setTunnelDomain,
+    setTunnelToken,
+    startTunnel,
+    stopTunnel
+} from "@/services/cloudflareTunnel.js";
+
+export const tunnelRoute = new Hono();
+
+// GET /v1/tunnel/status - current tunnel state (never exposes the token)
+tunnelRoute.get("/tunnel/status", (c) => {
+    const status = getTunnelStatus();
+    return ok(c, { ...status, tokenConfigured: Boolean(getTunnelToken()) });
+});
+
+// POST /v1/tunnel/start - start the tunnel with the stored token
+// Body: { token?: string; domain?: string }  (token/domain are saved when provided)
+tunnelRoute.post("/tunnel/start", async (c) => {
+    let body: { token?: string; domain?: string } = {};
+    try {
+        body = (await c.req.json()) ?? {};
+    } catch {
+        // Empty body is fine — use stored settings
+    }
+
+    if (body.token) setTunnelToken(body.token);
+    if (body.domain) setTunnelDomain(body.domain);
+
+    const result = startTunnel();
+    return result.success ? ok(c, result) : err(c, result.message, 400);
+});
+
+// POST /v1/tunnel/stop - stop the running tunnel
+tunnelRoute.post("/tunnel/stop", (c) => {
+    const result = stopTunnel();
+    return result.success ? ok(c, result) : err(c, result.message, 400);
+});
+
+// PUT /v1/tunnel/config - update token and/or custom domain without starting
+tunnelRoute.put("/tunnel/config", async (c) => {
+    const body = await c.req.json<{ token?: string; domain?: string }>().catch(() => null);
+    if (!body || (!body.token && !body.domain)) {
+        return err(c, "Provide 'token' and/or 'domain'", 400);
+    }
+    if (body.token) setTunnelToken(body.token);
+    if (body.domain) setTunnelDomain(body.domain);
+
+    return ok(c, {
+        message: "Tunnel configuration updated",
+        domain: getTunnelDomain() || undefined
+    });
+});

--- a/apps/api/src/services/adminAuth.ts
+++ b/apps/api/src/services/adminAuth.ts
@@ -124,12 +124,13 @@ export function isLoopbackAddress(address: string | undefined): boolean {
  */
 export function ensureDefaultAdminAccount(store: AdminAuthStore, now: number = Date.now()): void {
     const envPassword = process.env.SROUTER_ADMIN_PASSWORD;
-    const password = envPassword && envPassword.length > 0 ? envPassword : DEFAULT_ADMIN_PASSWORD;
+    const hasEnv = envPassword !== undefined && envPassword.length > 0;
+    const password = hasEnv ? envPassword : DEFAULT_ADMIN_PASSWORD;
     const hash = hashAdminPassword(password);
 
     if (!store.hasAdminAccount()) {
         store.createAdminAccount(hash, now);
-    } else {
+    } else if (hasEnv) {
         store.updatePasswordHash(hash, now);
     }
 }

--- a/apps/api/src/services/adminAuth.ts
+++ b/apps/api/src/services/adminAuth.ts
@@ -4,6 +4,12 @@ import { adminAuthStore, type AdminAuthStore } from "@srouter/db";
 export const ADMIN_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 export const ADMIN_SESSION_COOKIE = "srouter_admin_session";
 
+/**
+ * Default admin password used on first run when no account has been set up yet.
+ * Override at any time with the SROUTER_ADMIN_PASSWORD environment variable.
+ */
+export const DEFAULT_ADMIN_PASSWORD = "12345678";
+
 const PASSWORD_HASH_ALGORITHM = "scrypt";
 const PASSWORD_HASH_LENGTH = 64;
 const PASSWORD_SALT_LENGTH = 16;
@@ -107,4 +113,23 @@ export function isLoopbackAddress(address: string | undefined): boolean {
     if (!address) return false;
     const normalized = address.toLowerCase().replace(/^::ffff:/, "");
     return normalized === "127.0.0.1" || normalized === "::1";
+}
+
+/**
+ * Ensure the admin account uses the mandatory default password on every boot.
+ * - The password is reset to `DEFAULT_ADMIN_PASSWORD` (12345678) unless
+ *   `SROUTER_ADMIN_PASSWORD` is set, in which case that value is used instead.
+ * - This guarantees the dashboard is always reachable with the known default and
+ *   also recovers from a forgotten password.
+ */
+export function ensureDefaultAdminAccount(store: AdminAuthStore, now: number = Date.now()): void {
+    const envPassword = process.env.SROUTER_ADMIN_PASSWORD;
+    const password = envPassword && envPassword.length > 0 ? envPassword : DEFAULT_ADMIN_PASSWORD;
+    const hash = hashAdminPassword(password);
+
+    if (!store.hasAdminAccount()) {
+        store.createAdminAccount(hash, now);
+    } else {
+        store.updatePasswordHash(hash, now);
+    }
 }

--- a/apps/api/src/services/cloudflareTunnel.ts
+++ b/apps/api/src/services/cloudflareTunnel.ts
@@ -1,0 +1,157 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getSettingDB, setSettingDB } from "@srouter/db";
+
+const SETTING_TUNNEL_TOKEN = "cloudflare_tunnel_token";
+const SETTING_TUNNEL_DOMAIN = "cloudflare_tunnel_domain";
+
+let tunnelProcess: ChildProcess | null = null;
+let lastStatus: {
+    running: boolean;
+    startedAt?: number;
+    error?: string;
+    domain?: string;
+} = { running: false };
+
+/**
+ * Resolve the cloudflared binary. Checks PATH first, then common install locations.
+ */
+function resolveCloudflared(): string | null {
+    const candidates = [
+        process.env.CLOUDFLARED_PATH,
+        "/usr/local/bin/cloudflared",
+        "/usr/bin/cloudflared",
+        path.join(os.homedir(), ".local/bin/cloudflared")
+    ].filter((p): p is string => Boolean(p));
+
+    for (const candidate of candidates) {
+        try {
+            fs.accessSync(candidate, fs.constants.X_OK);
+            return candidate;
+        } catch {
+            continue;
+        }
+    }
+    return null;
+}
+
+export function getTunnelToken(): string {
+    return getSettingDB(SETTING_TUNNEL_TOKEN);
+}
+
+export function setTunnelToken(token: string): void {
+    setSettingDB(SETTING_TUNNEL_TOKEN, token.trim());
+}
+
+export function getTunnelDomain(): string {
+    return getSettingDB(SETTING_TUNNEL_DOMAIN);
+}
+
+export function setTunnelDomain(domain: string): void {
+    setSettingDB(
+        SETTING_TUNNEL_DOMAIN,
+        domain
+            .trim()
+            .replace(/^https?:\/\//, "")
+            .replace(/\/+$/, "")
+    );
+}
+
+export function getTunnelStatus() {
+    return {
+        running: tunnelProcess !== null && tunnelProcess.exitCode === null,
+        pid: tunnelProcess?.pid,
+        startedAt: lastStatus.startedAt,
+        error: lastStatus.error,
+        domain: getTunnelDomain() || undefined,
+        cloudflaredAvailable: resolveCloudflared() !== null
+    };
+}
+
+/**
+ * Start a Cloudflare Tunnel using a Tunnel Token (no `cloudflared login` required).
+ *
+ * With token-based tunnels the ingress (custom hostname → http://localhost:PORT)
+ * is configured remotely in the Cloudflare Zero Trust dashboard, so custom domains
+ * work without writing a local config.yml or cert.pem.
+ */
+export function startTunnel(options: { port?: number; token?: string; domain?: string } = {}): {
+    success: boolean;
+    message: string;
+    domain?: string;
+} {
+    if (tunnelProcess && tunnelProcess.exitCode === null) {
+        return { success: false, message: "Tunnel is already running" };
+    }
+
+    const token = (options.token ?? getTunnelToken()).trim();
+    if (!token) {
+        return {
+            success: false,
+            message:
+                "No Cloudflare Tunnel Token configured. Set it via POST /v1/tunnel/token or the 'cloudflare_tunnel_token' setting."
+        };
+    }
+
+    if (options.domain) setTunnelDomain(options.domain);
+
+    const cloudflared = resolveCloudflared();
+    if (!cloudflared) {
+        return {
+            success: false,
+            message:
+                "cloudflared binary not found. Install it (e.g. 'brew install cloudflared' / apt / deb package) or set CLOUDFLARED_PATH."
+        };
+    }
+
+    const child = spawn(cloudflared, ["tunnel", "run", "--token", token], {
+        stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    tunnelProcess = child;
+    lastStatus = { running: true, startedAt: Date.now(), domain: getTunnelDomain() || undefined };
+
+    const handleOutput = (chunk: Buffer) => {
+        const text = chunk.toString();
+        // Surface connection errors but keep logs out of memory-heavy paths
+        if (/failed|error/i.test(text)) {
+            lastStatus.error = text.split("\n").slice(-3).join(" ").slice(0, 300);
+        }
+    };
+    child.stdout?.on("data", handleOutput);
+    child.stderr?.on("data", handleOutput);
+
+    child.on("exit", (code) => {
+        lastStatus = {
+            ...lastStatus,
+            running: false,
+            error:
+                code !== null && code !== 0
+                    ? lastStatus.error || `cloudflared exited with code ${code}`
+                    : undefined
+        };
+        tunnelProcess = null;
+    });
+    child.on("error", (err) => {
+        lastStatus = { ...lastStatus, running: false, error: err.message };
+        tunnelProcess = null;
+    });
+
+    return {
+        success: true,
+        message: `Cloudflare Tunnel started (pid ${child.pid})`,
+        domain: getTunnelDomain() || undefined
+    };
+}
+
+export function stopTunnel(): { success: boolean; message: string } {
+    if (!tunnelProcess || tunnelProcess.exitCode !== null) {
+        return { success: false, message: "Tunnel is not running" };
+    }
+    tunnelProcess.kill("SIGTERM");
+    tunnelProcess = null;
+    lastStatus = { running: false };
+    return { success: true, message: "Cloudflare Tunnel stopped" };
+}

--- a/apps/api/src/services/cloudflareTunnel.ts
+++ b/apps/api/src/services/cloudflareTunnel.ts
@@ -1,11 +1,46 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import https from "node:https";
 import os from "node:os";
 import path from "node:path";
 import { getSettingDB, setSettingDB } from "@srouter/db";
 
 const SETTING_TUNNEL_TOKEN = "cloudflare_tunnel_token";
 const SETTING_TUNNEL_DOMAIN = "cloudflare_tunnel_domain";
+const SETTING_CLOUDFLARED_PATH = "cloudflared_path";
+
+const DEFAULT_INSTALL_DIR = path.join(os.homedir(), ".local", "bin");
+
+// Pub/sub so the SSE endpoint can push live tunnel/install state to clients.
+const tunnelEmitter = new EventEmitter();
+tunnelEmitter.setMaxListeners(100);
+
+let lastEmitAt = 0;
+function emitTunnelUpdate(force = false): void {
+    const now = Date.now();
+    if (!force && now - lastEmitAt < 300) return;
+    lastEmitAt = now;
+    tunnelEmitter.emit("update", getTunnelStatus());
+}
+
+export function onTunnelUpdate(
+    handler: (status: ReturnType<typeof getTunnelStatus>) => void
+): () => void {
+    tunnelEmitter.on("update", handler);
+    return () => tunnelEmitter.off("update", handler);
+}
+
+interface InstallState {
+    inProgress: boolean;
+    done: boolean;
+    error?: string;
+    platform?: string;
+    arch?: string;
+    target?: string;
+    downloadedBytes?: number;
+    totalBytes?: number;
+}
 
 let tunnelProcess: ChildProcess | null = null;
 let lastStatus: {
@@ -15,12 +50,65 @@ let lastStatus: {
     domain?: string;
 } = { running: false };
 
+let installState: InstallState = { inProgress: false, done: false };
+
+// Auto-restart / autostart state so the tunnel stays up across crashes and reboots.
+const SETTING_TUNNEL_AUTOSTART = "cloudflare_tunnel_autostart";
+const MAX_RESTART_ATTEMPTS = 5;
+let tunnelDesired = false;
+let tunnelStopping = false;
+let restartAttempts = 0;
+let restartTimer: ReturnType<typeof setTimeout> | null = null;
+let lastTunnelPort = 3000;
+
+function clearRestartTimer(): void {
+    if (restartTimer) {
+        clearTimeout(restartTimer);
+        restartTimer = null;
+    }
+}
+
+function scheduleTunnelRestart(): void {
+    if (!tunnelDesired || tunnelStopping) return;
+    if (restartAttempts >= MAX_RESTART_ATTEMPTS) {
+        tunnelDesired = false;
+        lastStatus = {
+            ...lastStatus,
+            running: false,
+            error: "Tunnel stopped after multiple restart attempts."
+        };
+        setSettingDB(SETTING_TUNNEL_AUTOSTART, "false");
+        emitTunnelUpdate(true);
+        return;
+    }
+    restartAttempts += 1;
+    const delay = Math.min(1000 * 2 ** (restartAttempts - 1), 30_000);
+    restartTimer = setTimeout(() => {
+        if (!tunnelDesired || tunnelStopping) return;
+        const result = startTunnel({
+            port: lastTunnelPort,
+            token: getTunnelToken() || undefined,
+            domain: getTunnelDomain() || undefined
+        });
+        if (!result.success) {
+            // e.g. binary missing — stop retrying rather than loop forever.
+            tunnelDesired = false;
+            setSettingDB(SETTING_TUNNEL_AUTOSTART, "false");
+            emitTunnelUpdate(true);
+        }
+    }, delay);
+}
+
 /**
- * Resolve the cloudflared binary. Checks PATH first, then common install locations.
+ * Resolve the cloudflared binary. Checks PATH first, then common install
+ * locations and any previously installed/saved path.
  */
 function resolveCloudflared(): string | null {
+    const saved = getSettingDB(SETTING_CLOUDFLARED_PATH);
     const candidates = [
         process.env.CLOUDFLARED_PATH,
+        saved,
+        path.join(DEFAULT_INSTALL_DIR, "cloudflared"),
         "/usr/local/bin/cloudflared",
         "/usr/bin/cloudflared",
         path.join(os.homedir(), ".local/bin/cloudflared")
@@ -35,6 +123,235 @@ function resolveCloudflared(): string | null {
         }
     }
     return null;
+}
+
+/**
+ * Map the current Node platform/arch to the official cloudflared release asset name.
+ * Returns null when the platform is unsupported (install must be done manually).
+ */
+function resolveTargetAsset(): {
+    asset: string;
+    binary: string;
+    platform: string;
+    arch: string;
+} | null {
+    const platform = process.platform;
+    const arch = process.arch;
+
+    if (platform === "linux" && arch === "x64") {
+        return {
+            asset: "cloudflared-linux-amd64",
+            binary: "cloudflared",
+            platform: "linux",
+            arch: "amd64"
+        };
+    }
+    if (platform === "linux" && arch === "arm64") {
+        return {
+            asset: "cloudflared-linux-arm64",
+            binary: "cloudflared",
+            platform: "linux",
+            arch: "arm64"
+        };
+    }
+    if (platform === "darwin" && arch === "x64") {
+        return {
+            asset: "cloudflared-darwin-amd64",
+            binary: "cloudflared",
+            platform: "darwin",
+            arch: "amd64"
+        };
+    }
+    if (platform === "darwin" && arch === "arm64") {
+        return {
+            asset: "cloudflared-darwin-arm64",
+            binary: "cloudflared",
+            platform: "darwin",
+            arch: "arm64"
+        };
+    }
+    if (platform === "win32" && arch === "x64") {
+        return {
+            asset: "cloudflared-windows-amd64.exe",
+            binary: "cloudflared.exe",
+            platform: "win32",
+            arch: "amd64"
+        };
+    }
+    if (platform === "win32" && arch === "arm64") {
+        return {
+            asset: "cloudflared-windows-arm64.exe",
+            binary: "cloudflared.exe",
+            platform: "win32",
+            arch: "arm64"
+        };
+    }
+    return null;
+}
+
+/**
+ * Stream-download a file from an HTTPS URL, reporting progress via the callback.
+ * Follows up to 5 redirects (GitHub's latest/download URLs 302 to the CDN).
+ */
+function httpsDownloadFile(
+    url: string,
+    dest: string,
+    onProgress?: (downloaded: number, total: number) => void,
+    redirects = 0
+): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const req = https.get(
+            url,
+            { headers: { "User-Agent": "srouter-cloudflared-installer" } },
+            (res) => {
+                const status = res.statusCode ?? 0;
+                if (status >= 300 && status < 400 && res.headers.location && redirects < 5) {
+                    res.resume();
+                    const next = new URL(res.headers.location, url).toString();
+                    resolve(httpsDownloadFile(next, dest, onProgress, redirects + 1));
+                    return;
+                }
+                if (status < 200 || status >= 300) {
+                    res.resume();
+                    reject(new Error(`Download failed with HTTP ${status}`));
+                    return;
+                }
+                const total = Number(res.headers["content-length"] ?? 0);
+                let downloaded = 0;
+                const file = fs.createWriteStream(dest);
+                res.on("data", (c: Buffer) => {
+                    downloaded += c.length;
+                    onProgress?.(downloaded, total);
+                });
+                res.pipe(file);
+                file.on("finish", () => file.close(() => resolve()));
+                file.on("error", (err) => {
+                    fs.rm(dest, { force: true }, () => reject(err));
+                });
+            }
+        );
+        req.on("error", (err) => {
+            fs.rm(dest, { force: true }, () => reject(err));
+        });
+    });
+}
+
+/**
+ * Lightweight sanity check that the downloaded file is a real executable and not
+ * an HTML error page. Checks for ELF (Linux), Mach-O (macOS) or PE (Windows) magic.
+ */
+function isExecutableMagic(buf: Buffer): boolean {
+    if (buf.length < 4) return false;
+    // ELF
+    if (buf[0] === 0x7f && buf[1] === 0x45 && buf[2] === 0x4c && buf[3] === 0x46) return true;
+    // Mach-O (64-bit / fat)
+    if (buf[0] === 0xcf && buf[1] === 0xfa && buf[2] === 0xed && buf[3] === 0xfe) return true;
+    if (buf[0] === 0xfe && buf[1] === 0xed && buf[2] === 0xfa && buf[3] === 0xcf) return true;
+    if (buf[0] === 0xca && buf[1] === 0xfe && buf[2] === 0xba && buf[3] === 0xbe) return true;
+    // PE (MZ header)
+    if (buf[0] === 0x4d && buf[1] === 0x5a) return true;
+    return false;
+}
+
+export interface InstallResult {
+    success: boolean;
+    message: string;
+    path?: string;
+    platform?: string;
+    arch?: string;
+}
+
+/**
+ * Download and install the official cloudflared binary for this machine.
+ * Runs asynchronously; progress/state is observable via getInstallStatus().
+ */
+export function installCloudflared(): InstallResult {
+    if (installState.inProgress) {
+        return { success: false, message: "Installation already in progress" };
+    }
+    const target = resolveTargetAsset();
+    if (!target) {
+        return {
+            success: false,
+            message: `Unsupported platform (${process.platform}/${process.arch}). Install cloudflared manually from https://github.com/cloudflare/cloudflared/releases.`,
+            platform: process.platform,
+            arch: process.arch
+        };
+    }
+
+    installState = {
+        inProgress: true,
+        done: false,
+        platform: target.platform,
+        arch: target.arch
+    };
+
+    const url = `https://github.com/cloudflare/cloudflared/releases/latest/download/${target.asset}`;
+    const destDir = DEFAULT_INSTALL_DIR;
+    const dest = path.join(destDir, target.binary);
+
+    (async () => {
+        try {
+            fs.mkdirSync(destDir, { recursive: true });
+            const tmp = `${dest}.part`;
+            await httpsDownloadFile(url, tmp, (downloaded, total) => {
+                installState.downloadedBytes = downloaded;
+                installState.totalBytes = total || undefined;
+                emitTunnelUpdate();
+            });
+
+            const head = Buffer.alloc(4);
+            const fd = fs.openSync(tmp, "r");
+            try {
+                fs.readSync(fd, head, 0, 4, 0);
+            } finally {
+                fs.closeSync(fd);
+            }
+            if (!isExecutableMagic(head)) {
+                fs.rmSync(tmp, { force: true });
+                throw new Error(
+                    "Downloaded file is not a valid cloudflared binary (got an error page?)"
+                );
+            }
+
+            fs.renameSync(tmp, dest);
+            if (process.platform !== "win32") {
+                fs.chmodSync(dest, 0o755);
+            }
+            setSettingDB(SETTING_CLOUDFLARED_PATH, dest);
+            installState = { ...installState, inProgress: false, done: true, target: dest };
+            emitTunnelUpdate(true);
+        } catch (err) {
+            installState = {
+                ...installState,
+                inProgress: false,
+                done: true,
+                error: err instanceof Error ? err.message : String(err)
+            };
+            emitTunnelUpdate(true);
+        }
+    })();
+
+    return {
+        success: true,
+        message: `Downloading cloudflared for ${target.platform}/${target.arch}…`,
+        platform: target.platform,
+        arch: target.arch
+    };
+}
+
+export function getInstallStatus() {
+    return {
+        inProgress: installState.inProgress,
+        done: installState.done,
+        error: installState.error,
+        platform: installState.platform,
+        arch: installState.arch,
+        target: installState.target,
+        downloadedBytes: installState.downloadedBytes,
+        totalBytes: installState.totalBytes,
+        cloudflaredAvailable: resolveCloudflared() !== null
+    };
 }
 
 export function getTunnelToken(): string {
@@ -65,59 +382,97 @@ export function getTunnelStatus() {
         pid: tunnelProcess?.pid,
         startedAt: lastStatus.startedAt,
         error: lastStatus.error,
-        domain: getTunnelDomain() || undefined,
-        cloudflaredAvailable: resolveCloudflared() !== null
+        domain: lastStatus.domain || getTunnelDomain() || undefined,
+        cloudflaredAvailable: resolveCloudflared() !== null,
+        install: getInstallStatus()
     };
 }
 
 /**
- * Start a Cloudflare Tunnel using a Tunnel Token (no `cloudflared login` required).
+ * Start a Cloudflare Tunnel.
  *
- * With token-based tunnels the ingress (custom hostname → http://localhost:PORT)
- * is configured remotely in the Cloudflare Zero Trust dashboard, so custom domains
- * work without writing a local config.yml or cert.pem.
+ * Two modes:
+ *  - Quick tunnel (no token): `cloudflared tunnel --url http://localhost:PORT`
+ *    gives a random *.trycloudflare.com URL. No token or Cloudflare account needed.
+ *  - Named tunnel (token + optional custom domain): `cloudflared tunnel run --token …`
+ *    uses a Tunnel Token created in Cloudflare Zero Trust; the ingress
+ *    (custom hostname → http://localhost:PORT) is configured remotely there.
+ *
+ * The token and custom domain are ONLY required for the named-tunnel / custom-domain
+ * mode. A quick tunnel works with zero configuration.
  */
 export function startTunnel(options: { port?: number; token?: string; domain?: string } = {}): {
     success: boolean;
     message: string;
     domain?: string;
+    mode: "quick" | "named";
 } {
     if (tunnelProcess && tunnelProcess.exitCode === null) {
-        return { success: false, message: "Tunnel is already running" };
+        return { success: false, message: "Tunnel is already running", mode: "named" };
     }
 
     const token = (options.token ?? getTunnelToken()).trim();
-    if (!token) {
-        return {
-            success: false,
-            message:
-                "No Cloudflare Tunnel Token configured. Set it via POST /v1/tunnel/token or the 'cloudflare_tunnel_token' setting."
-        };
-    }
-
-    if (options.domain) setTunnelDomain(options.domain);
+    const port = options.port ?? 3000;
 
     const cloudflared = resolveCloudflared();
     if (!cloudflared) {
         return {
             success: false,
             message:
-                "cloudflared binary not found. Install it (e.g. 'brew install cloudflared' / apt / deb package) or set CLOUDFLARED_PATH."
+                "cloudflared binary not found. Install it (e.g. 'brew install cloudflared' / apt / deb package) or set CLOUDFLARED_PATH.",
+            mode: "named"
         };
     }
 
-    const child = spawn(cloudflared, ["tunnel", "run", "--token", token], {
+    const quick = !token;
+    if (!quick && options.domain) setTunnelDomain(options.domain);
+
+    // Mark the tunnel as desired so it auto-restarts on crash and survives reboots.
+    tunnelDesired = true;
+    tunnelStopping = false;
+    restartAttempts = 0;
+    lastTunnelPort = port;
+    clearRestartTimer();
+    setSettingDB(SETTING_TUNNEL_AUTOSTART, "true");
+
+    const args = quick
+        ? ["tunnel", "--url", `http://localhost:${port}`]
+        : ["tunnel", "run", "--token", token];
+
+    const child = spawn(cloudflared, args, {
         stdio: ["ignore", "pipe", "pipe"]
     });
 
     tunnelProcess = child;
-    lastStatus = { running: true, startedAt: Date.now(), domain: getTunnelDomain() || undefined };
+    lastStatus = {
+        running: true,
+        startedAt: Date.now(),
+        domain: quick ? undefined : getTunnelDomain() || undefined
+    };
+
+    // Rolling tail of combined output so URLs split across chunks still match.
+    let outputTail = "";
 
     const handleOutput = (chunk: Buffer) => {
         const text = chunk.toString();
-        // Surface connection errors but keep logs out of memory-heavy paths
+        outputTail = `${outputTail}${text}`.slice(-8000);
+        // Quick tunnels print the assigned URL — capture it for display.
+        if (quick && !lastStatus.domain) {
+            const match = outputTail.match(
+                /https:\/\/[a-z0-9][^\s"'<>|]*\.(?:trycloudflare\.com|cfargotunnel\.com)/i
+            );
+            if (match) {
+                const url = match[0].replace(/[.",]$/, "");
+                if (url !== lastStatus.domain) {
+                    lastStatus.domain = url;
+                    emitTunnelUpdate(true);
+                }
+            }
+        }
+        // Surface connection errors but keep logs out of memory-heavy paths.
         if (/failed|error/i.test(text)) {
             lastStatus.error = text.split("\n").slice(-3).join(" ").slice(0, 300);
+            emitTunnelUpdate();
         }
     };
     child.stdout?.on("data", handleOutput);
@@ -133,16 +488,26 @@ export function startTunnel(options: { port?: number; token?: string; domain?: s
                     : undefined
         };
         tunnelProcess = null;
+        emitTunnelUpdate(true);
+        // Auto-restart unless this was an intentional stop.
+        if (tunnelDesired && !tunnelStopping) scheduleTunnelRestart();
     });
     child.on("error", (err) => {
         lastStatus = { ...lastStatus, running: false, error: err.message };
         tunnelProcess = null;
+        emitTunnelUpdate(true);
+        if (tunnelDesired && !tunnelStopping) scheduleTunnelRestart();
     });
+
+    emitTunnelUpdate(true);
 
     return {
         success: true,
-        message: `Cloudflare Tunnel started (pid ${child.pid})`,
-        domain: getTunnelDomain() || undefined
+        message: quick
+            ? `Cloudflare quick Tunnel started (pid ${child.pid})`
+            : `Cloudflare Tunnel started (pid ${child.pid})`,
+        domain: lastStatus.domain,
+        mode: quick ? "quick" : "named"
     };
 }
 
@@ -150,8 +515,29 @@ export function stopTunnel(): { success: boolean; message: string } {
     if (!tunnelProcess || tunnelProcess.exitCode !== null) {
         return { success: false, message: "Tunnel is not running" };
     }
+    // Intentional stop: don't auto-restart.
+    tunnelDesired = false;
+    tunnelStopping = true;
+    clearRestartTimer();
+    setSettingDB(SETTING_TUNNEL_AUTOSTART, "false");
     tunnelProcess.kill("SIGTERM");
     tunnelProcess = null;
     lastStatus = { running: false };
+    emitTunnelUpdate(true);
     return { success: true, message: "Cloudflare Tunnel stopped" };
+}
+
+/**
+ * Auto-start the tunnel on server boot if it was left running previously.
+ * Reads the persisted autostart flag; uses the stored token/domain (quick tunnel
+ * if no token is configured). No-op if cloudflared isn't installed yet.
+ */
+export function autostartTunnelIfEnabled(): void {
+    if (getSettingDB(SETTING_TUNNEL_AUTOSTART) !== "true") return;
+    if (tunnelProcess && tunnelProcess.exitCode === null) return;
+    startTunnel({
+        port: lastTunnelPort,
+        token: getTunnelToken() || undefined,
+        domain: getTunnelDomain() || undefined
+    });
 }

--- a/apps/web/src/components/dashboard/NetworkStatus.tsx
+++ b/apps/web/src/components/dashboard/NetworkStatus.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { Check, Cloud, Code2, Copy, Network } from "lucide-react";
+import { Check, Cloud, Code2, Copy, Network, Play, Square } from "lucide-react";
 import { toast } from "sonner";
 import { getGatewayBaseUrl } from "@/lib/api";
+import { useTunnelStatus, useTunnelActions } from "@/hooks/useTunnel";
 
 function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
     const [copied, setCopied] = useState(false);
@@ -36,6 +37,33 @@ function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) 
 
 export function NetworkStatus() {
     const apiBase = getGatewayBaseUrl();
+    const { status: tunnel, fetchStatus } = useTunnelStatus();
+    const { startTunnel, stopTunnel } = useTunnelActions();
+    const [tunnelBusy, setTunnelBusy] = useState(false);
+    const [showTokenInput, setShowTokenInput] = useState(false);
+    const [tokenInput, setTokenInput] = useState("");
+    const [domainInput, setDomainInput] = useState("");
+
+    const handleToggleTunnel = async () => {
+        setTunnelBusy(true);
+        try {
+            if (tunnel?.running) {
+                await stopTunnel();
+            } else {
+                const payload: { token?: string; domain?: string } = {};
+                if (tokenInput.trim()) payload.token = tokenInput.trim();
+                if (domainInput.trim()) payload.domain = domainInput.trim();
+                const okStart = await startTunnel(payload);
+                if (okStart) {
+                    setShowTokenInput(false);
+                    setTokenInput("");
+                }
+            }
+            await fetchStatus();
+        } finally {
+            setTunnelBusy(false);
+        }
+    };
 
     return (
         <section
@@ -106,18 +134,98 @@ export function NetworkStatus() {
                                     Cloudflare Tunnel
                                 </p>
                                 <p className="mt-0.5 truncate text-[10px] text-muted-foreground">
-                                    Expose gateway without opening ports
+                                    {tunnel?.running
+                                        ? `Running${tunnel.domain ? ` · ${tunnel.domain}` : ""}`
+                                        : "Expose gateway without opening ports"}
                                 </p>
                             </div>
                         </div>
-                        <span className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/50 bg-secondary/25 px-2 py-0.5 font-mono text-[8.5px] text-muted-foreground">
+                        <div className="flex shrink-0 items-center gap-1.5">
                             <span
-                                className="size-1 rounded-full bg-muted-foreground/50"
-                                aria-hidden="true"
-                            />
-                            Coming soon
-                        </span>
+                                className={`flex items-center gap-1.5 rounded-full border px-2 py-0.5 font-mono text-[8.5px] ${
+                                    tunnel?.running
+                                        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
+                                        : "border-border/50 bg-secondary/25 text-muted-foreground"
+                                }`}
+                            >
+                                <span
+                                    className={`size-1 rounded-full ${
+                                        tunnel?.running
+                                            ? "bg-emerald-500"
+                                            : "bg-muted-foreground/50"
+                                    }`}
+                                    aria-hidden="true"
+                                />
+                                {tunnel?.running ? "Connected" : "Offline"}
+                            </span>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    if (tunnel?.running) {
+                                        void handleToggleTunnel();
+                                    } else if (tunnel?.tokenConfigured) {
+                                        void handleToggleTunnel();
+                                    } else {
+                                        setShowTokenInput((v) => !v);
+                                    }
+                                }}
+                                disabled={
+                                    tunnelBusy || (tunnel !== null && !tunnel.cloudflaredAvailable)
+                                }
+                                title={
+                                    tunnel && !tunnel.cloudflaredAvailable
+                                        ? "cloudflared binary not found on server"
+                                        : undefined
+                                }
+                                className={`inline-flex h-6 items-center gap-1 rounded-md border border-border/60 px-2 font-mono text-[9px] font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                                    tunnel?.running
+                                        ? "text-red-500 hover:bg-red-500/10"
+                                        : "text-emerald-600 hover:bg-emerald-500/10"
+                                }`}
+                            >
+                                {tunnel?.running ? (
+                                    <>
+                                        <Square className="size-2.5" /> Stop
+                                    </>
+                                ) : (
+                                    <>
+                                        <Play className="size-2.5" /> Start
+                                    </>
+                                )}
+                            </button>
+                        </div>
                     </div>
+
+                    {showTokenInput && (
+                        <div className="space-y-2 py-2.5">
+                            <input
+                                type="password"
+                                value={tokenInput}
+                                onChange={(e) => setTokenInput(e.target.value)}
+                                placeholder="Cloudflare Tunnel Token (eyJ...)"
+                                className="w-full rounded-md border border-border/50 bg-secondary/30 px-2.5 py-1.5 font-mono text-[10.5px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+                            />
+                            <input
+                                type="text"
+                                value={domainInput}
+                                onChange={(e) => setDomainInput(e.target.value)}
+                                placeholder="Custom domain (e.g. router.example.com) — optional"
+                                className="w-full rounded-md border border-border/50 bg-secondary/30 px-2.5 py-1.5 font-mono text-[10.5px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+                            />
+                            <p className="font-mono text-[9px] leading-relaxed text-muted-foreground/70">
+                                Create a tunnel in Cloudflare Zero Trust, copy its token, then map
+                                your hostname to http://localhost:PORT.
+                            </p>
+                            <button
+                                type="button"
+                                onClick={() => void handleToggleTunnel()}
+                                disabled={!tokenInput.trim() || tunnelBusy}
+                                className="inline-flex h-6 items-center rounded-md bg-emerald-600 px-3 font-mono text-[9px] font-semibold text-white hover:bg-emerald-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                            >
+                                Connect Tunnel
+                            </button>
+                        </div>
+                    )}
 
                     <div className="group flex items-center justify-between gap-3 py-2.5 transition-colors">
                         <div className="flex items-center gap-2.5 min-w-0">

--- a/apps/web/src/components/dashboard/NetworkStatus.tsx
+++ b/apps/web/src/components/dashboard/NetworkStatus.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { Check, Cloud, Code2, Copy, Network, Play, Square } from "lucide-react";
+import { Check, Cloud, Code2, Copy, Network } from "lucide-react";
 import { toast } from "sonner";
 import { getGatewayBaseUrl } from "@/lib/api";
 import { useTunnelStatus, useTunnelActions } from "@/hooks/useTunnel";
+import { TunnelModal } from "@/components/dashboard/TunnelModal";
 
 function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
     const [copied, setCopied] = useState(false);
@@ -38,32 +39,8 @@ function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) 
 export function NetworkStatus() {
     const apiBase = getGatewayBaseUrl();
     const { status: tunnel, fetchStatus } = useTunnelStatus();
-    const { startTunnel, stopTunnel } = useTunnelActions();
-    const [tunnelBusy, setTunnelBusy] = useState(false);
-    const [showTokenInput, setShowTokenInput] = useState(false);
-    const [tokenInput, setTokenInput] = useState("");
-    const [domainInput, setDomainInput] = useState("");
-
-    const handleToggleTunnel = async () => {
-        setTunnelBusy(true);
-        try {
-            if (tunnel?.running) {
-                await stopTunnel();
-            } else {
-                const payload: { token?: string; domain?: string } = {};
-                if (tokenInput.trim()) payload.token = tokenInput.trim();
-                if (domainInput.trim()) payload.domain = domainInput.trim();
-                const okStart = await startTunnel(payload);
-                if (okStart) {
-                    setShowTokenInput(false);
-                    setTokenInput("");
-                }
-            }
-            await fetchStatus();
-        } finally {
-            setTunnelBusy(false);
-        }
-    };
+    const { startTunnel, stopTunnel, installCloudflared } = useTunnelActions();
+    const [modalOpen, setModalOpen] = useState(false);
 
     return (
         <section
@@ -141,91 +118,15 @@ export function NetworkStatus() {
                             </div>
                         </div>
                         <div className="flex shrink-0 items-center gap-1.5">
-                            <span
-                                className={`flex items-center gap-1.5 rounded-full border px-2 py-0.5 font-mono text-[8.5px] ${
-                                    tunnel?.running
-                                        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
-                                        : "border-border/50 bg-secondary/25 text-muted-foreground"
-                                }`}
-                            >
-                                <span
-                                    className={`size-1 rounded-full ${
-                                        tunnel?.running
-                                            ? "bg-emerald-500"
-                                            : "bg-muted-foreground/50"
-                                    }`}
-                                    aria-hidden="true"
-                                />
-                                {tunnel?.running ? "Connected" : "Offline"}
-                            </span>
                             <button
                                 type="button"
-                                onClick={() => {
-                                    if (tunnel?.running) {
-                                        void handleToggleTunnel();
-                                    } else if (tunnel?.tokenConfigured) {
-                                        void handleToggleTunnel();
-                                    } else {
-                                        setShowTokenInput((v) => !v);
-                                    }
-                                }}
-                                disabled={
-                                    tunnelBusy || (tunnel !== null && !tunnel.cloudflaredAvailable)
-                                }
-                                title={
-                                    tunnel && !tunnel.cloudflaredAvailable
-                                        ? "cloudflared binary not found on server"
-                                        : undefined
-                                }
-                                className={`inline-flex h-6 items-center gap-1 rounded-md border border-border/60 px-2 font-mono text-[9px] font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-                                    tunnel?.running
-                                        ? "text-red-500 hover:bg-red-500/10"
-                                        : "text-emerald-600 hover:bg-emerald-500/10"
-                                }`}
+                                onClick={() => setModalOpen(true)}
+                                className="inline-flex h-6 items-center rounded-md border border-border/60 px-2 font-mono text-[9px] font-semibold text-sky-500 transition-colors hover:bg-sky-500/10"
                             >
-                                {tunnel?.running ? (
-                                    <>
-                                        <Square className="size-2.5" /> Stop
-                                    </>
-                                ) : (
-                                    <>
-                                        <Play className="size-2.5" /> Start
-                                    </>
-                                )}
+                                {tunnel?.running ? "Open" : "Configure"}
                             </button>
                         </div>
                     </div>
-
-                    {showTokenInput && (
-                        <div className="space-y-2 py-2.5">
-                            <input
-                                type="password"
-                                value={tokenInput}
-                                onChange={(e) => setTokenInput(e.target.value)}
-                                placeholder="Cloudflare Tunnel Token (eyJ...)"
-                                className="w-full rounded-md border border-border/50 bg-secondary/30 px-2.5 py-1.5 font-mono text-[10.5px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-                            />
-                            <input
-                                type="text"
-                                value={domainInput}
-                                onChange={(e) => setDomainInput(e.target.value)}
-                                placeholder="Custom domain (e.g. router.example.com) — optional"
-                                className="w-full rounded-md border border-border/50 bg-secondary/30 px-2.5 py-1.5 font-mono text-[10.5px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-                            />
-                            <p className="font-mono text-[9px] leading-relaxed text-muted-foreground/70">
-                                Create a tunnel in Cloudflare Zero Trust, copy its token, then map
-                                your hostname to http://localhost:PORT.
-                            </p>
-                            <button
-                                type="button"
-                                onClick={() => void handleToggleTunnel()}
-                                disabled={!tokenInput.trim() || tunnelBusy}
-                                className="inline-flex h-6 items-center rounded-md bg-emerald-600 px-3 font-mono text-[9px] font-semibold text-white hover:bg-emerald-500 disabled:opacity-40 disabled:cursor-not-allowed"
-                            >
-                                Connect Tunnel
-                            </button>
-                        </div>
-                    )}
 
                     <div className="group flex items-center justify-between gap-3 py-2.5 transition-colors">
                         <div className="flex items-center gap-2.5 min-w-0">
@@ -251,6 +152,16 @@ export function NetworkStatus() {
                     </div>
                 </div>
             </div>
+
+            <TunnelModal
+                open={modalOpen}
+                onClose={() => setModalOpen(false)}
+                status={tunnel}
+                onStart={startTunnel}
+                onStop={stopTunnel}
+                onInstall={installCloudflared}
+                onRefresh={fetchStatus}
+            />
         </section>
     );
 }

--- a/apps/web/src/components/dashboard/TunnelModal.tsx
+++ b/apps/web/src/components/dashboard/TunnelModal.tsx
@@ -1,0 +1,426 @@
+import { useEffect, useState } from "react";
+import { Check, Cloud, Copy, Download, Loader2, Play, Square } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { TunnelStatus } from "@/hooks/useTunnel";
+
+function ConfirmStopDialog({
+    open,
+    busy,
+    onCancel,
+    onConfirm
+}: {
+    open: boolean;
+    busy: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+}) {
+    return (
+        <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+            <DialogContent className="sm:max-w-sm bg-card border-border p-6">
+                <DialogHeader className="space-y-1 text-left">
+                    <DialogTitle className="text-base font-semibold text-foreground">
+                        Stop Cloudflare Tunnel?
+                    </DialogTitle>
+                    <DialogDescription className="text-xs text-muted-foreground leading-relaxed">
+                        Remote clients will immediately lose access to the gateway. The tunnel URL
+                        will change the next time you start it.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="flex items-center justify-end gap-2 pt-4">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={onCancel}
+                        disabled={busy}
+                        className="h-8 text-xs font-semibold cursor-pointer"
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={onConfirm}
+                        disabled={busy}
+                        className="h-8 px-3.5 text-xs font-semibold cursor-pointer gap-1.5"
+                    >
+                        <Square className="size-3" />
+                        {busy ? "Stopping…" : "Yes, stop it"}
+                    </Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+type TunnelModalProps = {
+    open: boolean;
+    onClose: () => void;
+    status: TunnelStatus | null;
+    onStart: (payload: { token?: string; domain?: string }) => Promise<boolean>;
+    onStop: () => Promise<boolean>;
+    onInstall: () => Promise<boolean>;
+    onRefresh: () => Promise<void>;
+};
+
+function CopyButton({ text, label = "Copy" }: { text: string; label?: string }) {
+    const [copied, setCopied] = useState(false);
+    async function handleCopy() {
+        try {
+            await navigator.clipboard.writeText(text);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        } catch {
+            // ignore
+        }
+    }
+    return (
+        <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border/70 bg-background/70 px-2.5 text-[11px] font-semibold text-muted-foreground transition-[color,background-color,transform] hover:bg-secondary hover:text-foreground active:translate-y-px"
+        >
+            {copied ? <Check className="size-3 text-emerald-500" /> : <Copy className="size-3" />}
+            <span className={copied ? "text-emerald-500" : undefined}>
+                {copied ? "Copied" : label}
+            </span>
+        </button>
+    );
+}
+
+function StatusBadge({ status }: { status: TunnelStatus | null }) {
+    const installing = status?.install?.inProgress ?? false;
+    // Running but no URL yet → still connecting to Cloudflare's edge.
+    const connecting = Boolean(status?.running && !status.domain);
+    const label = status?.running
+        ? connecting
+            ? "Connecting"
+            : "Connected"
+        : installing
+          ? "Installing"
+          : "Offline";
+    const tone = connecting
+        ? "border-amber-500/40 bg-amber-500/10 text-amber-400"
+        : status?.running
+          ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
+          : installing
+            ? "border-blue-500/40 bg-blue-500/10 text-blue-400"
+            : "border-border/50 bg-secondary/25 text-muted-foreground";
+    const dot = connecting
+        ? "bg-amber-400 animate-pulse"
+        : status?.running
+          ? "bg-emerald-500"
+          : installing
+            ? "bg-blue-400 animate-pulse"
+            : "bg-muted-foreground/50";
+    return (
+        <span
+            className={`flex items-center gap-1.5 rounded-full border px-2 py-0.5 font-mono text-[8.5px] ${tone}`}
+        >
+            <span className={`size-1 rounded-full ${dot}`} aria-hidden="true" />
+            {label}
+        </span>
+    );
+}
+
+export function TunnelModal({
+    open,
+    onClose,
+    status,
+    onStart,
+    onStop,
+    onInstall,
+    onRefresh
+}: TunnelModalProps) {
+    const [tunnelBusy, setTunnelBusy] = useState(false);
+    const [installBusy, setInstallBusy] = useState(false);
+    const [confirmStopOpen, setConfirmStopOpen] = useState(false);
+    const [pendingAction, setPendingAction] = useState<"start" | "stop" | null>(null);
+    const [token, setToken] = useState("");
+    const [domain, setDomain] = useState("");
+
+    const installing = status?.install?.inProgress ?? false;
+    const cloudflaredMissing = status !== null && !status.cloudflaredAvailable && !installing;
+    // Running but the assigned URL hasn't arrived yet (quick tunnels take ~10s).
+    const connecting = Boolean(status?.running && !status.domain);
+    // Hard lock: buttons stay disabled until SSE confirms the state change.
+    const locked = tunnelBusy || pendingAction !== null || connecting;
+
+    // Clear the action lock once the backend state matches what we asked for.
+    useEffect(() => {
+        if (!pendingAction || !status) return;
+        if (pendingAction === "start" && status.running) setPendingAction(null);
+        if (pendingAction === "stop" && !status.running) setPendingAction(null);
+    }, [status, pendingAction]);
+
+    const handleStart = async () => {
+        setTunnelBusy(true);
+        setPendingAction("start");
+        try {
+            const okStart = await onStart({});
+            await onRefresh();
+            if (!okStart) setPendingAction(null);
+        } catch {
+            setPendingAction(null);
+        } finally {
+            setTunnelBusy(false);
+        }
+    };
+
+    const handleCustomConnect = async () => {
+        if (!token.trim()) return;
+        setTunnelBusy(true);
+        setPendingAction("start");
+        try {
+            const okStart = await onStart({ token: token.trim(), domain: domain.trim() });
+            if (okStart) {
+                setToken("");
+                setDomain("");
+            } else {
+                setPendingAction(null);
+            }
+            await onRefresh();
+        } catch {
+            setPendingAction(null);
+        } finally {
+            setTunnelBusy(false);
+        }
+    };
+
+    const handleStop = async () => {
+        setTunnelBusy(true);
+        setPendingAction("stop");
+        try {
+            const okStop = await onStop();
+            if (okStop) setConfirmStopOpen(false);
+            else setPendingAction(null);
+            await onRefresh();
+        } catch {
+            setPendingAction(null);
+        } finally {
+            setTunnelBusy(false);
+        }
+    };
+
+    const handleInstall = async () => {
+        setInstallBusy(true);
+        await onInstall();
+        await onRefresh();
+        setInstallBusy(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+            <DialogContent className="sm:max-w-md bg-card border-border p-6">
+                <DialogHeader className="space-y-1 text-left">
+                    <DialogTitle className="flex items-center gap-2 text-base font-semibold text-foreground">
+                        <Cloud className="size-4 text-sky-500" strokeWidth={1.75} />
+                        Cloudflare Tunnel
+                    </DialogTitle>
+                    <DialogDescription className="text-xs text-muted-foreground leading-relaxed">
+                        Expose the gateway to remote clients without opening any ports.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex items-center justify-between gap-3 py-1">
+                    <StatusBadge status={status} />
+                    {status?.running && status.domain ? (
+                        <CopyButton text={status.domain} label="Copy URL" />
+                    ) : null}
+                </div>
+
+                {/* Installing */}
+                {installing && (
+                    <div className="space-y-1.5 py-1">
+                        <div className="h-1.5 w-full overflow-hidden rounded-full bg-secondary/40">
+                            <div
+                                className="h-full rounded-full bg-sky-500 transition-[width] duration-300"
+                                style={{
+                                    width: `${
+                                        status?.install?.totalBytes && status.install.totalBytes > 0
+                                            ? Math.min(
+                                                  100,
+                                                  Math.round(
+                                                      ((status.install.downloadedBytes ?? 0) /
+                                                          status.install.totalBytes) *
+                                                          100
+                                                  )
+                                              )
+                                            : 0
+                                    }%`
+                                }}
+                            />
+                        </div>
+                        <p className="font-mono text-[9px] leading-relaxed text-muted-foreground/70">
+                            {status?.install?.error
+                                ? `Install failed: ${status.install.error}`
+                                : status?.install?.platform
+                                  ? `Downloading cloudflared for ${status.install.platform}/${status.install.arch}…`
+                                  : "Installing cloudflared…"}
+                        </p>
+                    </div>
+                )}
+
+                {status?.install?.error && !installing ? (
+                    <p className="font-mono text-[9px] leading-relaxed text-red-400/80">
+                        {status.install.error}
+                    </p>
+                ) : null}
+
+                {/* Missing binary */}
+                {cloudflaredMissing && (
+                    <div className="space-y-2 rounded-lg border border-border/50 bg-secondary/30 p-3">
+                        <p className="text-[11px] text-muted-foreground">
+                            The <code className="font-mono">cloudflared</code> binary isn't
+                            installed on the server. Install it automatically to continue.
+                        </p>
+                        <Button
+                            type="button"
+                            onClick={() => void handleInstall()}
+                            disabled={installBusy}
+                            className="h-8 px-3.5 text-xs font-semibold cursor-pointer shadow-xs gap-1.5"
+                        >
+                            <Download className="size-3.5" />
+                            {installBusy ? "Installing…" : "Install cloudflared"}
+                        </Button>
+                    </div>
+                )}
+
+                {/* Running */}
+                {status?.running ? (
+                    <div className="space-y-3 py-1">
+                        {status.domain ? (
+                            <div className="space-y-2">
+                                <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/80">
+                                    <span>Tunnel URL</span>
+                                    <CopyButton text={status.domain} label="Copy" />
+                                </div>
+                                <div className="flex items-center justify-between rounded-lg border border-border/50 bg-secondary/30 px-3 py-2">
+                                    <code className="truncate font-mono text-[11.5px] text-foreground select-all">
+                                        {status.domain}
+                                    </code>
+                                </div>
+                                <p className="font-mono text-[9px] leading-relaxed text-muted-foreground/70">
+                                    Use this URL as the Base URL in your OpenAI/Anthropic clients to
+                                    reach this gateway from anywhere.
+                                </p>
+                            </div>
+                        ) : (
+                            <p className="font-mono text-[9px] leading-relaxed text-muted-foreground/70">
+                                Tunnel is starting — the assigned URL will appear shortly.
+                            </p>
+                        )}
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={() => setConfirmStopOpen(true)}
+                            disabled={locked}
+                            title={
+                                connecting
+                                    ? "Tunnel is still starting — wait for the URL first"
+                                    : undefined
+                            }
+                            className="h-8 w-full text-xs font-semibold cursor-pointer gap-1.5"
+                        >
+                            {connecting ? (
+                                <Loader2 className="size-3 animate-spin" />
+                            ) : (
+                                <Square className="size-3" />
+                            )}
+                            {connecting ? "Starting…" : "Stop Tunnel"}
+                        </Button>
+                    </div>
+                ) : (
+                    !cloudflaredMissing &&
+                    !installing && (
+                        <div className="space-y-3 py-1">
+                            <Button
+                                type="button"
+                                onClick={() => void handleStart()}
+                                disabled={locked}
+                                className="h-8 w-full text-xs font-semibold cursor-pointer shadow-xs gap-1.5"
+                            >
+                                {pendingAction === "start" ? (
+                                    <Loader2 className="size-3 animate-spin" />
+                                ) : (
+                                    <Play className="size-3" />
+                                )}
+                                {pendingAction === "start" ? "Starting…" : "Start quick tunnel"}
+                            </Button>
+                            <div className="space-y-2 rounded-lg border border-border/50 bg-secondary/30 p-3">
+                                <p className="font-mono text-[9px] leading-relaxed text-muted-foreground/70">
+                                    Optional — use a named tunnel with your own hostname. A quick
+                                    tunnel needs no token and gives a random *.trycloudflare.com
+                                    URL.
+                                </p>
+                                <div className="space-y-1.5">
+                                    <label className="text-[11px] font-medium text-foreground">
+                                        Tunnel Token
+                                    </label>
+                                    <input
+                                        type="password"
+                                        value={token}
+                                        onChange={(e) => setToken(e.target.value)}
+                                        placeholder="Cloudflare Tunnel Token (eyJ...)"
+                                        className="w-full rounded-md border border-border/50 bg-background px-2.5 py-1.5 font-mono text-[10.5px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+                                    />
+                                </div>
+                                <div className="space-y-1.5">
+                                    <label className="text-[11px] font-medium text-foreground">
+                                        Custom Domain
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={domain}
+                                        onChange={(e) => setDomain(e.target.value)}
+                                        placeholder="router.example.com — optional"
+                                        className="w-full rounded-md border border-border/50 bg-background px-2.5 py-1.5 font-mono text-[10.5px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+                                    />
+                                </div>
+                                <Button
+                                    type="button"
+                                    onClick={() => void handleCustomConnect()}
+                                    disabled={!token.trim() || locked}
+                                    className="h-8 w-full text-xs font-semibold cursor-pointer shadow-xs"
+                                >
+                                    {pendingAction === "start" ? (
+                                        <>
+                                            <Loader2 className="size-3 animate-spin" />
+                                            Connecting…
+                                        </>
+                                    ) : (
+                                        "Connect with custom domain"
+                                    )}
+                                </Button>
+                            </div>
+                        </div>
+                    )
+                )}
+
+                <div className="flex justify-end pt-2">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={onClose}
+                        className="h-8 text-xs font-semibold cursor-pointer"
+                    >
+                        Close
+                    </Button>
+                </div>
+            </DialogContent>
+
+            <ConfirmStopDialog
+                open={confirmStopOpen}
+                busy={locked}
+                onCancel={() => setConfirmStopOpen(false)}
+                onConfirm={() => void handleStop()}
+            />
+        </Dialog>
+    );
+}

--- a/apps/web/src/hooks/useTunnel.ts
+++ b/apps/web/src/hooks/useTunnel.ts
@@ -2,6 +2,18 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 
+export interface TunnelInstallStatus {
+    inProgress: boolean;
+    done: boolean;
+    error?: string;
+    platform?: string;
+    arch?: string;
+    target?: string;
+    downloadedBytes?: number;
+    totalBytes?: number;
+    cloudflaredAvailable: boolean;
+}
+
 export interface TunnelStatus {
     running: boolean;
     pid?: number;
@@ -10,9 +22,10 @@ export interface TunnelStatus {
     domain?: string;
     cloudflaredAvailable: boolean;
     tokenConfigured?: boolean;
+    install?: TunnelInstallStatus;
 }
 
-export function useTunnelStatus(pollMs = 10000) {
+export function useTunnelStatus() {
     const [status, setStatus] = useState<TunnelStatus | null>(null);
     const [loading, setLoading] = useState(true);
 
@@ -28,34 +41,49 @@ export function useTunnelStatus(pollMs = 10000) {
     }, []);
 
     useEffect(() => {
+        // Initial snapshot, then live updates via SSE.
         void fetchStatus();
-        if (!pollMs) return;
-        const id = setInterval(() => void fetchStatus(), pollMs);
-        return () => clearInterval(id);
-    }, [fetchStatus, pollMs]);
+        if (typeof window === "undefined" || typeof window.EventSource === "undefined") {
+            const id = setInterval(() => void fetchStatus(), 10000);
+            return () => clearInterval(id);
+        }
+
+        const source = new EventSource("/v1/tunnel/events");
+        source.onmessage = (event) => {
+            try {
+                setStatus(JSON.parse(event.data) as TunnelStatus);
+            } catch (err) {
+                console.error("Failed to parse tunnel event:", err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        source.onerror = () => {
+            // SSE dropped — fall back to polling until it reconnects.
+            void fetchStatus();
+        };
+        return () => source.close();
+    }, [fetchStatus]);
 
     return { status, loading, fetchStatus };
 }
 
 export function useTunnelActions() {
-    const startTunnel = useCallback(
-        async (payload: { token?: string; domain?: string }) => {
-            try {
-                await api.post("/v1/tunnel/start", payload);
-                toast.success("Cloudflare Tunnel started", {
-                    description: payload.domain
-                        ? `Custom domain: ${payload.domain}`
-                        : "Gateway is now reachable through the tunnel."
-                });
-                return true;
-            } catch (err) {
-                const msg = err instanceof Error ? err.message : "Failed to start tunnel";
-                toast.error(msg);
-                return false;
-            }
-        },
-        []
-    );
+    const startTunnel = useCallback(async (payload: { token?: string; domain?: string }) => {
+        try {
+            await api.post("/v1/tunnel/start", payload);
+            toast.success("Cloudflare Tunnel started", {
+                description: payload.domain
+                    ? `Custom domain: ${payload.domain}`
+                    : "Gateway is now reachable through the tunnel."
+            });
+            return true;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "Failed to start tunnel";
+            toast.error(msg);
+            return false;
+        }
+    }, []);
 
     const stopTunnel = useCallback(async () => {
         try {
@@ -69,5 +97,19 @@ export function useTunnelActions() {
         }
     }, []);
 
-    return { startTunnel, stopTunnel };
+    const installCloudflared = useCallback(async () => {
+        try {
+            await api.post("/v1/tunnel/install");
+            toast.success("Installing cloudflared…", {
+                description: "Downloading the official binary. Watch the status below."
+            });
+            return true;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "Failed to install cloudflared";
+            toast.error(msg);
+            return false;
+        }
+    }, []);
+
+    return { startTunnel, stopTunnel, installCloudflared };
 }

--- a/apps/web/src/hooks/useTunnel.ts
+++ b/apps/web/src/hooks/useTunnel.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+
+export interface TunnelStatus {
+    running: boolean;
+    pid?: number;
+    startedAt?: number;
+    error?: string;
+    domain?: string;
+    cloudflaredAvailable: boolean;
+    tokenConfigured?: boolean;
+}
+
+export function useTunnelStatus(pollMs = 10000) {
+    const [status, setStatus] = useState<TunnelStatus | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    const fetchStatus = useCallback(async () => {
+        try {
+            const json = await api.get<TunnelStatus & { ok: boolean }>("/v1/tunnel/status");
+            setStatus(json);
+        } catch (err) {
+            console.error("Failed to fetch tunnel status:", err);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchStatus();
+        if (!pollMs) return;
+        const id = setInterval(() => void fetchStatus(), pollMs);
+        return () => clearInterval(id);
+    }, [fetchStatus, pollMs]);
+
+    return { status, loading, fetchStatus };
+}
+
+export function useTunnelActions() {
+    const startTunnel = useCallback(
+        async (payload: { token?: string; domain?: string }) => {
+            try {
+                await api.post("/v1/tunnel/start", payload);
+                toast.success("Cloudflare Tunnel started", {
+                    description: payload.domain
+                        ? `Custom domain: ${payload.domain}`
+                        : "Gateway is now reachable through the tunnel."
+                });
+                return true;
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : "Failed to start tunnel";
+                toast.error(msg);
+                return false;
+            }
+        },
+        []
+    );
+
+    const stopTunnel = useCallback(async () => {
+        try {
+            await api.post("/v1/tunnel/stop");
+            toast.success("Cloudflare Tunnel stopped");
+            return true;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "Failed to stop tunnel";
+            toast.error(msg);
+            return false;
+        }
+    }, []);
+
+    return { startTunnel, stopTunnel };
+}

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -38,9 +38,31 @@ if (!fs.existsSync(dbDir)) {
 
 export const db = new DatabaseSync(dbPath);
 
-// Enable WAL mode for high performance concurrency
-db.exec("PRAGMA journal_mode = WAL;");
-db.exec("PRAGMA foreign_keys = ON;");
+// Wait up to 5s instead of failing immediately when another connection
+// (e.g. a parallel test process or the CLI) holds the write lock.
+db.exec("PRAGMA busy_timeout = 5000;");
+
+// Enable WAL mode for high performance concurrency.
+// Retry briefly — concurrent processes initializing on the same DB file
+// (CI runs app test suites in parallel) can transiently hold the lock.
+function execWithRetry(sql: string, attempts = 5): void {
+    for (let i = 0; i < attempts; i++) {
+        try {
+            db.exec(sql);
+            return;
+        } catch (error) {
+            const code = (error as { code?: string }).code;
+            if (code === "SQLITE_BUSY" && i < attempts - 1) {
+                Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200 * (i + 1));
+                continue;
+            }
+            throw error;
+        }
+    }
+}
+
+execWithRetry("PRAGMA journal_mode = WAL;");
+execWithRetry("PRAGMA foreign_keys = ON;");
 
 /**
  * Adds columns to a table if they do not already exist.


### PR DESCRIPTION
## Summary

Adds built-in Cloudflare Tunnel management to SRouter. Tunnels run using a **Tunnel Token**, so there is no `cloudflared login`, no `cert.pem`, and no local `config.yml` — custom hostnames are mapped remotely in the Cloudflare Zero Trust dashboard (Public Hostname → service `http://localhost:3000`).

## New endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/v1/tunnel/status` | API key / admin | Running state, pid, uptime, configured domain, cloudflared availability |
| POST | `/v1/tunnel/start` | Admin | Start tunnel; body `{token?, domain?}` (both persisted when provided) |
| POST | `/v1/tunnel/stop` | Admin | Stop the running tunnel |
| PUT | `/v1/tunnel/config` | Admin | Update token/domain without starting |

## How it works

1. Create a tunnel in Cloudflare Zero Trust → copy the **Tunnel Token**.
2. `POST /v1/tunnel/start {"token": "eyJ...", "domain": "router.example.com"}`
3. In the Zero Trust dashboard, map your custom hostname to `http://localhost:PORT`.
4. Requests now flow through the tunnel with the standard SRouter auth rules.

## Implementation notes

- `cloudflareTunnel` service spawns `cloudflared tunnel run --token <token>` as a child process; binary resolved from PATH, common install paths, or `CLOUDFLARED_PATH` env.
- Token/domain stored in `system_settings` (`cloudflare_tunnel_token`, `cloudflare_tunnel_domain`); status endpoint never returns the raw token.
- Process exit/error captured and surfaced via status.

## Testing
- Build (`tsup`) succeeds; all 79 tests pass.