### PR TITLE
ci(docker): write digest to a file before uploading as artifact

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,11 +88,18 @@ jobs:
                   cache-from: type=gha,scope=${{ matrix.arch }}
                   cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
+            - name: Export image digest
+              env:
+                  DIGEST: ${{ steps.build.outputs.digest }}
+              # build-push-action outputs the digest as a string ("sha256:...");
+              # write it to a file first — upload-artifact takes paths, not values.
+              run: echo "$DIGEST" > "digest-${{ matrix.arch }}"
+
             - name: Upload image digest
               uses: actions/upload-artifact@v4
               with:
                   name: digest-${{ matrix.arch }}
-                  path: ${{ steps.build.outputs.digest }}
+                  path: digest-${{ matrix.arch }}
                   if-no-files-found: error
                   retention-days: 1
 


### PR DESCRIPTION
## Problem

Follow-up to #37 — after merging, both `Build (amd64)` and `Build (arm64)` jobs fail at **Upload image digest** (run [32622491013](https://github.com/seaavey/SRouter/actions/runs/32622491013)):

```
##[error]No files were found with the provided path: sha256:46a0be9f...
```

My bug in #37: `steps.build.outputs.digest` from `docker/build-push-action` is a **string value** (`sha256:...`), but I passed it to `actions/upload-artifact` as `path:`. The action looked for a file literally named `sha256:...`, found nothing, and `if-no-files-found: error` failed the job.

## Fix

Write the digest string to a real file first, upload the file:

```yaml
- name: Export image digest
  env:
      DIGEST: ${{ steps.build.outputs.digest }}
  run: echo "$DIGEST" > "digest-${{ matrix.arch }}"

- name: Upload image digest
  uses: actions/upload-artifact@v4
  with:
      name: digest-${{ matrix.arch }}
      path: digest-${{ matrix.arch }}
      ...
```

The merge job already globs `digest-*` and reads content via `cat`, so it needs no changes — with `merge-multiple: true`, a flat single-file artifact extracts to exactly `digest-<arch>` in the download path.

One-line `docker build` steps built and pushed images fine in the failed run (digests `sha256:46a0be9f` / `sha256:dbd8b6ef` are up), so only the artifact plumbing was broken.