### PR TITLE
feat(auth): password-first setup, fix remote dashboard access, drop 12-char minimum

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,7 +25,7 @@ import { adminAuth } from "@/middleware/adminAuth.js";
 import { startTokenRefreshSweeper } from "@/services/tokenRefresh.js";
 import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry } from "@/services/registry.js";
-import { ensureDefaultAdminAccount } from "@/services/adminAuth.js";
+import { bootstrapAdminAccountFromEnv } from "@/services/adminAuth.js";
 import { autostartTunnelIfEnabled } from "@/services/cloudflareTunnel.js";
 import { adminAuthStore } from "@srouter/db";
 
@@ -67,8 +67,9 @@ app.use(
     })
 );
 
-// Ensure an admin account exists on first run (default password: 12345678).
-ensureDefaultAdminAccount(adminAuthStore);
+// Bootstrap the admin account only when SROUTER_ADMIN_PASSWORD is set.
+// Otherwise first-run setup happens through the dashboard.
+bootstrapAdminAccountFromEnv(adminAuthStore);
 
 // Re-launch the Cloudflare Tunnel if it was left running when the server last stopped.
 autostartTunnelIfEnabled();

--- a/apps/api/src/routes/v1/admin.ts
+++ b/apps/api/src/routes/v1/admin.ts
@@ -28,7 +28,6 @@ interface AdminRequestBody {
 export interface AdminRouteOptions {
     store?: AdminAuthStore;
     getClientAddress?: (c: Context) => string | undefined;
-    getSetupToken?: () => string | undefined;
     now?: () => number;
     secureCookies?: boolean;
 }
@@ -68,7 +67,6 @@ function clearAdminSessionCookie(c: Context, secure: boolean): void {
 export function createAdminRoute(options: AdminRouteOptions = {}): Hono {
     const store = options.store ?? adminAuthStore;
     const getClientAddress = options.getClientAddress ?? getDirectClientAddress;
-    const getSetupToken = options.getSetupToken ?? (() => process.env.SROUTER_SETUP_TOKEN);
     const now = options.now ?? (() => Date.now());
     const secureCookies = options.secureCookies ?? process.env.SROUTER_SECURE_COOKIES === "true";
     const failedLogins = new Map<string, { count: number; blockedUntil: number }>();
@@ -76,13 +74,9 @@ export function createAdminRoute(options: AdminRouteOptions = {}): Hono {
 
     route.get("/admin/status", (c) => {
         const authenticated = verifyAdminSession(store, getCookie(c, ADMIN_SESSION_COOKIE), now());
-        const address = getClientAddress(c);
-        const configuredSetupToken = getSetupToken();
         return ok(c, {
             setupRequired: !store.hasAdminAccount(),
-            authenticated,
-            setupTokenConfigured: Boolean(configuredSetupToken),
-            clientIsLoopback: isLoopbackAddress(address)
+            authenticated
         });
     });
 
@@ -110,21 +104,10 @@ export function createAdminRoute(options: AdminRouteOptions = {}): Hono {
             });
         }
 
-        const address = getClientAddress(c);
-        const configuredSetupToken = getSetupToken();
-        const hasValidSetupToken =
-            Boolean(configuredSetupToken) && body?.setupToken === configuredSetupToken;
-        if (!isLoopbackAddress(address) && !hasValidSetupToken) {
-            return err(
-                c,
-                "Initial admin setup is only available from localhost or with a setup token",
-                403,
-                {
-                    type: "authentication_error",
-                    code: "setup_not_allowed"
-                }
-            );
-        }
+        // First-come-wins: anyone who reaches the instance before setup completes
+        // can claim it. The window closes permanently once an account exists
+        // (the hasAdminAccount check above). Deployers should finish setup
+        // immediately after first boot.
 
         const created = store.createAdminAccount(hashAdminPassword(body.password as string), now());
         if (!created) {

--- a/apps/api/src/routes/v1/logs.ts
+++ b/apps/api/src/routes/v1/logs.ts
@@ -3,10 +3,9 @@ import { LogsController } from "@/controllers/logs.controller.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const logsRoute = new Hono();
-logsRoute.use("/*", apiKeyAuth);
 
 // GET /v1/logs - Get recent request logs
-logsRoute.get("/logs", LogsController.listLogs);
+logsRoute.get("/logs", apiKeyAuth, LogsController.listLogs);
 
 // GET /v1/logs/stats - Get token usage summary & request count
-logsRoute.get("/logs/stats", LogsController.getStats);
+logsRoute.get("/logs/stats", apiKeyAuth, LogsController.getStats);

--- a/apps/api/src/routes/v1/models.ts
+++ b/apps/api/src/routes/v1/models.ts
@@ -3,10 +3,11 @@ import { ModelsController } from "@/controllers/models.controller.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const modelsRoute = new Hono();
-modelsRoute.use("/*", apiKeyAuth);
 
-// GET /v1/models
-modelsRoute.get("/models", ModelsController.listModels);
+// GET /v1/models — apiKeyAuth applied per-route, not as a catch-all use("/*").
+// This route is also mounted at "/" for clients using a bare base URL, where
+// a catch-all would swallow the dashboard root and every unmatched path.
+modelsRoute.get("/models", apiKeyAuth, ModelsController.listModels);
 
 // GET /v1/models/:model (supports slashes in namespaced model IDs)
-modelsRoute.get("/models/:model{.+}", ModelsController.getModelById);
+modelsRoute.get("/models/:model{.+}", apiKeyAuth, ModelsController.getModelById);

--- a/apps/api/src/routes/v1/quota.ts
+++ b/apps/api/src/routes/v1/quota.ts
@@ -3,8 +3,7 @@ import { QuotaController } from "@/controllers/quota.controller.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const quotaRoute = new Hono();
-quotaRoute.use("/*", apiKeyAuth);
 
 // GET /v1/quota and /v1/qouta - Fetch key quota & usage stats
-quotaRoute.get("/quota", QuotaController.getQuota);
-quotaRoute.get("/qouta", QuotaController.getQuota);
+quotaRoute.get("/quota", apiKeyAuth, QuotaController.getQuota);
+quotaRoute.get("/qouta", apiKeyAuth, QuotaController.getQuota);

--- a/apps/api/src/services/adminAuth.ts
+++ b/apps/api/src/services/adminAuth.ts
@@ -16,9 +16,6 @@ export function validateAdminPassword(value: unknown): string | null {
     if (typeof value !== "string" || value.length === 0) {
         return "Password is required";
     }
-    if (value.length < 12) {
-        return "Password must be at least 12 characters";
-    }
     if (value.length > 128) {
         return "Password must be at most 128 characters";
     }

--- a/apps/api/src/services/adminAuth.ts
+++ b/apps/api/src/services/adminAuth.ts
@@ -4,12 +4,6 @@ import { adminAuthStore, type AdminAuthStore } from "@srouter/db";
 export const ADMIN_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 export const ADMIN_SESSION_COOKIE = "srouter_admin_session";
 
-/**
- * Default admin password used on first run when no account has been set up yet.
- * Override at any time with the SROUTER_ADMIN_PASSWORD environment variable.
- */
-export const DEFAULT_ADMIN_PASSWORD = "12345678";
-
 const PASSWORD_HASH_ALGORITHM = "scrypt";
 const PASSWORD_HASH_LENGTH = 64;
 const PASSWORD_SALT_LENGTH = 16;
@@ -116,21 +110,21 @@ export function isLoopbackAddress(address: string | undefined): boolean {
 }
 
 /**
- * Ensure the admin account uses the mandatory default password on every boot.
- * - The password is reset to `DEFAULT_ADMIN_PASSWORD` (12345678) unless
- *   `SROUTER_ADMIN_PASSWORD` is set, in which case that value is used instead.
- * - This guarantees the dashboard is always reachable with the known default and
- *   also recovers from a forgotten password.
+ * Bootstrap the admin account from the environment when requested.
+ * - `SROUTER_ADMIN_PASSWORD` set → creates the account if missing, or resets
+ *   the password on every boot (documented recovery path for a forgotten password).
+ * - Not set → no account is auto-created. First-run setup happens through the
+ *   dashboard ("create your admin password"), which is first-come-wins until
+ *   an account exists.
  */
-export function ensureDefaultAdminAccount(store: AdminAuthStore, now: number = Date.now()): void {
+export function bootstrapAdminAccountFromEnv(store: AdminAuthStore, now: number = Date.now()): void {
     const envPassword = process.env.SROUTER_ADMIN_PASSWORD;
-    const hasEnv = envPassword !== undefined && envPassword.length > 0;
-    const password = hasEnv ? envPassword : DEFAULT_ADMIN_PASSWORD;
-    const hash = hashAdminPassword(password);
+    if (envPassword === undefined || envPassword.length === 0) return;
 
+    const hash = hashAdminPassword(envPassword);
     if (!store.hasAdminAccount()) {
         store.createAdminAccount(hash, now);
-    } else if (hasEnv) {
+    } else {
         store.updatePasswordHash(hash, now);
     }
 }

--- a/apps/api/tests/admin-auth-route.test.ts
+++ b/apps/api/tests/admin-auth-route.test.ts
@@ -176,17 +176,17 @@ test("change-password validates current password and updates admin account", asy
     });
     assert.equal(wrongCurrent.status, 401);
 
-    // Short password
-    const shortPass = await app.request("/v1/admin/change-password", {
+    // Over-length password (> 128)
+    const tooLong = await app.request("/v1/admin/change-password", {
         method: "POST",
         headers: { "Content-Type": "application/json", Cookie: cookie },
         body: JSON.stringify({
             currentPassword: "correct horse battery staple",
-            newPassword: "short",
-            confirmation: "short"
+            newPassword: "a".repeat(129),
+            confirmation: "a".repeat(129)
         })
     });
-    assert.equal(shortPass.status, 400);
+    assert.equal(tooLong.status, 400);
 
     // Mismatched confirmation
     const mismatch = await app.request("/v1/admin/change-password", {

--- a/apps/api/tests/admin-auth-route.test.ts
+++ b/apps/api/tests/admin-auth-route.test.ts
@@ -6,7 +6,7 @@ import { AdminAuthStore } from "../../../packages/db/src/adminAuth.js";
 import { createAdminRoute } from "../src/routes/v1/admin.js";
 import { hashAdminPassword } from "../src/services/adminAuth.js";
 
-function createTestApp(options: { address?: string; setupToken?: string } = {}) {
+function createTestApp(options: { address?: string } = {}) {
     const store = new AdminAuthStore(new DatabaseSync(":memory:"));
     const app = new Hono();
     app.route(
@@ -14,7 +14,6 @@ function createTestApp(options: { address?: string; setupToken?: string } = {}) 
         createAdminRoute({
             store,
             getClientAddress: () => options.address,
-            getSetupToken: () => options.setupToken,
             secureCookies: false
         })
     );
@@ -34,29 +33,7 @@ test("admin status reports setup and authentication state", async () => {
     assert.equal(initial.status, 200);
     assert.deepEqual(await initial.json(), {
         setupRequired: true,
-        authenticated: false,
-        setupTokenConfigured: false,
-        clientIsLoopback: false
-    });
-});
-
-test("admin status reports loopback and setup token configuration", async () => {
-    const local = createTestApp({ address: "127.0.0.1" });
-    const localStatus = await local.app.request("/v1/admin/status");
-    assert.deepEqual(await localStatus.json(), {
-        setupRequired: true,
-        authenticated: false,
-        setupTokenConfigured: false,
-        clientIsLoopback: true
-    });
-
-    const remote = createTestApp({ address: "192.168.1.10", setupToken: "setup-secret" });
-    const remoteStatus = await remote.app.request("/v1/admin/status");
-    assert.deepEqual(await remoteStatus.json(), {
-        setupRequired: true,
-        authenticated: false,
-        setupTokenConfigured: true,
-        clientIsLoopback: false
+        authenticated: false
     });
 });
 
@@ -81,15 +58,14 @@ test("local setup creates an account and establishes a session", async () => {
     });
     assert.deepEqual(await status.json(), {
         setupRequired: false,
-        authenticated: true,
-        setupTokenConfigured: false,
-        clientIsLoopback: true
+        authenticated: true
     });
 });
 
-test("remote setup requires the configured one-time setup token", async () => {
-    const withoutToken = createTestApp({ address: "192.168.1.10", setupToken: "setup-secret" });
-    const rejected = await withoutToken.app.request("/v1/admin/setup", {
+test("remote setup is first-come-wins and closes after the first account", async () => {
+    const { app } = createTestApp({ address: "192.168.1.10" });
+
+    const first = await app.request("/v1/admin/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -97,26 +73,14 @@ test("remote setup requires the configured one-time setup token", async () => {
             confirmation: "correct horse battery staple"
         })
     });
-    assert.equal(rejected.status, 403);
+    assert.equal(first.status, 201);
 
-    const accepted = await withoutToken.app.request("/v1/admin/setup", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-            password: "correct horse battery staple",
-            confirmation: "correct horse battery staple",
-            setupToken: "setup-secret"
-        })
-    });
-    assert.equal(accepted.status, 201);
-
-    const second = await withoutToken.app.request("/v1/admin/setup", {
+    const second = await app.request("/v1/admin/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             password: "another correct password",
-            confirmation: "another correct password",
-            setupToken: "setup-secret"
+            confirmation: "another correct password"
         })
     });
     assert.equal(second.status, 409);
@@ -150,9 +114,7 @@ test("login and logout manage the admin session", async () => {
     const status = await app.request("/v1/admin/status", { headers: { Cookie: cookie } });
     assert.deepEqual(await status.json(), {
         setupRequired: false,
-        authenticated: false,
-        setupTokenConfigured: false,
-        clientIsLoopback: true
+        authenticated: false
     });
 });
 

--- a/apps/api/tests/admin-auth-service.test.ts
+++ b/apps/api/tests/admin-auth-service.test.ts
@@ -24,9 +24,9 @@ test("admin passwords use salted scrypt hashes", () => {
 });
 
 test("admin password validation enforces the setup policy", () => {
-    assert.equal(validateAdminPassword("short"), "Password must be at least 12 characters");
+    assert.equal(validateAdminPassword("short"), null);
     assert.equal(validateAdminPassword("a".repeat(129)), "Password must be at most 128 characters");
-    assert.equal(validateAdminPassword("a".repeat(12)), null);
+    assert.equal(validateAdminPassword("a".repeat(128)), null);
     assert.equal(validateAdminPassword(null), "Password is required");
 });
 

--- a/apps/web/src/components/auth/AdminAuthGate.tsx
+++ b/apps/web/src/components/auth/AdminAuthGate.tsx
@@ -68,7 +68,7 @@ function AdminAuthForm({ setupRequired, onAuthenticated }: AdminAuthFormProps) {
                                 value={password}
                                 onChange={(event) => setPassword(event.target.value)}
                                 placeholder={
-                                    setupRequired ? "At least 12 characters" : "Admin password"
+                                    setupRequired ? "Choose a password" : "Admin password"
                                 }
                                 required
                             />

--- a/apps/web/src/components/auth/AdminAuthGate.tsx
+++ b/apps/web/src/components/auth/AdminAuthGate.tsx
@@ -8,30 +8,18 @@ import { Input } from "@/components/ui/input";
 interface AdminStatus {
     setupRequired: boolean;
     authenticated: boolean;
-    setupTokenConfigured: boolean;
-    clientIsLoopback: boolean;
 }
 
 interface AdminAuthFormProps {
     setupRequired: boolean;
-    setupTokenConfigured: boolean;
-    clientIsLoopback: boolean;
     onAuthenticated: () => void;
 }
 
-function AdminAuthForm({
-    setupRequired,
-    setupTokenConfigured,
-    clientIsLoopback,
-    onAuthenticated
-}: AdminAuthFormProps) {
+function AdminAuthForm({ setupRequired, onAuthenticated }: AdminAuthFormProps) {
     const [password, setPassword] = useState("");
     const [confirmation, setConfirmation] = useState("");
-    const [setupToken, setSetupToken] = useState("");
     const [error, setError] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
-
-    const remoteSetupLocked = setupRequired && !clientIsLoopback && !setupTokenConfigured;
 
     async function handleSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -41,13 +29,10 @@ function AdminAuthForm({
         try {
             await api.post<{ authenticated: boolean }>(
                 setupRequired ? "/v1/admin/setup" : "/v1/admin/login",
-                setupRequired
-                    ? { password, confirmation, ...(setupToken ? { setupToken } : {}) }
-                    : { password }
+                setupRequired ? { password, confirmation } : { password }
             );
             setPassword("");
             setConfirmation("");
-            setSetupToken("");
             onAuthenticated();
         } catch (cause) {
             setError(cause instanceof ApiError ? cause.message : "Unable to authenticate");
@@ -103,41 +88,11 @@ function AdminAuthForm({
                                     />
                                 </label>
 
-                                {clientIsLoopback ? (
-                                    <p className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-[11px] font-normal text-emerald-600 dark:text-emerald-400">
-                                        You are on the server machine — no setup token needed.
-                                    </p>
-                                ) : remoteSetupLocked ? (
-                                    <p className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-[11px] font-normal text-destructive">
-                                        Remote setup is not enabled on this server. Ask your server
-                                        administrator to configure the{" "}
-                                        <code className="rounded bg-destructive/10 px-1 py-0.5 font-mono text-[10px]">
-                                            SROUTER_SETUP_TOKEN
-                                        </code>{" "}
-                                        environment variable, or open SRouter from the server
-                                        machine to finish setup.
-                                    </p>
-                                ) : (
-                                    <>
-                                        <label className="flex flex-col gap-1.5 text-xs font-medium">
-                                            Setup token
-                                            <Input
-                                                type="password"
-                                                autoComplete="off"
-                                                value={setupToken}
-                                                onChange={(event) =>
-                                                    setSetupToken(event.target.value)
-                                                }
-                                                placeholder="Provided by your server administrator"
-                                            />
-                                            <span className="text-[11px] font-normal text-muted-foreground">
-                                                This server requires a setup token for first-time
-                                                setup from outside the server machine. Ask your
-                                                server administrator for it.
-                                            </span>
-                                        </label>
-                                    </>
-                                )}
+                                <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] font-normal text-amber-600 dark:text-amber-400">
+                                    First-come-wins: anyone who opens this page before you finish
+                                    setup can claim the instance. Set your password right after
+                                    deploying.
+                                </p>
                             </>
                         ) : null}
 
@@ -206,8 +161,6 @@ export function AdminAuthGate({ children }: { children: ReactNode }) {
         return (
             <AdminAuthForm
                 setupRequired={statusQuery.data.setupRequired}
-                setupTokenConfigured={statusQuery.data.setupTokenConfigured}
-                clientIsLoopback={statusQuery.data.clientIsLoopback}
                 onAuthenticated={() => void statusQuery.refetch()}
             />
         );

--- a/apps/web/src/components/settings/SecuritySettings.tsx
+++ b/apps/web/src/components/settings/SecuritySettings.tsx
@@ -113,11 +113,6 @@ print(response.choices[0].message.content)`;
             return;
         }
 
-        if (newPassword.length < 12) {
-            setPasswordError("New password must be at least 12 characters long.");
-            return;
-        }
-
         if (newPassword !== confirmation) {
             setPasswordError("New password and confirmation do not match.");
             return;
@@ -304,7 +299,7 @@ print(response.choices[0].message.content)`;
                             </label>
                             <Input
                                 type="password"
-                                placeholder="Min. 12 characters"
+                                placeholder="New password"
                                 value={newPassword}
                                 onChange={(e) => setNewPassword(e.target.value)}
                                 required


### PR DESCRIPTION
## Summary

Three related changes for the first-run experience on remote deployments:

### 1. Password-first setup (no default account, no setup token)

New deployment flow: open the dashboard in a browser → **"Create your admin password"** → set it → session cookie → done. No default `12345678` account, no `SROUTER_SETUP_TOKEN`, no SSH.

- `ensureDefaultAdminAccount` (auto-creating `12345678` every boot) is replaced by `bootstrapAdminAccountFromEnv`, which only acts when `SROUTER_ADMIN_PASSWORD` is set — kept as the documented recovery path
- First-come-wins: once an account exists, further setup attempts get 409. The setup form shows a warning about this
- `/v1/admin/status` drops `setupTokenConfigured` / `clientIsLoopback` (no longer meaningful)
- Machine-client auth via `sr-live-*` API keys unchanged

**Security tradeoff (intentional):** removing the setup token means whoever reaches a fresh deployment first can claim the admin account. Mitigations: login rate-limiting stays, window closes after first setup, and `SROUTER_ADMIN_PASSWORD` can be set upfront.

### 2. Fix: catch-all `apiKeyAuth` blocked the dashboard and admin routes remotely

`modelsRoute`, `logsRoute`, and `quotaRoute` registered `apiKeyAuth` via `use("/*")`. Since `modelsRoute` is mounted at both `/v1` and `/`, the catch-all intercepted **every unmatched path on both mounts** — including `GET /` (dashboard shell) and `/v1/admin/*` (login, setup, status) — before static serving or the admin route ran. Remote browsers got `missing_api_key` on first load and could never reach the login screen. Loopback testing masked it (key wall opens for localhost).

Fix: apply `apiKeyAuth` per-route in the three routes. Endpoint auth identical; accidental interception gone.

### 3. Drop the 12-character password minimum

Users choose their own password length. A 128-char max remains as a storage bound. Removed from the API validator, the setup form hint, and the change-password form.

## Verification

- Full API suite: 80/80 pass; web build green
- Non-loopback client (LAN IP) against a fresh server:
  - `GET /` → 200 dashboard HTML
  - `GET /v1/admin/status` → 200 `{"setupRequired":true,"authenticated":false}`
  - `GET /v1/models` → 401 without key (machine API unchanged)
- Setup flow: 201 + session cookie; second setup → 409; wrong password rejected; `SROUTER_ADMIN_PASSWORD` env bootstrap works
- Short passwords (`short`) now accepted; 129-char rejected

**Breaking change** for deployments relying on the default password: log in once with `SROUTER_ADMIN_PASSWORD` or wipe the admin row to re-trigger setup.