### PR TITLE
ci(docker): fix merge job failure — quote labels, inspect real tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -172,6 +172,11 @@ jobs:
                 docker buildx imagetools create "${ARGS[@]}"
 
             - name: Inspect final manifest
+              env:
+                  TAGS: ${{ steps.meta.outputs.tags }}
               run: |
-                docker buildx imagetools inspect \
-                  "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}"
+                # Inspect the first tag metadata-action actually created.
+                # github.ref_name is not a valid image tag on branch refs
+                # (contains "/") and does not match semver tags on releases.
+                FIRST_TAG=$(echo "$TAGS" | head -n 1)
+                docker buildx imagetools inspect "$FIRST_TAG"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -154,17 +154,22 @@ jobs:
                   TAGS: ${{ steps.meta.outputs.tags }}
                   LABELS: ${{ steps.meta.outputs.labels }}
               run: |
-                # metadata-action emits newline-delimited "image:tag" entries;
-                # buildx imagetools create wants one "-t <ref>" flag per line.
-                TAG_REFS=$(echo "$TAGS" | sed 's/^/-t /')
-                # Append OCI labels as imagetools annotations.
-                ANNOTATIONS=$(echo "$LABELS" | sed 's/^/--annotation index:/')
-                # Every digest-* file holds one arch image digest.
-                SOURCES=$(for digest_file in digest-*; do
-                  echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@$(cat "$digest_file")"
-                done)
-                # shellcheck disable=SC2086 # word splitting is intentional here
-                docker buildx imagetools create $TAG_REFS $ANNOTATIONS $SOURCES
+                # metadata-action emits newline-delimited entries for both tags
+                # and labels. Build bash arrays so label values containing
+                # spaces (e.g. the repo description) stay quoted as a single
+                # argument — unquoted word splitting made buildx parse
+                # "High-performance" from the description as an image source.
+                ARGS=()
+                while IFS= read -r tag; do
+                  ARGS+=( -t "$tag" )
+                done <<< "$TAGS"
+                while IFS= read -r label; do
+                  ARGS+=( --annotation "index:${label}" )
+                done <<< "$LABELS"
+                for digest_file in digest-*; do
+                  ARGS+=( "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@$(cat "$digest_file")" )
+                done
+                docker buildx imagetools create "${ARGS[@]}"
 
             - name: Inspect final manifest
               run: |


### PR DESCRIPTION
## Problem

After #38 merged, run [32623024723](https://github.com/seaavey/SRouter/actions/runs/32623024723) still failed at **Merge & Tag Manifest** — two separate bugs:

**1. Unquoted word splitting on labels** (the failure):
```
ERROR: failed to parse source "High-performance", valid sources are digests,
references and descriptors: invalid reference format
```
`docker/metadata-action` emits labels including `org.opencontainers.image.description` = the repo description, which contains spaces (`SRouter - High-performance...`). The manifest step built args via unquoted string expansion, so word splitting turned `High-performance` into a bare token buildx tried to parse as an image source.

**2. Inspect step used `github.ref_name` as the tag** (latent):
Branch refs contain `/` — invalid in Docker tags — and release refs (`v0.1.2`) don't match the semver tags metadata-action creates (`0.1.2`). Inspect would always fail on branch builds and tag builds.

## Fix

- Build `imagetools create` args as a **bash array** — each tag, label, and digest ref becomes exactly one quoted argv entry regardless of spaces
- Inspect the **first tag from the metadata output** — the exact ref the manifest was just pushed to

## Verification

Tested end-to-end on my fork before opening this PR — run [32623400721](https://github.com/Sienz16/SRouter/actions/runs/32623400721): all four jobs green (Check Release Version, Build amd64, Build arm64, Merge & Tag Manifest), multi-arch manifest created and inspected. The same workflow file, same commit.