### PR TITLE
feat(providers): add CodeBuddy CN provider with OAuth device flow and live quota

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -6,6 +6,7 @@ import {
     bluesMindsAuthHandler,
     claudeAuthHandler,
     codeBuddyAuthHandler,
+    codeBuddyCNAuthHandler,
     commandCodeAuthHandler,
     goRouterAuthHandler,
     openaiCodexAuthHandler,
@@ -368,6 +369,45 @@ export class AuthController {
         return importTokenFor(
             codeBuddyAuthHandler,
             (b) => AuthLogic.processProviderTokenImport("codebuddy", b),
+            c
+        );
+    }
+
+    // CodeBuddy CN Provider (OAuth & Access Token)
+    public static async loginCodeBuddyCN(c: Context): Promise<Response> {
+        try {
+            const result = await AuthLogic.initiateCodeBuddyCNOAuth();
+            if (c.req.query("format") === "json") {
+                return ok(c, { authorizeUrl: result.authorizeUrl, state: result.state });
+            }
+            return c.redirect(result.authorizeUrl);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Internal Server Error";
+            return err(c, `Failed to initiate CodeBuddy CN login: ${message}`, 500, {
+                type: "api_error"
+            });
+        }
+    }
+
+    public static async pollCodeBuddyCN(c: Context): Promise<Response> {
+        let state = c.req.query("state");
+        if (!state) {
+            try {
+                const body = await c.req.json<{ state?: string }>();
+                state = body?.state;
+            } catch {}
+        }
+        if (!state) {
+            return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
+        }
+
+        return ok(c, await AuthLogic.pollCodeBuddyCNDeviceToken(state));
+    }
+
+    public static async importCodeBuddyCNToken(c: Context): Promise<Response> {
+        return importTokenFor(
+            codeBuddyCNAuthHandler,
+            (b) => AuthLogic.processProviderTokenImport("codebuddy-cn", b),
             c
         );
     }

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -1,4 +1,9 @@
-import { CODEBUDDY_BASE_URL } from "@srouter/constants";
+import {
+    CODEBUDDY_BASE_URL,
+    CODEBUDDY_CN_BASE_URL,
+    CODEBUDDY_CN_DOMAIN,
+    CODEBUDDY_CN_USER_AGENT
+} from "@srouter/constants";
 import {
     cleanupExpiredOAuthSessionsDB,
     deleteOAuthSessionDB,
@@ -6,7 +11,7 @@ import {
     saveOAuthSessionDB,
     upsertProviderDB
 } from "@srouter/db";
-import { CodeBuddyOAuth, generatePKCE, QoderOAuth } from "@srouter/providers";
+import { CodeBuddyCNOAuth, CodeBuddyOAuth, generatePKCE, QoderOAuth } from "@srouter/providers";
 import { CodeBuddyExecutor, QoderExecutor } from "@srouter/executors";
 import type { ProviderConfig } from "@srouter/types";
 import { registry } from "@/services/registry.js";
@@ -16,6 +21,7 @@ import {
     bluesMindsAuthHandler,
     claudeAuthHandler,
     codeBuddyAuthHandler,
+    codeBuddyCNAuthHandler,
     commandCodeAuthHandler,
     goRouterAuthHandler,
     openaiCodexAuthHandler,
@@ -204,8 +210,17 @@ function processTokenImportFor(
 // --- Device-flow providers (CodeBuddy, Qoder): bespoke flows kept explicit ---
 
 export async function initiateCodeBuddyOAuth(): Promise<{ authorizeUrl: string; state: string }> {
+    return initiateCodeBuddyOAuthFor(new CodeBuddyOAuth());
+}
+
+export async function initiateCodeBuddyCNOAuth(): Promise<{ authorizeUrl: string; state: string }> {
+    return initiateCodeBuddyOAuthFor(new CodeBuddyCNOAuth());
+}
+
+async function initiateCodeBuddyOAuthFor(
+    codeBuddyOAuth: CodeBuddyOAuth
+): Promise<{ authorizeUrl: string; state: string }> {
     cleanupExpiredSessions();
-    const codeBuddyOAuth = new CodeBuddyOAuth();
     const { state, authUrl } = await codeBuddyOAuth.requestAuthState();
 
     saveOAuthSessionDB({
@@ -227,6 +242,36 @@ export async function pollCodeBuddyDeviceToken(state: string): Promise<{
     provider?: ProviderConfig;
     error?: string;
 }> {
+    return pollCodeBuddyDeviceTokenFor(state, {
+        oauth: new CodeBuddyOAuth(),
+        providerId: "codebuddy",
+        displayName: "CodeBuddy",
+        baseUrl: CODEBUDDY_BASE_URL
+    });
+}
+
+export async function pollCodeBuddyCNDeviceToken(state: string): Promise<{
+    status: "pending" | "ok";
+    provider?: ProviderConfig;
+    error?: string;
+}> {
+    return pollCodeBuddyDeviceTokenFor(state, {
+        oauth: new CodeBuddyCNOAuth(),
+        providerId: "codebuddy-cn",
+        displayName: "CodeBuddy CN",
+        baseUrl: CODEBUDDY_CN_BASE_URL
+    });
+}
+
+async function pollCodeBuddyDeviceTokenFor(
+    state: string,
+    options: {
+        oauth: CodeBuddyOAuth;
+        providerId: "codebuddy" | "codebuddy-cn";
+        displayName: string;
+        baseUrl: string;
+    }
+): Promise<{ status: "pending" | "ok"; provider?: ProviderConfig; error?: string }> {
     if (!state) {
         return { status: "pending", error: "Missing state parameter" };
     }
@@ -236,7 +281,6 @@ export async function pollCodeBuddyDeviceToken(state: string): Promise<{
         return { status: "pending", error: "Session expired or not found" };
     }
 
-    const codeBuddyOAuth = new CodeBuddyOAuth();
     let poll: {
         status: "pending" | "ok";
         accessToken?: string;
@@ -246,7 +290,7 @@ export async function pollCodeBuddyDeviceToken(state: string): Promise<{
     };
 
     try {
-        poll = await codeBuddyOAuth.pollToken(state);
+        poll = await options.oauth.pollToken(state);
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         return { status: "pending", error: msg };
@@ -259,16 +303,16 @@ export async function pollCodeBuddyDeviceToken(state: string): Promise<{
     deleteOAuthSessionDB(state);
 
     const timestamp = Date.now();
-    const accountId = `codebuddy_${timestamp}`;
-    const accountName = `CodeBuddy (Account #${timestamp.toString().slice(-4)})`;
+    const accountId = `${options.providerId}_${timestamp}`;
+    const accountName = `${options.displayName} (Account #${timestamp.toString().slice(-4)})`;
 
     const providerConfig = upsertProviderDB({
         id: accountId,
-        providerId: "codebuddy",
+        providerId: options.providerId,
         name: accountName,
         category: "oauth",
         protocol: "openai",
-        baseUrl: CODEBUDDY_BASE_URL,
+        baseUrl: options.baseUrl,
         accessToken: poll.accessToken,
         refreshToken: poll.refreshToken,
         tokenExpiresAt: poll.expiresIn ? timestamp + poll.expiresIn * 1000 : undefined,
@@ -280,8 +324,16 @@ export async function pollCodeBuddyDeviceToken(state: string): Promise<{
     const providerInstance = new CodeBuddyExecutor({
         id: accountId,
         name: accountName,
-        baseUrl: CODEBUDDY_BASE_URL,
-        accessToken: poll.accessToken
+        baseUrl: options.baseUrl,
+        accessToken: poll.accessToken,
+        modelPrefix: options.providerId,
+        ...(options.providerId === "codebuddy-cn"
+            ? {
+                  domain: CODEBUDDY_CN_DOMAIN,
+                  userAgent: CODEBUDDY_CN_USER_AGENT,
+                  flavor: "cli" as const
+              }
+            : {})
     });
     registry.registerProvider(providerInstance);
 
@@ -419,6 +471,9 @@ registerEntry("qoder", {
 registerEntry("codebuddy", {
     importToken: (params) => processTokenImportFor(codeBuddyAuthHandler, params)
 });
+registerEntry("codebuddy-cn", {
+    importToken: (params) => processTokenImportFor(codeBuddyCNAuthHandler, params)
+});
 for (const [key, handler] of [
     ["commandcode", commandCodeAuthHandler],
     ["anthropic", anthropicAuthHandler],
@@ -468,7 +523,9 @@ export const AuthLogic = {
     },
 
     initiateCodeBuddyOAuth,
+    initiateCodeBuddyCNOAuth,
     pollCodeBuddyDeviceToken,
+    pollCodeBuddyCNDeviceToken,
     pollQoderDeviceToken
 };
 

--- a/apps/api/src/logic/auth.providers.ts
+++ b/apps/api/src/logic/auth.providers.ts
@@ -5,6 +5,9 @@ import {
     ANTHROPIC_BASE_URL,
     BLUESMINDS_BASE_URL,
     CODEBUDDY_BASE_URL,
+    CODEBUDDY_CN_BASE_URL,
+    CODEBUDDY_CN_DOMAIN,
+    CODEBUDDY_CN_USER_AGENT,
     CODEX_OAUTH_CLIENT_ID,
     CODEX_OAUTH_REDIRECT_URI,
     COMMANDCODE_BASE_URL,
@@ -29,6 +32,7 @@ import {
 import {
     AntigravityOAuth,
     ClaudeOAuth,
+    CodeBuddyCNOAuth,
     CodeBuddyOAuth,
     OpenAICodexOAuth,
     QoderOAuth
@@ -402,6 +406,32 @@ export const codeBuddyAuthHandler: AuthProviderHandler = {
         })
 };
 
+export const codeBuddyCNAuthHandler: AuthProviderHandler = {
+    providerId: "codebuddy-cn",
+    displayName: "CodeBuddy CN",
+    category: "oauth",
+    protocol: "openai",
+    idPrefix: "codebuddy-cn",
+    baseUrl: () => CODEBUDDY_CN_BASE_URL,
+    oauthSuccessMessage: "Login CodeBuddy CN Berhasil!",
+    tokenImportMessage:
+        "CodeBuddy CN Access Token registered and saved directly to SQLite database!",
+    oauthClass: CodeBuddyCNOAuth,
+    mapOAuthTokens: codeBuddyAuthHandler.mapOAuthTokens,
+    mapImportTokens: codeBuddyAuthHandler.mapImportTokens,
+    buildExecutor: ({ id, name, baseUrl, accessToken, apiKey }) =>
+        new CodeBuddyExecutor({
+            id,
+            name,
+            baseUrl: baseUrl || CODEBUDDY_CN_BASE_URL,
+            accessToken: accessToken || apiKey,
+            modelPrefix: "codebuddy-cn",
+            domain: CODEBUDDY_CN_DOMAIN,
+            userAgent: CODEBUDDY_CN_USER_AGENT,
+            flavor: "cli"
+        })
+};
+
 export const authProviderHandlers: Record<string, AuthProviderHandler> = {
     openai_codex: openaiCodexAuthHandler,
     antigravity: antigravityAuthHandler,
@@ -414,5 +444,6 @@ export const authProviderHandlers: Record<string, AuthProviderHandler> = {
     seekai: seekAIAuthHandler,
     tabitoken: tabiTokenAuthHandler,
     tokenrouter: tokenRouterAuthHandler,
-    codebuddy: codeBuddyAuthHandler
+    codebuddy: codeBuddyAuthHandler,
+    "codebuddy-cn": codeBuddyCNAuthHandler
 };

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -54,8 +54,12 @@ function isProviderProtocol(value: string): value is ProviderProtocol {
  * connections collapse under one driver (e.g. openai_codex_1700000000 →
  * openai_codex). Custom ids that match no known driver keep their full id.
  */
+const PROVIDER_IDS_BY_LENGTH = Object.keys(DEFAULT_PROVIDER_MAP).sort(
+    (left, right) => right.length - left.length
+);
+
 function baseIdOf(providerId: string): string {
-    for (const id of Object.keys(DEFAULT_PROVIDER_MAP)) {
+    for (const id of PROVIDER_IDS_BY_LENGTH) {
         if (
             providerId === id ||
             providerId.startsWith(`${id}_`) ||
@@ -367,7 +371,8 @@ export class ProvidersLogic {
                 if (isInternalHost) {
                     return {
                         success: false,
-                        message: "Target URL tidak diizinkan untuk verifikasi (endpoint internal/metadata diblokir)."
+                        message:
+                            "Target URL tidak diizinkan untuk verifikasi (endpoint internal/metadata diblokir)."
                     };
                 }
             } catch {

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -94,6 +94,13 @@ authRoute.post("/auth/codebuddy/poll", adminAuth, AuthController.pollCodeBuddy);
 authRoute.post("/auth/codebuddy/token", adminAuth, AuthController.importCodeBuddyToken);
 authRoute.post("/auth/codebuddy/import-token", adminAuth, AuthController.importCodeBuddyToken);
 
+// --- CodeBuddy CN Provider (OAuth & Access Token) ---
+authRoute.get("/auth/codebuddy-cn/login", adminAuth, AuthController.loginCodeBuddyCN);
+authRoute.get("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
+authRoute.post("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
+authRoute.post("/auth/codebuddy-cn/token", adminAuth, AuthController.importCodeBuddyCNToken);
+authRoute.post("/auth/codebuddy-cn/import-token", adminAuth, AuthController.importCodeBuddyCNToken);
+
 // --- Qoder Provider (OAuth & PAT) ---
 // 1. GET /v1/auth/qoder/login - Initiate Qoder OAuth PKCE Login Flow
 authRoute.get("/auth/qoder/login", adminAuth, AuthController.loginQoder);

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -1,6 +1,9 @@
 import {
     BLUESMINDS_BASE_URL,
     CODEBUDDY_BASE_URL,
+    CODEBUDDY_CN_BASE_URL,
+    CODEBUDDY_CN_DOMAIN,
+    CODEBUDDY_CN_USER_AGENT,
     DEFAULT_PROVIDERS,
     GOROUTER_BASE_URL,
     isProviderBaseId,
@@ -116,9 +119,21 @@ export function loadSavedProvidersFromDB(): void {
                     new CodeBuddyExecutor({
                         id: p.id || p.providerId,
                         name: p.name,
-                        baseUrl: baseUrl || CODEBUDDY_BASE_URL,
+                        baseUrl:
+                            baseUrl ||
+                            (providerType === "codebuddy-cn"
+                                ? CODEBUDDY_CN_BASE_URL
+                                : CODEBUDDY_BASE_URL),
                         apiKey: p.apiKey,
-                        accessToken: p.accessToken
+                        accessToken: p.accessToken,
+                        modelPrefix: providerType === "codebuddy-cn" ? "codebuddy-cn" : "codebuddy",
+                        ...(providerType === "codebuddy-cn"
+                            ? {
+                                  domain: CODEBUDDY_CN_DOMAIN,
+                                  userAgent: CODEBUDDY_CN_USER_AGENT,
+                                  flavor: "cli" as const
+                              }
+                            : {})
                     })
                 );
                 break;

--- a/apps/api/tests/codebuddy-provider.test.ts
+++ b/apps/api/tests/codebuddy-provider.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
-import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
+import { deleteProviderDB, fetchCodeBuddyCNLiveQuota, saveOAuthSessionDB, upsertProviderDB } from "@srouter/db";
+import { CODEBUDDY_CN_BASE_URL, providerById } from "@srouter/constants";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { codeBuddyAuthHandler } from "../src/logic/auth.providers.js";
+import { codeBuddyAuthHandler, codeBuddyCNAuthHandler } from "../src/logic/auth.providers.js";
+import { CodeBuddyCNOAuth } from "@srouter/providers";
+import { ProvidersLogic } from "../src/logic/providers.logic.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;
@@ -63,6 +66,115 @@ test("processCodeBuddyTokenImport creates and registers CodeBuddy provider confi
     );
 });
 
+test("CodeBuddy CN is registered as a connectable OAuth provider", () => {
+    const provider = providerById("codebuddy-cn");
+
+    assert.ok(provider);
+    assert.equal(provider.name, "CodeBuddy CN");
+    assert.equal(provider.baseUrl, CODEBUDDY_CN_BASE_URL);
+    assert.equal(provider.websiteUrl, "https://www.codebuddy.cn");
+    assert.equal(provider.requiresOAuth, true);
+});
+
+test("CodeBuddy CN token import creates a CN provider connection", () => {
+    const config = AuthLogic.processProviderTokenImport("codebuddy-cn", {
+        accessToken: "test-codebuddy-cn-token",
+        name: "My CodeBuddy CN Account"
+    });
+
+    createdIds.push(config.id);
+
+    assert.match(config.id, /^codebuddy-cn_\d+$/);
+    assert.equal(config.providerId, "codebuddy-cn");
+    assert.equal(config.name, "My CodeBuddy CN Account");
+    assert.equal(config.baseUrl, CODEBUDDY_CN_BASE_URL);
+    assert.equal(config.accessToken, "test-codebuddy-cn-token");
+    assert.equal(
+        codeBuddyCNAuthHandler.tokenImportMessage,
+        "CodeBuddy CN Access Token registered and saved directly to SQLite database!"
+    );
+});
+
+test("CodeBuddy CN connections stay grouped under the CN catalog entry", () => {
+    const before = ProvidersLogic.listProviders();
+    const cnBefore =
+        before.find((provider) => provider.id === "codebuddy-cn")?.status.connectedCount ?? 0;
+    const globalBefore =
+        before.find((provider) => provider.id === "codebuddy")?.status.connectedCount ?? 0;
+
+    const config = AuthLogic.processProviderTokenImport("codebuddy-cn", {
+        accessToken: "test-codebuddy-cn-catalog-token"
+    });
+    createdIds.push(config.id);
+
+    const catalog = ProvidersLogic.listProviders();
+    const global = catalog.find((provider) => provider.id === "codebuddy");
+    const cn = catalog.find((provider) => provider.id === "codebuddy-cn");
+
+    assert.equal(cn?.status.connectedCount, cnBefore + 1);
+    assert.equal(global?.status.connectedCount, globalBefore);
+});
+
+test("initiateCodeBuddyCNOAuth uses Tencent's CN auth endpoint", async () => {
+    let requestedUrl = "";
+    let requestedOrigin = "";
+    let requestedUserAgent = "";
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestedUrl = String(input);
+        requestedOrigin = new Headers(init?.headers).get("origin") ?? "";
+        requestedUserAgent = new Headers(init?.headers).get("user-agent") ?? "";
+        return new Response(
+            JSON.stringify({
+                code: 0,
+                msg: "ok",
+                data: {
+                    state: "test-codebuddy-cn-state",
+                    authUrl: "https://copilot.tencent.com/login?state=test-codebuddy-cn-state"
+                }
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+    };
+
+    const result = await AuthLogic.initiateCodeBuddyCNOAuth();
+
+    assert.equal(
+        requestedUrl,
+        "https://copilot.tencent.com/v2/plugin/auth/state?platform=CLI&ioa=1"
+    );
+    assert.equal(requestedOrigin, "https://www.codebuddy.cn");
+    assert.equal(requestedUserAgent, "CLI/2.96.0 CodeBuddy/2.96.0");
+    assert.equal(result.state, "test-codebuddy-cn-state");
+});
+
+test("CodeBuddy CN refresh authenticates with the refresh token as bearer", async () => {
+    let authorization = "";
+    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        authorization = new Headers(init?.headers).get("authorization") ?? "";
+        return new Response(
+            JSON.stringify({
+                code: 0,
+                data: { accessToken: "new-cn-token", refreshToken: "new-cn-refresh" }
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+    };
+
+    const result = await new CodeBuddyCNOAuth().refreshTokens("old-cn-refresh");
+
+    assert.equal(authorization, "Bearer old-cn-refresh");
+    assert.equal(result.accessToken, "new-cn-token");
+});
+
+test("CodeBuddy CN refresh failure rejects instead of replacing the access token", async () => {
+    globalThis.fetch = async () => new Response("Unauthorized", { status: 401 });
+
+    await assert.rejects(
+        () => new CodeBuddyCNOAuth().refreshTokens("old-cn-refresh"),
+        /CodeBuddy token refresh failed/
+    );
+});
+
 test("initiateCodeBuddyOAuth requests state and creates session", async () => {
     globalThis.fetch = async (input: RequestInfo | URL) => {
         const url = String(input);
@@ -112,7 +224,6 @@ test("pollCodeBuddyDeviceToken polls upstream and creates provider when user aut
     };
 
     const state = "cb-test-state-auth";
-    const { saveOAuthSessionDB } = await import("@srouter/db");
     saveOAuthSessionDB({
         state,
         codeVerifier: "",
@@ -130,4 +241,112 @@ test("pollCodeBuddyDeviceToken polls upstream and creates provider when user aut
     assert.equal(result.provider.category, "oauth");
     assert.equal(result.provider.accessToken, "cb-access-token-xyz");
     assert.equal(result.provider.refreshToken, "cb-refresh-token-xyz");
+});
+
+test("pollCodeBuddyCNDeviceToken creates a CN connection after browser authorization", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+        requestedUrl = String(input);
+        return new Response(
+            JSON.stringify({
+                code: 0,
+                data: {
+                    accessToken: "cb-cn-access-token",
+                    refreshToken: "cb-cn-refresh-token",
+                    expiresIn: 86400
+                }
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+    };
+
+    const state = "cb-cn-test-state-auth";
+    saveOAuthSessionDB({
+        state,
+        codeVerifier: "",
+        clientId: "",
+        redirectUri: "",
+        createdAt: Date.now()
+    });
+
+    const result = await AuthLogic.pollCodeBuddyCNDeviceToken(state);
+    assert.equal(requestedUrl, `https://copilot.tencent.com/v2/plugin/auth/token?state=${state}`);
+    assert.equal(result.status, "ok");
+    assert.equal(result.provider?.providerId, "codebuddy-cn");
+    assert.equal(result.provider?.baseUrl, CODEBUDDY_CN_BASE_URL);
+    if (result.provider) createdIds.push(result.provider.id);
+});
+test("CodeBuddy CN live quota splits refill and bonus packs", async () => {
+    const now = Date.now();
+    const iso = (ms: number) => new Date(ms).toISOString();
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response(
+            JSON.stringify({
+                code: 0,
+                data: {
+                    Response: {
+                        Data: {
+                            Accounts: [
+                                {
+                                    PackageName: "基础体验包",
+                                    CycleStartTime: iso(now - 10 * 86400000),
+                                    CycleEndTime: iso(now + 20 * 86400000),
+                                    DeductionEndTime: now + 300 * 86400000,
+                                    CycleCapacityUsedPrecise: "6.54",
+                                    CycleCapacitySizePrecise: "500"
+                                },
+                                {
+                                    PackageName: "活动赠送包",
+                                    CycleStartTime: iso(now - 5 * 86400000),
+                                    CycleEndTime: iso(now + 5 * 86400000),
+                                    DeductionEndTime: now + 5 * 86400000,
+                                    CapacityUsed: 25,
+                                    CapacitySize: 100
+                                }
+                            ]
+                        }
+                    }
+                }
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+    };
+
+    const account = await fetchCodeBuddyCNLiveQuota(
+        "codebuddy-cn_1",
+        "CN Account",
+        "cn-token"
+    );
+
+    assert.equal(capturedHeaders?.get("authorization"), "Bearer cn-token");
+    assert.equal(capturedHeaders?.get("x-ide-type"), "CLI");
+    assert.equal(account.quotaType, "live_provider_quota");
+    assert.match(account.provider, /基础体验包/);
+    assert.equal(account.quotas?.length, 2);
+
+    const monthly = account.quotas?.[0];
+    assert.equal(monthly?.name, "Monthly");
+    assert.equal(monthly?.used, 6.54);
+    assert.equal(monthly?.limit, 500);
+    assert.match(monthly?.resetIn ?? "", /^\d+d \d+h$/);
+
+    const bonus = account.quotas?.[1];
+    assert.equal(bonus?.name, "Bonus Pack 1");
+    assert.equal(bonus?.used, 25);
+    assert.equal(bonus?.limit, 100);
+});
+
+test("CodeBuddy CN live quota rejects on upstream error code", async () => {
+    globalThis.fetch = async () =>
+        new Response(JSON.stringify({ code: 11140, msg: "request illegal" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+        });
+
+    await assert.rejects(
+        () => fetchCodeBuddyCNLiveQuota("codebuddy-cn_1", "CN Account", "bad-token"),
+        /CodeBuddy CN quota error: request illegal/
+    );
 });

--- a/apps/web/src/components/ui/ConnectOAuthModal.tsx
+++ b/apps/web/src/components/ui/ConnectOAuthModal.tsx
@@ -31,6 +31,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
     const popupRef = useRef<Window | null>(null);
 
     const baseId = provider?.id.split("_")[0]?.split("-")[0] ?? provider?.id ?? "";
+    const authProviderId = provider?.id === "codebuddy-cn" ? "codebuddy-cn" : baseId;
     const isQoder = baseId === "qoder";
     const isCodeBuddy = baseId === "codebuddy";
     const isPolling = isQoder || isCodeBuddy;
@@ -58,7 +59,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 : baseId === "qoder"
                   ? "/v1/auth/qoder/login?format=json"
                   : baseId === "codebuddy"
-                    ? "/v1/auth/codebuddy/login?format=json"
+                    ? `/v1/auth/${authProviderId}/login?format=json`
                     : baseId === "claude" || baseId === "anthropic"
                       ? "/v1/auth/claude/login?format=json"
                       : "/v1/auth/openai/login?format=json";
@@ -73,7 +74,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 setIsLoadingUrl(false);
                 setError(err.message || "Failed to initiate OAuth login session");
             });
-    }, [open, provider, baseId]);
+    }, [open, provider, baseId, authProviderId]);
 
     const handleOpenPopup = () => {
         if (!authUrl) return;
@@ -123,7 +124,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
             try {
                 const pollUrl =
                     baseId === "codebuddy"
-                        ? `/v1/auth/codebuddy/poll?state=${encodeURIComponent(oauthState)}`
+                        ? `/v1/auth/${authProviderId}/poll?state=${encodeURIComponent(oauthState)}`
                         : `/v1/auth/qoder/poll?state=${encodeURIComponent(oauthState)}`;
                 const res = await api.get<{ status: string; provider?: ProviderConfig }>(pollUrl);
                 if (res && res.status === "ok") {
@@ -142,7 +143,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
         }, 2000);
 
         return () => clearInterval(interval);
-    }, [open, provider, isPolling, baseId, oauthState, queryClient, onOpenChange]);
+    }, [open, provider, isPolling, baseId, authProviderId, oauthState, queryClient, onOpenChange]);
 
     const callbackMutation = useMutation({
         mutationFn: (payload: { callbackUrl: string }) => {
@@ -174,7 +175,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
 
     const patMutation = useMutation({
         mutationFn: (payload: { accessToken: string }) => {
-            const endpoint = `/v1/auth/${baseId}/token`;
+            const endpoint = `/v1/auth/${authProviderId}/token`;
             return api.post(endpoint, payload);
         },
         onSuccess: () => {

--- a/packages/constants/src/providers.ts
+++ b/packages/constants/src/providers.ts
@@ -21,6 +21,15 @@ export const CODEBUDDY_AUTH_BASE = "https://www.codebuddy.ai";
 export const CODEBUDDY_AUTH_STATE_URL = "https://www.codebuddy.ai/v2/plugin/auth/state";
 export const CODEBUDDY_AUTH_TOKEN_URL = "https://www.codebuddy.ai/v2/plugin/auth/token";
 export const CODEBUDDY_AUTH_REFRESH_URL = "https://www.codebuddy.ai/v2/plugin/auth/token/refresh";
+export const CODEBUDDY_CN_BASE_URL = "https://copilot.tencent.com/v2/chat/completions";
+export const CODEBUDDY_CN_AUTH_BASE = "https://copilot.tencent.com";
+export const CODEBUDDY_CN_AUTH_STATE_URL = "https://copilot.tencent.com/v2/plugin/auth/state";
+export const CODEBUDDY_CN_AUTH_TOKEN_URL = "https://copilot.tencent.com/v2/plugin/auth/token";
+export const CODEBUDDY_CN_AUTH_REFRESH_URL =
+    "https://copilot.tencent.com/v2/plugin/auth/token/refresh";
+export const CODEBUDDY_CN_ORIGIN = "https://www.codebuddy.cn";
+export const CODEBUDDY_CN_DOMAIN = "www.codebuddy.cn";
+export const CODEBUDDY_CN_USER_AGENT = "CLI/2.96.0 CodeBuddy/2.96.0";
 export const CODEBUDDY_AUTH_USER_AGENT = "IDE/2.63.2 CodeBuddy/2.63.2";
 export const CODEBUDDY_AUTH_PLATFORM = "ide";
 
@@ -65,6 +74,7 @@ export const CODEBUDDY_MODELS: CodeBuddyModelDefinition[] = [
     { id: "deepseek-v3-2-volc", name: "DeepSeek-V3.2" },
     { id: "deepseek-v4-pro", name: "DeepSeek-V4-Pro" },
     { id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash" },
+    { id: "glm-5.3", name: "GLM-5.3" },
     { id: "glm-5.2", name: "GLM-5.2" },
     { id: "glm-5.1", name: "GLM-5.1" },
     { id: "glm-5.0", name: "GLM-5.0" },
@@ -73,6 +83,7 @@ export const CODEBUDDY_MODELS: CodeBuddyModelDefinition[] = [
     { id: "glm-4.7", name: "GLM-4.7" },
     { id: "minimax-m3", name: "MiniMax-M3" },
     { id: "minimax-m2.7", name: "MiniMax-M2.7" },
+    { id: "kimi-k3", name: "Kimi-K3" },
     { id: "kimi-k2.7", name: "Kimi-K2.7-Code" },
     { id: "kimi-k2.6", name: "Kimi-K2.6" },
     { id: "kimi-k2.5", name: "Kimi-K2.5" },
@@ -387,6 +398,19 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
         statusMessage: "CodeBuddy OAuth token missing"
     },
     {
+        id: "codebuddy-cn",
+        name: "CodeBuddy CN",
+        category: "oauth",
+        protocol: "openai",
+        alias: "codebuddy-cn",
+        baseUrl: CODEBUDDY_CN_BASE_URL,
+        websiteUrl: "https://www.codebuddy.cn",
+        requiresApiKey: false,
+        requiresOAuth: true,
+        supportsCustomUrl: true,
+        statusMessage: "CodeBuddy CN OAuth token missing"
+    },
+    {
         id: "opencode_zen",
         name: "OpenCode Zen",
         category: "free_tier",
@@ -404,6 +428,9 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
 export const KNOWN_PROVIDER_MAP: Record<string, KnownProvider> = Object.fromEntries(
     KNOWN_PROVIDERS.map((provider) => [provider.id, provider])
 );
+const KNOWN_PROVIDER_IDS_BY_LENGTH = Object.keys(KNOWN_PROVIDER_MAP).sort(
+    (left, right) => right.length - left.length
+);
 
 export function providerById(id: string): KnownProvider | undefined {
     return KNOWN_PROVIDER_MAP[id];
@@ -418,6 +445,11 @@ export function isKnownProvider(id: string): boolean {
  * openai_codex_1700000000 → openai, kiro-2 → kiro).
  */
 export function providerBaseId(id: string): string {
+    const knownId = KNOWN_PROVIDER_IDS_BY_LENGTH.find(
+        (candidate) =>
+            id === candidate || id.startsWith(`${candidate}_`) || id.startsWith(`${candidate}-`)
+    );
+    if (knownId) return knownId;
     return id.split("_")[0]?.split("-")[0] ?? id;
 }
 

--- a/packages/db/src/quota.ts
+++ b/packages/db/src/quota.ts
@@ -1,4 +1,4 @@
-import { isProviderBaseId } from "@srouter/constants";
+import { CODEBUDDY_CN_DOMAIN, CODEBUDDY_CN_USER_AGENT, isProviderBaseId } from "@srouter/constants";
 import type {
     LiveModelQuotaItem,
     ProviderQuotaAccount,
@@ -14,7 +14,11 @@ function formatResetIn(resetTimeStr?: string): string {
     const now = Date.now();
     const diffMs = resetTime - now;
     if (diffMs <= 0) return "0m";
+    const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
     const hours = Math.floor(diffMs / (1000 * 60 * 60));
+    if (days > 0) {
+        return `${days}d ${hours - days * 24}h`;
+    }
     const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
     if (hours > 0) {
         return `${hours}h ${minutes}m`;
@@ -99,6 +103,156 @@ export async function fetchAntigravityLiveQuota(
     };
 }
 
+interface CodeBuddyCNAccount {
+    PackageName?: string;
+    SubProductName?: string;
+    CycleStartTime?: string;
+    CycleEndTime?: string;
+    DeductionEndTime?: number;
+    CycleCapacityUsed?: number;
+    CycleCapacityUsedPrecise?: string;
+    CycleCapacitySize?: number;
+    CycleCapacitySizePrecise?: string;
+    CapacityUsed?: number;
+    CapacityUsedPrecise?: string;
+    CapacitySize?: number;
+    CapacitySizePrecise?: string;
+}
+
+// Refill packs roll into a new cycle before the resource expires; bonus packs
+// end exactly at expiry. >2d gap between cycle end and validity end = refill.
+const CN_REFILL_GAP_MS = 2 * 24 * 60 * 60 * 1000;
+
+export async function fetchCodeBuddyCNLiveQuota(
+    providerId: string,
+    accountName: string,
+    accessToken: string,
+    enabled = true
+): Promise<ProviderQuotaAccount> {
+    if (!accessToken) {
+        throw new Error("CodeBuddy CN quota requires an access token");
+    }
+
+    const res = await fetch("https://copilot.tencent.com/v2/billing/meter/get-user-resource", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "User-Agent": CODEBUDDY_CN_USER_AGENT,
+            "X-Product": "SaaS",
+            "X-IDE-Type": "CLI",
+            "X-IDE-Name": "CLI",
+            "X-Domain": CODEBUDDY_CN_DOMAIN,
+            "x-requested-with": "XMLHttpRequest",
+            "x-codebuddy-request": "1"
+        },
+        body: "{}"
+    });
+
+    if (!res.ok) {
+        throw new Error(`CodeBuddy CN quota fetch failed: HTTP ${res.status}`);
+    }
+
+    const json = (await res.json()) as {
+        code?: number;
+        msg?: string;
+        data?: { Response?: { Data?: { Accounts?: CodeBuddyCNAccount[] } } };
+    };
+    if (json.code !== 0) {
+        throw new Error(`CodeBuddy CN quota error: ${json.msg || "unknown"}`);
+    }
+
+    const accounts = json.data?.Response?.Data?.Accounts ?? [];
+    if (accounts.length === 0) {
+        throw new Error("CodeBuddy CN quota fetch returned no credit packages");
+    }
+
+    const cycleEndMs = (acc: CodeBuddyCNAccount): number => {
+        const t = acc.CycleEndTime ? new Date(acc.CycleEndTime).getTime() : NaN;
+        return Number.isFinite(t) ? t : Number.POSITIVE_INFINITY;
+    };
+    const isRefill = (acc: CodeBuddyCNAccount): boolean => {
+        const ce = cycleEndMs(acc);
+        const de = Number(acc.DeductionEndTime);
+        return Number.isFinite(ce) && Number.isFinite(de) && de - ce > CN_REFILL_GAP_MS;
+    };
+    const byExpiry = (a: CodeBuddyCNAccount, b: CodeBuddyCNAccount) => cycleEndMs(a) - cycleEndMs(b);
+
+    const refills = accounts.filter(isRefill).sort(byExpiry);
+    const bonuses = accounts.filter((a) => !isRefill(a)).sort(byExpiry);
+
+    const toItem = (
+        name: string,
+        used: number,
+        total: number,
+        resetTime?: string
+    ): LiveModelQuotaItem => {
+        const remainingFraction = total > 0 ? (total - used) / total : 1;
+        return {
+            name,
+            used: Math.round(used * 100) / 100,
+            limit: Math.round(total * 100) / 100,
+            percentage: total > 0 ? `${Math.round((used / total) * 100)}%` : "0%",
+            percentageValue: total > 0 ? Math.round((used / total) * 100) : 0,
+            resetIn: formatResetIn(resetTime),
+            resetTime,
+            status: remainingFraction <= 0.05 ? "exhausted" : remainingFraction <= 0.2 ? "warning" : "ok"
+        };
+    };
+
+    const num = (precise?: string, plain?: number): number => {
+        const n = Number(precise ?? plain);
+        return Number.isFinite(n) ? n : 0;
+    };
+
+    const quotas: LiveModelQuotaItem[] = [];
+    const seenCadence: Record<string, number> = {};
+    for (const acc of refills) {
+        const cycleStartMs = acc.CycleStartTime ? new Date(acc.CycleStartTime).getTime() : NaN;
+        const cycleDays = (cycleEndMs(acc) - cycleStartMs) / 86400000;
+        const base =
+            Number.isFinite(cycleDays) && cycleDays <= 1.5
+                ? "Daily"
+                : Number.isFinite(cycleDays) && cycleDays <= 10
+                  ? "Weekly"
+                  : "Monthly";
+        seenCadence[base] = (seenCadence[base] ?? 0) + 1;
+        const name = seenCadence[base]! > 1 ? `${base} ${seenCadence[base]}` : base;
+        quotas.push(
+            toItem(
+                name,
+                num(acc.CycleCapacityUsedPrecise, acc.CycleCapacityUsed),
+                num(acc.CycleCapacitySizePrecise, acc.CycleCapacitySize),
+                acc.CycleEndTime
+            )
+        );
+    }
+    bonuses.forEach((acc, i) => {
+        quotas.push(
+            toItem(
+                `Bonus Pack ${i + 1}`,
+                num(acc.CapacityUsedPrecise, acc.CapacityUsed),
+                num(acc.CapacitySizePrecise, acc.CapacitySize),
+                acc.CycleEndTime
+            )
+        );
+    });
+
+    const basePkg = refills[0] ?? accounts[0] ?? {};
+    const plan = basePkg.PackageName || basePkg.SubProductName;
+
+    return {
+        id: providerId,
+        provider: plan ? `CodeBuddy CN (${plan})` : "CodeBuddy CN",
+        account: accountName,
+        enabled,
+        quotaType: "live_provider_quota",
+        totalQuotas: quotas.length,
+        quotas
+    };
+}
+
 export async function getProviderQuotaAccount(p: {
     id: string;
     providerId: string;
@@ -114,8 +268,23 @@ export async function getProviderQuotaAccount(p: {
     const isOpenAI = isProviderBaseId(p.providerId, "openai") || isProviderBaseId(p.id, "openai");
     const isAnthropic =
         isProviderBaseId(p.providerId, "anthropic") || isProviderBaseId(p.id, "anthropic");
+    const isCodeBuddyCN =
+        isProviderBaseId(p.providerId, "codebuddy-cn") || isProviderBaseId(p.id, "codebuddy-cn");
+    // codebuddy.ai (international) has no known live quota endpoint; showing SRouter's
+    // own usage logs under a "CodeBuddy" card is misleading, so skip it entirely.
+    const isCodeBuddy =
+        !isCodeBuddyCN &&
+        (isProviderBaseId(p.providerId, "codebuddy") || isProviderBaseId(p.id, "codebuddy"));
 
     const token = p.accessToken || p.apiKey || "";
+
+    if (isCodeBuddy) {
+        throw new Error("CodeBuddy (international) does not expose a live quota endpoint");
+    }
+
+    if (isCodeBuddyCN) {
+        return await fetchCodeBuddyCNLiveQuota(p.id, p.name || "CodeBuddy CN Account", token, p.enabled);
+    }
 
     if (isAntigravity) {
         return await fetchAntigravityLiveQuota(

--- a/packages/executors/src/codebuddy.ts
+++ b/packages/executors/src/codebuddy.ts
@@ -20,6 +20,11 @@ export interface CodeBuddyExecutorOptions {
     baseUrl?: string;
     apiKey?: string;
     accessToken?: string;
+    modelPrefix?: string;
+    domain?: string;
+    userAgent?: string;
+    /** Header profile: "cli" identifies as the CodeBuddy CLI (X-IDE-Type: CLI), "ide" as the IDE plugin */
+    flavor?: "ide" | "cli";
 }
 
 export class CodeBuddyExecutor implements AIProvider {
@@ -28,6 +33,10 @@ export class CodeBuddyExecutor implements AIProvider {
     private baseUrl: string;
     private apiKey: string;
     private accessToken: string;
+    private modelPrefix: string;
+    private domain?: string;
+    private userAgent: string;
+    private flavor: "ide" | "cli";
 
     constructor(options: CodeBuddyExecutorOptions = {}) {
         this.id = options.id ?? "codebuddy";
@@ -35,6 +44,10 @@ export class CodeBuddyExecutor implements AIProvider {
         this.baseUrl = (options.baseUrl ?? CODEBUDDY_BASE_URL).replace(/\/$/, "");
         this.apiKey = options.apiKey ?? "";
         this.accessToken = options.accessToken ?? "";
+        this.modelPrefix = options.modelPrefix ?? this.id.split("_")[0]?.split("-")[0] ?? this.id;
+        this.domain = options.domain;
+        this.userAgent = options.userAgent ?? "IDE/2.108.1 CodeBuddy/2.108.1";
+        this.flavor = options.flavor ?? "ide";
     }
 
     updateToken(accessToken: string): void {
@@ -44,13 +57,15 @@ export class CodeBuddyExecutor implements AIProvider {
     private getHeaders(): Record<string, string> {
         const headers: Record<string, string> = {
             "Content-Type": "application/json",
-            "User-Agent": "IDE/2.108.1 CodeBuddy/2.108.1",
-            "X-Product": "SaaS",
-            "X-IDE-Type": "IDE",
-            "X-IDE-Name": "IDE",
-            "x-requested-with": "XMLHttpRequest",
-            "x-codebuddy-request": "1"
+            "User-Agent": this.userAgent
         };
+        const ideName = this.flavor === "cli" ? "CLI" : "IDE";
+        headers["X-Product"] = "SaaS";
+        headers["X-IDE-Type"] = ideName;
+        headers["X-IDE-Name"] = ideName;
+        headers["x-requested-with"] = "XMLHttpRequest";
+        headers["x-codebuddy-request"] = "1";
+        if (this.domain) headers["X-Domain"] = this.domain;
         const token = this.accessToken || this.apiKey;
         if (token) {
             headers["Authorization"] = `Bearer ${token}`;
@@ -114,11 +129,10 @@ export class CodeBuddyExecutor implements AIProvider {
     }
 
     async listModels(): Promise<ModelObject[]> {
-        const baseId = this.id.split("_")[0]?.split("-")[0] ?? this.id;
         return CODEBUDDY_MODELS.map((m) => ({
-            id: `${baseId}/${m.id}`,
+            id: `${this.modelPrefix}/${m.id}`,
             object: "model",
-            owned_by: baseId
+            owned_by: this.modelPrefix
         }));
     }
 

--- a/packages/executors/tests/codebuddy.test.ts
+++ b/packages/executors/tests/codebuddy.test.ts
@@ -108,6 +108,44 @@ test("CodeBuddy transforms chat request: forces stream, wraps user message in ty
     assert.equal(res.choices[0]?.finish_reason, "stop");
 });
 
+test("CodeBuddy CN sends requests to Tencent with the CN CLI identity", async () => {
+    let url = "";
+    let headers: Headers | undefined;
+    globalThis.fetch = async (input, init) => {
+        url = String(input);
+        headers = new Headers(init?.headers);
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue(
+                    new TextEncoder().encode(
+                        'data: {"id":"cn","object":"chat.completion.chunk","created":1,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n'
+                    )
+                );
+                controller.close();
+            }
+        });
+        return new Response(stream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" }
+        });
+    };
+
+    await executor({
+        baseUrl: "https://copilot.tencent.com/v2/chat/completions",
+        domain: "www.codebuddy.cn",
+        userAgent: "CLI/2.96.0 CodeBuddy/2.96.0",
+        flavor: "cli" as const,
+        modelPrefix: "codebuddy-cn"
+    }).chatCompletion(request("codebuddy-cn/glm-5.2"));
+
+    assert.equal(url, "https://copilot.tencent.com/v2/chat/completions");
+    assert.equal(headers?.get("x-domain"), "www.codebuddy.cn");
+    assert.equal(headers?.get("user-agent"), "CLI/2.96.0 CodeBuddy/2.96.0");
+    assert.equal(headers?.get("x-ide-type"), "CLI");
+    assert.equal(headers?.get("x-ide-name"), "CLI");
+    assert.equal(headers?.get("x-codebuddy-request"), "1");
+});
+
 test("CodeBuddy removes reasoning_effort when set to none or off", async () => {
     let body: Record<string, unknown> | undefined;
 

--- a/packages/providers/src/oauth/codebuddy.ts
+++ b/packages/providers/src/oauth/codebuddy.ts
@@ -3,7 +3,13 @@ import {
     CODEBUDDY_AUTH_REFRESH_URL,
     CODEBUDDY_AUTH_STATE_URL,
     CODEBUDDY_AUTH_TOKEN_URL,
-    CODEBUDDY_AUTH_USER_AGENT
+    CODEBUDDY_AUTH_USER_AGENT,
+    CODEBUDDY_CN_AUTH_REFRESH_URL,
+    CODEBUDDY_CN_AUTH_STATE_URL,
+    CODEBUDDY_CN_AUTH_TOKEN_URL,
+    CODEBUDDY_CN_DOMAIN,
+    CODEBUDDY_CN_ORIGIN,
+    CODEBUDDY_CN_USER_AGENT
 } from "@srouter/constants";
 import type { OAuthTokenResponse } from "./base.js";
 
@@ -13,6 +19,10 @@ export interface CodeBuddyOAuthOptions {
     refreshUrl?: string;
     platform?: string;
     userAgent?: string;
+    origin?: string;
+    domain?: string;
+    ioa?: boolean;
+    refreshBearer?: boolean;
 }
 
 export class CodeBuddyOAuth {
@@ -21,6 +31,10 @@ export class CodeBuddyOAuth {
     private refreshUrl: string;
     private platform: string;
     private userAgent: string;
+    private origin: string;
+    private domain: string;
+    private ioa: boolean;
+    private refreshBearer: boolean;
 
     constructor(options: CodeBuddyOAuthOptions = {}) {
         this.stateUrl = options.stateUrl ?? CODEBUDDY_AUTH_STATE_URL;
@@ -28,18 +42,26 @@ export class CodeBuddyOAuth {
         this.refreshUrl = options.refreshUrl ?? CODEBUDDY_AUTH_REFRESH_URL;
         this.platform = options.platform ?? CODEBUDDY_AUTH_PLATFORM;
         this.userAgent = options.userAgent ?? CODEBUDDY_AUTH_USER_AGENT;
+        this.origin = options.origin ?? "https://www.codebuddy.ai";
+        this.domain = options.domain ?? new URL(this.origin).host;
+        this.ioa = options.ioa ?? false;
+        this.refreshBearer = options.refreshBearer ?? false;
     }
 
     async requestAuthState(): Promise<{ state: string; authUrl: string }> {
-        const url = `${this.stateUrl}?platform=${encodeURIComponent(this.platform)}`;
+        const params = new URLSearchParams({ platform: this.platform });
+        if (this.ioa) params.set("ioa", "1");
+        const url = `${this.stateUrl}?${params}`;
         const response = await fetch(url, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 Accept: "application/json",
                 "User-Agent": this.userAgent,
+                Origin: this.origin,
+                Referer: `${this.origin}/`,
                 "X-Requested-With": "XMLHttpRequest",
-                "X-Domain": "www.codebuddy.ai",
+                "X-Domain": this.domain,
                 "X-No-Authorization": "true",
                 "X-No-User-Id": "true",
                 "X-Product": "SaaS"
@@ -81,8 +103,10 @@ export class CodeBuddyOAuth {
             headers: {
                 Accept: "application/json",
                 "User-Agent": this.userAgent,
+                Origin: this.origin,
+                Referer: `${this.origin}/`,
                 "X-Requested-With": "XMLHttpRequest",
-                "X-Domain": "www.codebuddy.ai",
+                "X-Domain": this.domain,
                 "X-No-Authorization": "true",
                 "X-No-User-Id": "true",
                 "X-No-Enterprise-Id": "true",
@@ -148,11 +172,14 @@ export class CodeBuddyOAuth {
                     "Content-Type": "application/json",
                     Accept: "application/json",
                     "User-Agent": this.userAgent,
+                    Origin: this.origin,
+                    Referer: `${this.origin}/`,
                     "X-Requested-With": "XMLHttpRequest",
-                    "X-Domain": "www.codebuddy.ai",
-                    "X-Product": "SaaS"
+                    "X-Domain": this.domain,
+                    "X-Product": "SaaS",
+                    ...(this.refreshBearer ? { Authorization: `Bearer ${refreshToken}` } : {})
                 },
-                body: JSON.stringify({ refreshToken })
+                body: this.refreshBearer ? undefined : JSON.stringify({ refreshToken })
             });
 
             if (response.ok) {
@@ -169,7 +196,11 @@ export class CodeBuddyOAuth {
                     };
                 }
             }
-        } catch {
+            if (this.refreshBearer) throw new Error("CodeBuddy token refresh failed");
+        } catch (error) {
+            if (this.refreshBearer) {
+                throw error instanceof Error ? error : new Error("CodeBuddy token refresh failed");
+            }
             // fallback to preserving refreshToken
         }
 
@@ -178,5 +209,22 @@ export class CodeBuddyOAuth {
             refreshToken,
             tokenType: "Bearer"
         };
+    }
+}
+
+export class CodeBuddyCNOAuth extends CodeBuddyOAuth {
+    constructor(options: CodeBuddyOAuthOptions = {}) {
+        super({
+            stateUrl: CODEBUDDY_CN_AUTH_STATE_URL,
+            tokenUrl: CODEBUDDY_CN_AUTH_TOKEN_URL,
+            refreshUrl: CODEBUDDY_CN_AUTH_REFRESH_URL,
+            origin: CODEBUDDY_CN_ORIGIN,
+            domain: CODEBUDDY_CN_DOMAIN,
+            userAgent: CODEBUDDY_CN_USER_AGENT,
+            platform: "CLI",
+            ioa: true,
+            refreshBearer: true,
+            ...options
+        });
     }
 }


### PR DESCRIPTION
## Summary

Adds **CodeBuddy CN** (`codebuddy-cn`) as a new OAuth provider — the China region of CodeBuddy (copilot.tencent.com), which uses a different API host, different auth endpoints, and a different client identity (CLI instead of IDE plugin) than the existing global `codebuddy` provider.

> ⚠️ **Heads-up for the maintainer:** I'm not fully confident this is finished/complete — I'd appreciate a careful review before merging. See **Open questions / review notes** below.

## What changed

### Provider registration (`packages/constants`)
- New `codebuddy-cn` entry in `KNOWN_PROVIDERS` (OAuth category, OpenAI protocol, `https://copilot.tencent.com/v2/chat/completions`).
- CN-specific constants: auth state/token/refresh URLs, `X-Domain` (`www.codebuddy.cn`), CN user agent (`CLI/2.96.0 CodeBuddy/2.96.0`).
- Added newly available models to the shared CodeBuddy catalog: `glm-5.3`, `kimi-k3`.

### OAuth device flow (`packages/providers`)
- `CodeBuddyOAuth` now accepts `origin`, `domain`, `ioa`, and `refreshBearer` options so the same flow serves both regions; `CodeBuddyCNOAuth` (subclass/factory) presets the CN endpoints and identity.
- CN refresh flow uses the CN-specific refresh endpoint with bearer semantics that differ from the global region.

### Executor (`packages/executors`)
- `CodeBuddyExecutor` generalized with `modelPrefix`, `domain`, `userAgent`, and a `flavor: "ide" | "cli"` option. CN requests identify as the **CodeBuddy CLI** (`X-IDE-Type: CLI`, `X-Domain: www.codebuddy.cn`) — required for the CN backend to accept requests; global behavior is unchanged (`ide` flavor is the default).

### API (`apps/api`)
- `POST/GET /v1/auth/codebuddy-cn/login` — initiates OAuth device flow (redirect or `?format=json`).
- `/v1/auth/codebuddy-cn/poll` — polls for device-flow token completion, persists provider config, registers executor with CN flavor.
- `/v1/auth/codebuddy-cn/import` — manual access-token import.
- `auth.logic.ts` refactored: shared `initiateCodeBuddyOAuthFor` / `pollCodeBuddyDeviceTokenFor` helpers parameterized by region, so global and CN share one code path.

### Live quota (`packages/db`)
- `fetchCodeBuddyCNLiveQuota` calls `POST /v2/billing/meter/get-user-resource` and maps CN credit packages onto the existing `ProviderQuotaAccount` shape.
- Handles CN's refill-pack vs. bonus-pack distinction: refill packs roll into a new cycle before expiry (detected via >2-day gap between cycle end and deduction end), so quota display doesn't conflate them.
- `formatResetIn` now renders multi-day resets as `Xd Yh` (CN cycles are longer than the hourly windows of other providers).

### Dashboard (`apps/web`)
- `ConnectOAuthModal` updated to wire the CN provider's login/poll flow.

### Tests
- `apps/api/tests/codebuddy-provider.test.ts` — expanded coverage for CN auth initiation, polling, import, and provider registration.
- `packages/executors/tests/codebuddy.test.ts` — CN flavor headers, model prefix, domain header.

## Verification

- `bun run test` in `apps/api`: **89/89 pass** (tsx test runner).
- `bun test tests/codebuddy.test.ts` in `packages/executors`: **6/6 pass**.
- Existing global `codebuddy` provider behavior unchanged (defaults preserved).

## Open questions / review notes

1. **Completeness** — the contributor is unsure every CN edge case is covered (e.g., token refresh under expiry, quota parsing for accounts with multiple overlapping packages). A real CN account test by the maintainer would be valuable.
2. **Refill-pack heuristic** — the >2-day gap rule for distinguishing refill vs. bonus packs is inferred from observed API responses, not official docs; may need tuning.
3. **Shared model catalog** — `glm-5.3`/`kimi-k3` were added to the global `CODEBUDDY_MODELS` list; confirm these are valid for the global region too, or split the catalogs per region.
