### PR TITLE
refactor(auth): simplify auth controller and routes to pure JSON

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -33,52 +33,17 @@ export interface TokenImportBody {
     name?: string;
 }
 
-function renderOAuthSuccessHTML(providerName: string): Response {
-    const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Otorisasi Berhasil</title>
-  <style>
-    body { font-family: system-ui, -apple-system, sans-serif; background: #09090b; color: #f4f4f5; display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; margin: 0; text-align: center; }
-    .card { background: #18181b; border: 1px solid #27272a; border-radius: 16px; padding: 32px 40px; max-width: 380px; box-shadow: 0 20px 25px -5px rgba(0,0,0,0.5); }
-    .icon { font-size: 40px; margin-bottom: 12px; }
-    h1 { font-size: 18px; margin: 0 0 8px; color: #10b981; font-weight: 700; }
-    p { font-size: 13px; color: #a1a1aa; margin: 0; line-height: 1.5; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <div class="icon">✨</div>
-    <h1>Otorisasi Berhasil!</h1>
-    <p>Koneksi <strong>${providerName}</strong> telah berhasil ditambahkan ke SRouter. Jendela ini akan tertutup otomatis...</p>
-  </div>
-  <script>
-    try {
-      if (window.opener) {
-        window.opener.postMessage({ type: "SROUTER_OAUTH_SUCCESS" }, "*");
-      }
-    } catch (e) {}
-    setTimeout(function() {
-      window.close();
-    }, 1200);
-  </script>
-</body>
-</html>`;
-    return new Response(html, {
-        headers: { "Content-Type": "text/html; charset=utf-8" }
-    });
+async function extractState(c: Context): Promise<string | undefined> {
+    let state = c.req.query("state");
+    if (!state && c.req.method === "POST") {
+        try {
+            const body = await c.req.json<{ state?: string }>();
+            state = body?.state;
+        } catch {}
+    }
+    return state || undefined;
 }
 
-// --- Generic engine (parameterized by an AuthProviderHandler) ---
-
-/**
- * Initiate a PKCE OAuth login. Mirrors the original per-provider behavior:
- * - OpenAI login lets errors bubble (global handler → 500).
- * - Antigravity login catches errors and returns 400 invalid_request_error.
- * The `handleErrors` flag encodes that asymmetry.
- */
 function loginFor(
     handler: AuthProviderHandler,
     initiate: (params: OAuthLoginParams) => ReturnType<typeof AuthLogic.initiateOAuthPKCE>,
@@ -104,10 +69,6 @@ function loginFor(
     }
 }
 
-/**
- * Handle an OAuth callback (GET from browser popup, or POST with a callbackUrl body).
- * Shared by the main app and the secondary OAuth listener (port 1455).
- */
 async function handleOAuthCallbackFor(
     handler: AuthProviderHandler,
     processCallback: (code: string, state: string) => Promise<unknown>,
@@ -124,15 +85,11 @@ async function handleOAuthCallbackFor(
                     const parsedUrl = new URL(body.callbackUrl);
                     code = code || parsedUrl.searchParams.get("code") || undefined;
                     state = state || parsedUrl.searchParams.get("state") || undefined;
-                } catch {
-                    // Ignore invalid URL string
-                }
+                } catch {}
             }
             code = code || body.code;
             state = state || body.state;
-        } catch {
-            // Ignore JSON parse error
-        }
+        } catch {}
     }
 
     if (!code || !state) {
@@ -146,24 +103,17 @@ async function handleOAuthCallbackFor(
             name: string;
         };
 
-        if (c.req.method === "POST" || c.req.header("accept")?.includes("application/json")) {
-            return ok(c, {
-                success: true,
-                message: handler.oauthSuccessMessage,
-                provider: providerConfig
-            });
-        }
-
-        return renderOAuthSuccessHTML(providerConfig.name);
+        return ok(c, {
+            success: true,
+            message: handler.oauthSuccessMessage,
+            provider: providerConfig
+        });
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         return err(c, errorMessage, 500);
     }
 }
 
-/**
- * Import a provider token/API key from a JSON body.
- */
 async function importTokenFor(
     handler: AuthProviderHandler,
     importLogic: (body: TokenImportParams) => unknown,
@@ -193,10 +143,7 @@ async function importTokenFor(
     );
 }
 
-// --- Public API (thin adapters, names preserved so routes/index.ts stay unchanged) ---
-
 export class AuthController {
-    // OpenAI OAuth
     public static loginOpenAI(c: Context): Response {
         return loginFor(openaiCodexAuthHandler, (p) => AuthLogic.initiateOAuthPKCE(p), c, false);
     }
@@ -213,7 +160,6 @@ export class AuthController {
         return importTokenFor(openaiCodexAuthHandler, (b) => AuthLogic.processTokenImport(b), c);
     }
 
-    // Antigravity OAuth
     public static loginAntigravity(c: Context): Response {
         return loginFor(
             antigravityAuthHandler,
@@ -239,7 +185,6 @@ export class AuthController {
         );
     }
 
-    // CommandCode Provider (API key)
     public static async importCommandCodeToken(c: Context): Promise<Response> {
         return importTokenFor(
             commandCodeAuthHandler,
@@ -248,7 +193,6 @@ export class AuthController {
         );
     }
 
-    // Anthropic Provider (API key)
     public static async importAnthropicToken(c: Context): Promise<Response> {
         return importTokenFor(
             anthropicAuthHandler,
@@ -257,7 +201,6 @@ export class AuthController {
         );
     }
 
-    // Claude Code OAuth
     public static loginClaude(c: Context): Response {
         return loginFor(
             claudeAuthHandler,
@@ -283,7 +226,6 @@ export class AuthController {
         );
     }
 
-    // GoRouter Provider (API key)
     public static async importGoRouterToken(c: Context): Promise<Response> {
         return importTokenFor(
             goRouterAuthHandler,
@@ -292,7 +234,6 @@ export class AuthController {
         );
     }
 
-    // BluesMinds Provider (API key)
     public static async importBluesMindsToken(c: Context): Promise<Response> {
         return importTokenFor(
             bluesMindsAuthHandler,
@@ -301,7 +242,6 @@ export class AuthController {
         );
     }
 
-    // SeekAI Provider (API key)
     public static async importSeekAIToken(c: Context): Promise<Response> {
         return importTokenFor(
             seekAIAuthHandler,
@@ -310,7 +250,6 @@ export class AuthController {
         );
     }
 
-    // TabiToken Provider (API key)
     public static async importTabiTokenToken(c: Context): Promise<Response> {
         return importTokenFor(
             tabiTokenAuthHandler,
@@ -319,7 +258,6 @@ export class AuthController {
         );
     }
 
-    // TokenRouter Provider (API key)
     public static async importTokenRouterToken(c: Context): Promise<Response> {
         return importTokenFor(
             tokenRouterAuthHandler,
@@ -328,7 +266,6 @@ export class AuthController {
         );
     }
 
-    // CodeBuddy Provider (OAuth & Access Token)
     public static async loginCodeBuddy(c: Context): Promise<Response> {
         try {
             const result = await AuthLogic.initiateCodeBuddyOAuth();
@@ -349,14 +286,7 @@ export class AuthController {
     }
 
     public static async pollCodeBuddy(c: Context): Promise<Response> {
-        let state = c.req.query("state");
-        if (!state) {
-            try {
-                const body = await c.req.json<{ state?: string }>();
-                state = body?.state;
-            } catch {}
-        }
-
+        const state = await extractState(c);
         if (!state) {
             return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
         }
@@ -373,7 +303,6 @@ export class AuthController {
         );
     }
 
-    // CodeBuddy CN Provider (OAuth & Access Token)
     public static async loginCodeBuddyCN(c: Context): Promise<Response> {
         try {
             const result = await AuthLogic.initiateCodeBuddyCNOAuth();
@@ -390,13 +319,7 @@ export class AuthController {
     }
 
     public static async pollCodeBuddyCN(c: Context): Promise<Response> {
-        let state = c.req.query("state");
-        if (!state) {
-            try {
-                const body = await c.req.json<{ state?: string }>();
-                state = body?.state;
-            } catch {}
-        }
+        const state = await extractState(c);
         if (!state) {
             return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
         }
@@ -412,7 +335,6 @@ export class AuthController {
         );
     }
 
-    // Qoder Provider (OAuth & PAT)
     public static loginQoder(c: Context): Response {
         return loginFor(
             qoderAuthHandler,
@@ -439,14 +361,7 @@ export class AuthController {
     }
 
     public static async pollQoder(c: Context): Promise<Response> {
-        let state = c.req.query("state");
-        if (!state) {
-            try {
-                const body = await c.req.json<{ state?: string }>();
-                state = body?.state;
-            } catch {}
-        }
-
+        const state = await extractState(c);
         if (!state) {
             return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
         }

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -43,10 +43,6 @@ function cleanupExpiredSessions(): void {
     cleanupExpiredOAuthSessionsDB(PKCE_SESSION_MAX_AGE_MS);
 }
 
-/**
- * Resolve the PKCE client id for a handler, honoring per-call env + query overrides,
- * mirroring the original per-provider defaults exactly.
- */
 function resolveClientId(handler: AuthProviderHandler, params: OAuthLoginParams): string {
     return params.clientId || handler.clientId?.() || "";
 }
@@ -55,9 +51,6 @@ function resolveRedirectUri(handler: AuthProviderHandler, params: OAuthLoginPara
     return params.redirectUri || handler.defaultRedirectUri || "";
 }
 
-/**
- * Generate a stable, unique account id + human-friendly name for a newly saved provider.
- */
 function buildAccountIdentity(
     handler: AuthProviderHandler,
     now: number
@@ -67,8 +60,6 @@ function buildAccountIdentity(
         accountName: `${handler.displayName} (Account #${now.toString().slice(-4)})`
     };
 }
-
-// --- Generic engine (parameterized by an AuthProviderHandler) ---
 
 function initiatePKCEFor(handler: AuthProviderHandler, params: OAuthLoginParams): OAuthLoginResult {
     cleanupExpiredSessions();
@@ -204,10 +195,6 @@ function processTokenImportFor(
 
     return providerConfig;
 }
-
-// --- Public API (thin adapters, names preserved so routes/index.ts stay unchanged) ---
-
-// --- Device-flow providers (CodeBuddy, Qoder): bespoke flows kept explicit ---
 
 export async function initiateCodeBuddyOAuth(): Promise<{ authorizeUrl: string; state: string }> {
     return initiateCodeBuddyOAuthFor(new CodeBuddyOAuth());
@@ -431,8 +418,6 @@ export async function pollQoderDeviceToken(state: string): Promise<{
     };
 }
 
-// --- Provider handler registry: single source of truth for auth routes ---
-
 interface AuthProviderEntry {
     initiate?: (params: OAuthLoginParams) => OAuthLoginResult;
     callback?: (code: string, state: string) => Promise<ProviderConfig>;
@@ -488,10 +473,6 @@ for (const [key, handler] of [
     });
 }
 
-/**
- * Public API for controllers. Replaces ~20 one-line static delegators with
- * three registry lookups; route behavior is unchanged.
- */
 export const AuthLogic = {
     initiateOAuthPKCE: (params: OAuthLoginParams): OAuthLoginResult =>
         authProviderEntries.openai.initiate!(params),
@@ -526,12 +507,8 @@ export const AuthLogic = {
     initiateCodeBuddyCNOAuth,
     pollCodeBuddyDeviceToken,
     pollCodeBuddyCNDeviceToken,
-    pollQoderDeviceToken
-};
+    pollQoderDeviceToken,
 
-// Per-provider named adapters kept for backwards compatibility (tests + routes),
-// merged onto the AuthLogic facade so existing call sites keep working.
-export const AuthLogicAdapters = {
     initiateAntigravityOAuthPKCE: (params: OAuthLoginParams) =>
         AuthLogic.initiateProviderOAuth("antigravity", params),
     processAntigravityOAuthCallback: (code: string, state: string) =>
@@ -567,4 +544,3 @@ export const AuthLogicAdapters = {
     processQoderTokenImport: (params: TokenImportParams) =>
         AuthLogic.processProviderTokenImport("qoder", params)
 };
-Object.assign(AuthLogic, AuthLogicAdapters);

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -7,112 +7,63 @@ export const authRoute = new Hono();
 export const handleOAuthCallback = AuthController.handleOAuthCallback;
 export const handleAntigravityOAuthCallback = AuthController.handleAntigravityOAuthCallback;
 export const handleClaudeOAuthCallback = AuthController.handleClaudeOAuthCallback;
-export const handleCommandCodeTokenImport = AuthController.importCommandCodeToken;
-export const handleCodeBuddyTokenImport = AuthController.importCodeBuddyToken;
 export const handleQoderOAuthCallback = AuthController.handleQoderOAuthCallback;
 
-// --- OpenAI OAuth ---
-// 1. GET /v1/auth/openai/login - Initiate OAuth PKCE Login Flow
 authRoute.get("/auth/openai/login", adminAuth, AuthController.loginOpenAI);
-
-// 2. GET & POST /v1/auth/openai/callback - OAuth Callback Receiver
 authRoute.get("/auth/openai/callback", AuthController.handleOAuthCallback);
 authRoute.post("/auth/openai/callback", AuthController.handleOAuthCallback);
-
-// 3. POST /v1/auth/openai/token & POST /v1/auth/openai/import-token
 authRoute.post("/auth/openai/token", adminAuth, AuthController.importToken);
 authRoute.post("/auth/openai/import-token", adminAuth, AuthController.importToken);
 
-// --- Antigravity OAuth ---
-// 1. GET /v1/auth/antigravity/login - Initiate Antigravity OAuth PKCE Login Flow
 authRoute.get("/auth/antigravity/login", adminAuth, AuthController.loginAntigravity);
-
-// 2. GET & POST /v1/auth/antigravity/callback - Antigravity OAuth Callback Receiver
 authRoute.get("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
 authRoute.post("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
-
-// 3. POST /v1/auth/antigravity/token & POST /v1/auth/antigravity/import-token
 authRoute.post("/auth/antigravity/token", adminAuth, AuthController.importAntigravityToken);
 authRoute.post("/auth/antigravity/import-token", adminAuth, AuthController.importAntigravityToken);
 
-// --- CommandCode Provider (API key) ---
-// 1. POST /v1/auth/commandcode/token & POST /v1/auth/commandcode/import-token
 authRoute.post("/auth/commandcode/token", adminAuth, AuthController.importCommandCodeToken);
 authRoute.post("/auth/commandcode/import-token", adminAuth, AuthController.importCommandCodeToken);
 
-// --- Anthropic Provider (API key) ---
-// 1. POST /v1/auth/anthropic/token & POST /v1/auth/anthropic/import-token
 authRoute.post("/auth/anthropic/token", adminAuth, AuthController.importAnthropicToken);
 authRoute.post("/auth/anthropic/import-token", adminAuth, AuthController.importAnthropicToken);
 
-// --- Claude Code OAuth ---
-// 1. GET /v1/auth/claude/login - Initiate Claude Code OAuth PKCE Login Flow
 authRoute.get("/auth/claude/login", adminAuth, AuthController.loginClaude);
-
-// 2. GET & POST /v1/auth/claude/callback - OAuth Callback Receiver
 authRoute.get("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
 authRoute.post("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
-
-// 3. POST /v1/auth/claude/token & POST /v1/auth/claude/import-token
 authRoute.post("/auth/claude/token", adminAuth, AuthController.importClaudeToken);
 authRoute.post("/auth/claude/import-token", adminAuth, AuthController.importClaudeToken);
 
-// --- GoRouter Provider (API key) ---
-// 1. POST /v1/auth/gorouter/token & POST /v1/auth/gorouter/import-token
 authRoute.post("/auth/gorouter/token", adminAuth, AuthController.importGoRouterToken);
 authRoute.post("/auth/gorouter/import-token", adminAuth, AuthController.importGoRouterToken);
 
-// --- BluesMinds Provider (API key) ---
-// 1. POST /v1/auth/bluesminds/token & POST /v1/auth/bluesminds/import-token
 authRoute.post("/auth/bluesminds/token", adminAuth, AuthController.importBluesMindsToken);
 authRoute.post("/auth/bluesminds/import-token", adminAuth, AuthController.importBluesMindsToken);
 
-// --- SeekAI Provider (API key) ---
-// 1. POST /v1/auth/seekai/token & POST /v1/auth/seekai/import-token
 authRoute.post("/auth/seekai/token", adminAuth, AuthController.importSeekAIToken);
 authRoute.post("/auth/seekai/import-token", adminAuth, AuthController.importSeekAIToken);
 
-// --- TabiToken Provider (API key) ---
-// 1. POST /v1/auth/tabitoken/token & POST /v1/auth/tabitoken/import-token
 authRoute.post("/auth/tabitoken/token", adminAuth, AuthController.importTabiTokenToken);
 authRoute.post("/auth/tabitoken/import-token", adminAuth, AuthController.importTabiTokenToken);
 
-// --- TokenRouter Provider (API key) ---
-// 1. POST /v1/auth/tokenrouter/token & POST /v1/auth/tokenrouter/import-token
 authRoute.post("/auth/tokenrouter/token", adminAuth, AuthController.importTokenRouterToken);
 authRoute.post("/auth/tokenrouter/import-token", adminAuth, AuthController.importTokenRouterToken);
 
-// --- CodeBuddy Provider (OAuth & Access Token) ---
-// 1. GET /v1/auth/codebuddy/login - Initiate CodeBuddy OAuth Flow
 authRoute.get("/auth/codebuddy/login", adminAuth, AuthController.loginCodeBuddy);
-
-// 2. GET & POST /v1/auth/codebuddy/poll - CodeBuddy OAuth Poll Receiver
 authRoute.get("/auth/codebuddy/poll", adminAuth, AuthController.pollCodeBuddy);
 authRoute.post("/auth/codebuddy/poll", adminAuth, AuthController.pollCodeBuddy);
-
-// 3. POST /v1/auth/codebuddy/token & POST /v1/auth/codebuddy/import-token
 authRoute.post("/auth/codebuddy/token", adminAuth, AuthController.importCodeBuddyToken);
 authRoute.post("/auth/codebuddy/import-token", adminAuth, AuthController.importCodeBuddyToken);
 
-// --- CodeBuddy CN Provider (OAuth & Access Token) ---
 authRoute.get("/auth/codebuddy-cn/login", adminAuth, AuthController.loginCodeBuddyCN);
 authRoute.get("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
 authRoute.post("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
 authRoute.post("/auth/codebuddy-cn/token", adminAuth, AuthController.importCodeBuddyCNToken);
 authRoute.post("/auth/codebuddy-cn/import-token", adminAuth, AuthController.importCodeBuddyCNToken);
 
-// --- Qoder Provider (OAuth & PAT) ---
-// 1. GET /v1/auth/qoder/login - Initiate Qoder OAuth PKCE Login Flow
 authRoute.get("/auth/qoder/login", adminAuth, AuthController.loginQoder);
-
-// 2. GET & POST /v1/auth/qoder/callback - Qoder OAuth Callback Receiver
 authRoute.get("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
 authRoute.post("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
-
-// 3. GET & POST /v1/auth/qoder/poll - Device Flow Poll Receiver
 authRoute.get("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
 authRoute.post("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
-
-// 4. POST /v1/auth/qoder/token & POST /v1/auth/qoder/import-token
 authRoute.post("/auth/qoder/token", adminAuth, AuthController.importQoderToken);
 authRoute.post("/auth/qoder/import-token", adminAuth, AuthController.importQoderToken);


### PR DESCRIPTION
## Summary
- Drop `renderOAuthSuccessHTML` in favor of pure JSON responses across all OAuth callbacks.
- Remove dead re-exports in `routes/v1/auth.ts`.
- Unify query/body state extraction across polling endpoints.
- Inline named compatibility adapters directly on the `AuthLogic` object.
- Strip all comments from auth routes, controllers, and logic.

## Changes
- `apps/api/src/controllers/auth.controller.ts`: Removed HTML rendering function and boilerplate code, returning pure JSON.
- `apps/api/src/routes/v1/auth.ts`: Cleaned unused re-exports.
- `apps/api/src/logic/auth.logic.ts`: Streamlined facade without runtime `Object.assign`.

## Verification
- `pnpm run lint` passed without errors.
- `pnpm exec tsx --test 'tests/**/*.test.ts'` passed (89/89 tests passing).