### PR TITLE
refactor(auth): centralize auth types, namespace provider handlers, and clean controllers

### DIFF
--- a/.agents/skills/SRouter-API/SKILL.md
+++ b/.agents/skills/SRouter-API/SKILL.md
@@ -33,7 +33,7 @@ Layered architecture:
 ## Security & Auth Rules
 
 1. **Loopback Detection**: Local requests (`127.0.0.1`, `::1`) bypass API key if `require_api_key` is off in settings. Remote requests **must** provide a valid virtual key (`sr-live-*`).
-2. **Admin Auth Middleware**: Guard named `RequireAdmin` (PascalCase). Use in routes: `authRoute.get(..., RequireAdmin, ...)`. Scrypt password hashing with session cookie `srouter_admin_session`. Remote setup requires `SROUTER_SETUP_TOKEN`.
+2. **Admin Auth Middleware**: Guard named `RequireAdmin` (PascalCase). Use in routes: `AuthRouter.get(..., RequireAdmin, ...)`. Scrypt password hashing with session cookie `srouter_admin_session`. Remote setup requires `SROUTER_SETUP_TOKEN`.
 3. **SSRF Guard**: Target URLs in provider verification block `169.254.*`, `127.*`, `localhost`, and internal metadata hostnames.
 
 ## Code Standards & Conventions
@@ -44,8 +44,11 @@ Layered architecture:
     - `AuthController.<Provider>.Callback`
     - `AuthController.<Provider>.Poll`
     - `AuthController.<Provider>.ImportToken`
+- **Routers**: Use PascalCase for Hono route instances (e.g. `AuthRouter`).
+- **OAuth Callback Handlers**: Export callback handlers using canonical naming `<Provider>OAuthCallback` (e.g. `CodexOAuthCallback`, `AntigravityOAuthCallback`, `ClaudeOAuthCallback`, `QoderOAuthCallback`).
 - **Interfaces & Types**: Shared contracts live in `@srouter/types` (e.g. `@srouter/types/src/auth.ts`). No `any` in client options; use strict typing like `OAuthClientOptions`.
 - **Pure JSON Responses**: Endpoints render JSON only (no HTML server-side rendering in API layer).
+- **Clean Code**: No dangling comments or speculative dead code (strict YAGNI). Return types like `Promise<ProviderConfig>` must be explicit without `unknown` or unsafe casts.
 
 ## Testing & Validation
 

--- a/.agents/skills/SRouter-API/SKILL.md
+++ b/.agents/skills/SRouter-API/SKILL.md
@@ -14,6 +14,7 @@ Layered architecture:
 `Routes (Hono) → Controllers → Logic → Services / Database / Executors`
 
 ### Key Paths & Packages:
+
 - `apps/api/src/index.ts`: Dual-server entrypoint (Port 3000 for API/Dashboard, Port 1455 for OAuth callbacks).
 - `apps/api/src/routes/v1/`: Endpoint definitions (`chat.ts`, `messages.ts`, `models.ts`, `providers.ts`, `keys.ts`, `admin.ts`, `settings.ts`, `tunnel.ts`, `quota.ts`, `logs.ts`).
 - `apps/api/src/middleware/`: Security headers (`X-Version`, `X-Powered-By`), CORS, `apiKeyAuth` (loopback/virtual key), `adminAuth` (session cookie).
@@ -24,15 +25,29 @@ Layered architecture:
 - `packages/constants/`: Version definitions (`version.ts`), provider catalogs, seed data.
 
 ## Server Ports & Lifecycle
+
 - **Port 3000**: API routes (`/v1/*`), health (`/health`), and static dashboard serving.
 - **Port 1455**: Secondary server for OAuth callbacks (`/auth/*/callback`) & CLI fallback listener.
 - **Startup**: Database migrations/seeding → Token refresh sweeper daemon (`startTokenRefreshSweeper()`) → Model registry cache warming → Tunnel autostart.
 
 ## Security & Auth Rules
+
 1. **Loopback Detection**: Local requests (`127.0.0.1`, `::1`) bypass API key if `require_api_key` is off in settings. Remote requests **must** provide a valid virtual key (`sr-live-*`).
-2. **Admin Auth**: Scrypt password hashing with session cookie `srouter_admin_session`. Remote setup requires `SROUTER_SETUP_TOKEN`.
+2. **Admin Auth Middleware**: Guard named `RequireAdmin` (PascalCase). Use in routes: `authRoute.get(..., RequireAdmin, ...)`. Scrypt password hashing with session cookie `srouter_admin_session`. Remote setup requires `SROUTER_SETUP_TOKEN`.
 3. **SSRF Guard**: Target URLs in provider verification block `169.254.*`, `127.*`, `localhost`, and internal metadata hostnames.
 
+## Code Standards & Conventions
+
+- **Auth Handlers**: Individual handlers grouped under `AuthHandlers.<Provider>` (e.g. `AuthHandlers.Antigravity`, `AuthHandlers.OpenAI`) in `apps/api/src/services/authHandlers.ts`.
+- **Controllers Pattern**: Actions organized by namespace objects rather than flat methods:
+    - `AuthController.<Provider>.OAuth`
+    - `AuthController.<Provider>.Callback`
+    - `AuthController.<Provider>.Poll`
+    - `AuthController.<Provider>.ImportToken`
+- **Interfaces & Types**: Shared contracts live in `@srouter/types` (e.g. `@srouter/types/src/auth.ts`). No `any` in client options; use strict typing like `OAuthClientOptions`.
+- **Pure JSON Responses**: Endpoints render JSON only (no HTML server-side rendering in API layer).
+
 ## Testing & Validation
+
 - **Targeted Test Execution**: Always run `cd apps/api && pnpm test` or `pnpm test tests/<filename>.test.ts`. Never run full monorepo tests at once.
 - **Build**: `cd apps/api && pnpm run build` (tsup node20 ESM).

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -14,7 +14,7 @@ import {
     seekAIAuthHandler,
     tabiTokenAuthHandler,
     tokenRouterAuthHandler
-} from "@/logic/auth.providers.js";
+} from "@/services/authHandlers.js";
 import type {
     AuthProviderHandler,
     OAuthCallbackBody,

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -13,25 +13,16 @@ import {
     qoderAuthHandler,
     seekAIAuthHandler,
     tabiTokenAuthHandler,
-    tokenRouterAuthHandler,
-    type AuthProviderHandler,
-    type OAuthLoginParams,
-    type TokenImportParams
+    tokenRouterAuthHandler
 } from "@/logic/auth.providers.js";
+import type {
+    AuthProviderHandler,
+    OAuthCallbackBody,
+    OAuthLoginParams,
+    TokenImportBody,
+    TokenImportParams
+} from "@srouter/types";
 import { err, ok } from "@/utils/response.js";
-
-export interface OAuthCallbackBody {
-    code?: string;
-    state?: string;
-    callbackUrl?: string;
-}
-
-export interface TokenImportBody {
-    accessToken: string;
-    refreshToken?: string;
-    baseUrl?: string;
-    name?: string;
-}
 
 async function extractState(c: Context): Promise<string | undefined> {
     let state = c.req.query("state");

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -5,6 +5,7 @@ import type {
     AuthProviderHandler,
     OAuthCallbackBody,
     OAuthLoginParams,
+    ProviderConfig,
     TokenImportBody,
     TokenImportParams
 } from "@srouter/types";
@@ -48,7 +49,7 @@ function loginFor(
 
 async function handleOAuthCallbackFor(
     handler: AuthProviderHandler,
-    processCallback: (code: string, state: string) => Promise<unknown>,
+    processCallback: (code: string, state: string) => Promise<ProviderConfig>,
     c: Context
 ): Promise<Response> {
     let code = c.req.query("code") || undefined;
@@ -76,9 +77,7 @@ async function handleOAuthCallbackFor(
     }
 
     try {
-        const providerConfig = (await processCallback(code, state)) as {
-            name: string;
-        };
+        const providerConfig = await processCallback(code, state);
 
         return ok(c, {
             success: true,
@@ -93,7 +92,7 @@ async function handleOAuthCallbackFor(
 
 async function importTokenFor(
     handler: AuthProviderHandler,
-    importLogic: (body: TokenImportParams) => unknown,
+    importLogic: (body: TokenImportParams) => ProviderConfig,
     c: Context
 ): Promise<Response> {
     let body: TokenImportBody;

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -1,25 +1,9 @@
 import type { Context } from "hono";
 import { AuthLogic } from "@/logic/auth.logic.js";
-import {
-    anthropicAuthHandler,
-    antigravityAuthHandler,
-    bluesMindsAuthHandler,
-    claudeAuthHandler,
-    codeBuddyAuthHandler,
-    codeBuddyCNAuthHandler,
-    commandCodeAuthHandler,
-    goRouterAuthHandler,
-    openaiCodexAuthHandler,
-    qoderAuthHandler,
-    seekAIAuthHandler,
-    tabiTokenAuthHandler,
-    tokenRouterAuthHandler
-} from "@/services/authHandlers.js";
+import { AuthHandlers } from "@/services/authHandlers.js";
 import type {
     AuthProviderHandler,
-    OAuthCallbackBody,
     OAuthLoginParams,
-    TokenImportBody,
     TokenImportParams
 } from "@srouter/types";
 import { err, ok } from "@/utils/response.js";
@@ -70,7 +54,7 @@ async function handleOAuthCallbackFor(
 
     if ((!code || !state) && c.req.method === "POST") {
         try {
-            const body = await c.req.json<OAuthCallbackBody>();
+            const body = await c.req.json<{ code?: string; state?: string; callbackUrl?: string }>();
             if (body.callbackUrl) {
                 try {
                     const parsedUrl = new URL(body.callbackUrl);
@@ -110,18 +94,18 @@ async function importTokenFor(
     importLogic: (body: TokenImportParams) => unknown,
     c: Context
 ): Promise<Response> {
-    let body: TokenImportBody;
+    let body: { accessToken?: string; refreshToken?: string; baseUrl?: string; name?: string };
     try {
-        body = await c.req.json<TokenImportBody>();
+        body = await c.req.json();
     } catch {
         return err(c, "Invalid JSON body", 400, { type: "invalid_request_error" });
     }
 
-    if (!body.accessToken) {
+    if (!body?.accessToken) {
         return err(c, "Field 'accessToken' is required", 400, { type: "invalid_request_error" });
     }
 
-    const providerConfig = importLogic(body);
+    const providerConfig = importLogic(body as TokenImportParams);
 
     return ok(
         c,
@@ -136,24 +120,24 @@ async function importTokenFor(
 
 export class AuthController {
     public static loginOpenAI(c: Context): Response {
-        return loginFor(openaiCodexAuthHandler, (p) => AuthLogic.initiateOAuthPKCE(p), c, false);
+        return loginFor(AuthHandlers.OpenAI, (p) => AuthLogic.initiateOAuthPKCE(p), c, false);
     }
 
     public static async handleOAuthCallback(c: Context): Promise<Response> {
         return handleOAuthCallbackFor(
-            openaiCodexAuthHandler,
+            AuthHandlers.OpenAI,
             (code, state) => AuthLogic.processOAuthCallback(code, state),
             c
         );
     }
 
     public static async importToken(c: Context): Promise<Response> {
-        return importTokenFor(openaiCodexAuthHandler, (b) => AuthLogic.processTokenImport(b), c);
+        return importTokenFor(AuthHandlers.OpenAI, (b) => AuthLogic.processTokenImport(b), c);
     }
 
     public static loginAntigravity(c: Context): Response {
         return loginFor(
-            antigravityAuthHandler,
+            AuthHandlers.Antigravity,
             (p) => AuthLogic.initiateProviderOAuth("antigravity", p),
             c,
             true
@@ -162,7 +146,7 @@ export class AuthController {
 
     public static async handleAntigravityOAuthCallback(c: Context): Promise<Response> {
         return handleOAuthCallbackFor(
-            antigravityAuthHandler,
+            AuthHandlers.Antigravity,
             (code, state) => AuthLogic.processProviderOAuthCallback("antigravity", code, state),
             c
         );
@@ -170,7 +154,7 @@ export class AuthController {
 
     public static async importAntigravityToken(c: Context): Promise<Response> {
         return importTokenFor(
-            antigravityAuthHandler,
+            AuthHandlers.Antigravity,
             (b) => AuthLogic.processProviderTokenImport("antigravity", b),
             c
         );
@@ -178,7 +162,7 @@ export class AuthController {
 
     public static async importCommandCodeToken(c: Context): Promise<Response> {
         return importTokenFor(
-            commandCodeAuthHandler,
+            AuthHandlers.CommandCode,
             (b) => AuthLogic.processProviderTokenImport("commandcode", b),
             c
         );
@@ -186,7 +170,7 @@ export class AuthController {
 
     public static async importAnthropicToken(c: Context): Promise<Response> {
         return importTokenFor(
-            anthropicAuthHandler,
+            AuthHandlers.Anthropic,
             (b) => AuthLogic.processProviderTokenImport("anthropic", b),
             c
         );
@@ -194,7 +178,7 @@ export class AuthController {
 
     public static loginClaude(c: Context): Response {
         return loginFor(
-            claudeAuthHandler,
+            AuthHandlers.Claude,
             (p) => AuthLogic.initiateProviderOAuth("claude", p),
             c,
             false
@@ -203,7 +187,7 @@ export class AuthController {
 
     public static async handleClaudeOAuthCallback(c: Context): Promise<Response> {
         return handleOAuthCallbackFor(
-            claudeAuthHandler,
+            AuthHandlers.Claude,
             (code, state) => AuthLogic.processProviderOAuthCallback("claude", code, state),
             c
         );
@@ -211,7 +195,7 @@ export class AuthController {
 
     public static async importClaudeToken(c: Context): Promise<Response> {
         return importTokenFor(
-            claudeAuthHandler,
+            AuthHandlers.Claude,
             (b) => AuthLogic.processProviderTokenImport("claude", b),
             c
         );
@@ -219,7 +203,7 @@ export class AuthController {
 
     public static async importGoRouterToken(c: Context): Promise<Response> {
         return importTokenFor(
-            goRouterAuthHandler,
+            AuthHandlers.GoRouter,
             (b) => AuthLogic.processProviderTokenImport("gorouter", b),
             c
         );
@@ -227,7 +211,7 @@ export class AuthController {
 
     public static async importBluesMindsToken(c: Context): Promise<Response> {
         return importTokenFor(
-            bluesMindsAuthHandler,
+            AuthHandlers.BluesMinds,
             (b) => AuthLogic.processProviderTokenImport("bluesminds", b),
             c
         );
@@ -235,7 +219,7 @@ export class AuthController {
 
     public static async importSeekAIToken(c: Context): Promise<Response> {
         return importTokenFor(
-            seekAIAuthHandler,
+            AuthHandlers.SeekAI,
             (b) => AuthLogic.processProviderTokenImport("seekai", b),
             c
         );
@@ -243,7 +227,7 @@ export class AuthController {
 
     public static async importTabiTokenToken(c: Context): Promise<Response> {
         return importTokenFor(
-            tabiTokenAuthHandler,
+            AuthHandlers.TabiToken,
             (b) => AuthLogic.processProviderTokenImport("tabitoken", b),
             c
         );
@@ -251,7 +235,7 @@ export class AuthController {
 
     public static async importTokenRouterToken(c: Context): Promise<Response> {
         return importTokenFor(
-            tokenRouterAuthHandler,
+            AuthHandlers.TokenRouter,
             (b) => AuthLogic.processProviderTokenImport("tokenrouter", b),
             c
         );
@@ -288,7 +272,7 @@ export class AuthController {
 
     public static async importCodeBuddyToken(c: Context): Promise<Response> {
         return importTokenFor(
-            codeBuddyAuthHandler,
+            AuthHandlers.CodeBuddy,
             (b) => AuthLogic.processProviderTokenImport("codebuddy", b),
             c
         );
@@ -320,7 +304,7 @@ export class AuthController {
 
     public static async importCodeBuddyCNToken(c: Context): Promise<Response> {
         return importTokenFor(
-            codeBuddyCNAuthHandler,
+            AuthHandlers.CodeBuddyCN,
             (b) => AuthLogic.processProviderTokenImport("codebuddy-cn", b),
             c
         );
@@ -328,7 +312,7 @@ export class AuthController {
 
     public static loginQoder(c: Context): Response {
         return loginFor(
-            qoderAuthHandler,
+            AuthHandlers.Qoder,
             (p) => AuthLogic.initiateProviderOAuth("qoder", p),
             c,
             true
@@ -337,7 +321,7 @@ export class AuthController {
 
     public static async handleQoderOAuthCallback(c: Context): Promise<Response> {
         return handleOAuthCallbackFor(
-            qoderAuthHandler,
+            AuthHandlers.Qoder,
             (code, state) => AuthLogic.processProviderOAuthCallback("qoder", code, state),
             c
         );
@@ -345,7 +329,7 @@ export class AuthController {
 
     public static async importQoderToken(c: Context): Promise<Response> {
         return importTokenFor(
-            qoderAuthHandler,
+            AuthHandlers.Qoder,
             (b) => AuthLogic.processProviderTokenImport("qoder", b),
             c
         );

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -119,230 +119,222 @@ async function importTokenFor(
     );
 }
 
-export class AuthController {
-    public static loginOpenAI(c: Context): Response {
-        return loginFor(AuthHandlers.OpenAI, (p) => AuthLogic.initiateOAuthPKCE(p), c, false);
-    }
+export const AuthController = {
+    OpenAI: {
+        OAuth: (c: Context): Response =>
+            loginFor(AuthHandlers.OpenAI, (p) => AuthLogic.initiateOAuthPKCE(p), c, false),
+        Callback: (c: Context): Promise<Response> =>
+            handleOAuthCallbackFor(
+                AuthHandlers.OpenAI,
+                (code, state) => AuthLogic.processOAuthCallback(code, state),
+                c
+            ),
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(AuthHandlers.OpenAI, (b) => AuthLogic.processTokenImport(b), c)
+    },
 
-    public static async handleOAuthCallback(c: Context): Promise<Response> {
-        return handleOAuthCallbackFor(
-            AuthHandlers.OpenAI,
-            (code, state) => AuthLogic.processOAuthCallback(code, state),
-            c
-        );
-    }
+    Antigravity: {
+        OAuth: (c: Context): Response =>
+            loginFor(
+                AuthHandlers.Antigravity,
+                (p) => AuthLogic.initiateProviderOAuth("antigravity", p),
+                c,
+                true
+            ),
+        Callback: (c: Context): Promise<Response> =>
+            handleOAuthCallbackFor(
+                AuthHandlers.Antigravity,
+                (code, state) => AuthLogic.processProviderOAuthCallback("antigravity", code, state),
+                c
+            ),
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.Antigravity,
+                (b) => AuthLogic.processProviderTokenImport("antigravity", b),
+                c
+            )
+    },
 
-    public static async importToken(c: Context): Promise<Response> {
-        return importTokenFor(AuthHandlers.OpenAI, (b) => AuthLogic.processTokenImport(b), c);
-    }
+    CommandCode: {
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.CommandCode,
+                (b) => AuthLogic.processProviderTokenImport("commandcode", b),
+                c
+            )
+    },
 
-    public static loginAntigravity(c: Context): Response {
-        return loginFor(
-            AuthHandlers.Antigravity,
-            (p) => AuthLogic.initiateProviderOAuth("antigravity", p),
-            c,
-            true
-        );
-    }
+    Anthropic: {
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.Anthropic,
+                (b) => AuthLogic.processProviderTokenImport("anthropic", b),
+                c
+            )
+    },
 
-    public static async handleAntigravityOAuthCallback(c: Context): Promise<Response> {
-        return handleOAuthCallbackFor(
-            AuthHandlers.Antigravity,
-            (code, state) => AuthLogic.processProviderOAuthCallback("antigravity", code, state),
-            c
-        );
-    }
+    Claude: {
+        OAuth: (c: Context): Response =>
+            loginFor(
+                AuthHandlers.Claude,
+                (p) => AuthLogic.initiateProviderOAuth("claude", p),
+                c,
+                false
+            ),
+        Callback: (c: Context): Promise<Response> =>
+            handleOAuthCallbackFor(
+                AuthHandlers.Claude,
+                (code, state) => AuthLogic.processProviderOAuthCallback("claude", code, state),
+                c
+            ),
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.Claude,
+                (b) => AuthLogic.processProviderTokenImport("claude", b),
+                c
+            )
+    },
 
-    public static async importAntigravityToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.Antigravity,
-            (b) => AuthLogic.processProviderTokenImport("antigravity", b),
-            c
-        );
-    }
+    GoRouter: {
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.GoRouter,
+                (b) => AuthLogic.processProviderTokenImport("gorouter", b),
+                c
+            )
+    },
 
-    public static async importCommandCodeToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.CommandCode,
-            (b) => AuthLogic.processProviderTokenImport("commandcode", b),
-            c
-        );
-    }
+    BluesMinds: {
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.BluesMinds,
+                (b) => AuthLogic.processProviderTokenImport("bluesminds", b),
+                c
+            )
+    },
 
-    public static async importAnthropicToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.Anthropic,
-            (b) => AuthLogic.processProviderTokenImport("anthropic", b),
-            c
-        );
-    }
+    SeekAI: {
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.SeekAI,
+                (b) => AuthLogic.processProviderTokenImport("seekai", b),
+                c
+            )
+    },
 
-    public static loginClaude(c: Context): Response {
-        return loginFor(
-            AuthHandlers.Claude,
-            (p) => AuthLogic.initiateProviderOAuth("claude", p),
-            c,
-            false
-        );
-    }
+    TabiToken: {
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.TabiToken,
+                (b) => AuthLogic.processProviderTokenImport("tabitoken", b),
+                c
+            )
+    },
 
-    public static async handleClaudeOAuthCallback(c: Context): Promise<Response> {
-        return handleOAuthCallbackFor(
-            AuthHandlers.Claude,
-            (code, state) => AuthLogic.processProviderOAuthCallback("claude", code, state),
-            c
-        );
-    }
+    TokenRouter: {
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.TokenRouter,
+                (b) => AuthLogic.processProviderTokenImport("tokenrouter", b),
+                c
+            )
+    },
 
-    public static async importClaudeToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.Claude,
-            (b) => AuthLogic.processProviderTokenImport("claude", b),
-            c
-        );
-    }
-
-    public static async importGoRouterToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.GoRouter,
-            (b) => AuthLogic.processProviderTokenImport("gorouter", b),
-            c
-        );
-    }
-
-    public static async importBluesMindsToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.BluesMinds,
-            (b) => AuthLogic.processProviderTokenImport("bluesminds", b),
-            c
-        );
-    }
-
-    public static async importSeekAIToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.SeekAI,
-            (b) => AuthLogic.processProviderTokenImport("seekai", b),
-            c
-        );
-    }
-
-    public static async importTabiTokenToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.TabiToken,
-            (b) => AuthLogic.processProviderTokenImport("tabitoken", b),
-            c
-        );
-    }
-
-    public static async importTokenRouterToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.TokenRouter,
-            (b) => AuthLogic.processProviderTokenImport("tokenrouter", b),
-            c
-        );
-    }
-
-    public static async loginCodeBuddy(c: Context): Promise<Response> {
-        try {
-            const result = await AuthLogic.initiateCodeBuddyOAuth();
-            const format = c.req.query("format");
-            if (format === "json") {
-                return ok(c, {
-                    authorizeUrl: result.authorizeUrl,
-                    state: result.state
+    CodeBuddy: {
+        OAuth: async (c: Context): Promise<Response> => {
+            try {
+                const result = await AuthLogic.initiateCodeBuddyOAuth();
+                const format = c.req.query("format");
+                if (format === "json") {
+                    return ok(c, {
+                        authorizeUrl: result.authorizeUrl,
+                        state: result.state
+                    });
+                }
+                return c.redirect(result.authorizeUrl);
+            } catch (error) {
+                const message = error instanceof Error ? error.message : "Internal Server Error";
+                return err(c, `Failed to initiate CodeBuddy login: ${message}`, 500, {
+                    type: "api_error"
                 });
             }
-            return c.redirect(result.authorizeUrl);
-        } catch (error) {
-            const message = error instanceof Error ? error.message : "Internal Server Error";
-            return err(c, `Failed to initiate CodeBuddy login: ${message}`, 500, {
-                type: "api_error"
-            });
-        }
-    }
-
-    public static async pollCodeBuddy(c: Context): Promise<Response> {
-        const state = await extractState(c);
-        if (!state) {
-            return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
-        }
-
-        const result = await AuthLogic.pollCodeBuddyDeviceToken(state);
-        return ok(c, result);
-    }
-
-    public static async importCodeBuddyToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.CodeBuddy,
-            (b) => AuthLogic.processProviderTokenImport("codebuddy", b),
-            c
-        );
-    }
-
-    public static async loginCodeBuddyCN(c: Context): Promise<Response> {
-        try {
-            const result = await AuthLogic.initiateCodeBuddyCNOAuth();
-            if (c.req.query("format") === "json") {
-                return ok(c, { authorizeUrl: result.authorizeUrl, state: result.state });
+        },
+        Poll: async (c: Context): Promise<Response> => {
+            const state = await extractState(c);
+            if (!state) {
+                return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
             }
-            return c.redirect(result.authorizeUrl);
-        } catch (error) {
-            const message = error instanceof Error ? error.message : "Internal Server Error";
-            return err(c, `Failed to initiate CodeBuddy CN login: ${message}`, 500, {
-                type: "api_error"
-            });
-        }
+
+            const result = await AuthLogic.pollCodeBuddyDeviceToken(state);
+            return ok(c, result);
+        },
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.CodeBuddy,
+                (b) => AuthLogic.processProviderTokenImport("codebuddy", b),
+                c
+            )
+    },
+
+    CodeBuddyCN: {
+        OAuth: async (c: Context): Promise<Response> => {
+            try {
+                const result = await AuthLogic.initiateCodeBuddyCNOAuth();
+                if (c.req.query("format") === "json") {
+                    return ok(c, { authorizeUrl: result.authorizeUrl, state: result.state });
+                }
+                return c.redirect(result.authorizeUrl);
+            } catch (error) {
+                const message = error instanceof Error ? error.message : "Internal Server Error";
+                return err(c, `Failed to initiate CodeBuddy CN login: ${message}`, 500, {
+                    type: "api_error"
+                });
+            }
+        },
+        Poll: async (c: Context): Promise<Response> => {
+            const state = await extractState(c);
+            if (!state) {
+                return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
+            }
+
+            return ok(c, await AuthLogic.pollCodeBuddyCNDeviceToken(state));
+        },
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.CodeBuddyCN,
+                (b) => AuthLogic.processProviderTokenImport("codebuddy-cn", b),
+                c
+            )
+    },
+
+    Qoder: {
+        OAuth: (c: Context): Response =>
+            loginFor(
+                AuthHandlers.Qoder,
+                (p) => AuthLogic.initiateProviderOAuth("qoder", p),
+                c,
+                true
+            ),
+        Callback: (c: Context): Promise<Response> =>
+            handleOAuthCallbackFor(
+                AuthHandlers.Qoder,
+                (code, state) => AuthLogic.processProviderOAuthCallback("qoder", code, state),
+                c
+            ),
+        Poll: async (c: Context): Promise<Response> => {
+            const state = await extractState(c);
+            if (!state) {
+                return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
+            }
+
+            const result = await AuthLogic.pollQoderDeviceToken(state);
+            return ok(c, result);
+        },
+        ImportToken: (c: Context): Promise<Response> =>
+            importTokenFor(
+                AuthHandlers.Qoder,
+                (b) => AuthLogic.processProviderTokenImport("qoder", b),
+                c
+            )
     }
-
-    public static async pollCodeBuddyCN(c: Context): Promise<Response> {
-        const state = await extractState(c);
-        if (!state) {
-            return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
-        }
-
-        return ok(c, await AuthLogic.pollCodeBuddyCNDeviceToken(state));
-    }
-
-    public static async importCodeBuddyCNToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.CodeBuddyCN,
-            (b) => AuthLogic.processProviderTokenImport("codebuddy-cn", b),
-            c
-        );
-    }
-
-    public static loginQoder(c: Context): Response {
-        return loginFor(
-            AuthHandlers.Qoder,
-            (p) => AuthLogic.initiateProviderOAuth("qoder", p),
-            c,
-            true
-        );
-    }
-
-    public static async handleQoderOAuthCallback(c: Context): Promise<Response> {
-        return handleOAuthCallbackFor(
-            AuthHandlers.Qoder,
-            (code, state) => AuthLogic.processProviderOAuthCallback("qoder", code, state),
-            c
-        );
-    }
-
-    public static async importQoderToken(c: Context): Promise<Response> {
-        return importTokenFor(
-            AuthHandlers.Qoder,
-            (b) => AuthLogic.processProviderTokenImport("qoder", b),
-            c
-        );
-    }
-
-    public static async pollQoder(c: Context): Promise<Response> {
-        const state = await extractState(c);
-        if (!state) {
-            return err(c, "Missing state parameter", 400, { type: "invalid_request_error" });
-        }
-
-        const result = await AuthLogic.pollQoderDeviceToken(state);
-        return ok(c, result);
-    }
-}
+};

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -3,7 +3,9 @@ import { AuthLogic } from "@/logic/auth.logic.js";
 import { AuthHandlers } from "@/services/authHandlers.js";
 import type {
     AuthProviderHandler,
+    OAuthCallbackBody,
     OAuthLoginParams,
+    TokenImportBody,
     TokenImportParams
 } from "@srouter/types";
 import { err, ok } from "@/utils/response.js";
@@ -54,7 +56,7 @@ async function handleOAuthCallbackFor(
 
     if ((!code || !state) && c.req.method === "POST") {
         try {
-            const body = await c.req.json<{ code?: string; state?: string; callbackUrl?: string }>();
+            const body = await c.req.json<OAuthCallbackBody>();
             if (body.callbackUrl) {
                 try {
                     const parsedUrl = new URL(body.callbackUrl);
@@ -94,9 +96,9 @@ async function importTokenFor(
     importLogic: (body: TokenImportParams) => unknown,
     c: Context
 ): Promise<Response> {
-    let body: { accessToken?: string; refreshToken?: string; baseUrl?: string; name?: string };
+    let body: TokenImportBody;
     try {
-        body = await c.req.json();
+        body = await c.req.json<TokenImportBody>();
     } catch {
         return err(c, "Invalid JSON body", 400, { type: "invalid_request_error" });
     }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,10 +6,10 @@ import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import {
     AuthRouter,
-    handleAntigravityOAuthCallback,
-    handleClaudeOAuthCallback,
-    handleOAuthCallback,
-    handleQoderOAuthCallback
+    AntigravityOAuthCallback,
+    ClaudeOAuthCallback,
+    CodexOAuthCallback,
+    QoderOAuthCallback
 } from "@/routes/v1/auth.js";
 import { adminRoute } from "@/routes/v1/admin.js";
 import { chatRoute } from "@/routes/v1/chat.js";
@@ -196,14 +196,14 @@ serve(
 // Secondary listener on Port 1455 for OAuth callbacks and local Anthropic proxy
 const oauthApp = new Hono();
 oauthApp.onError(errorHandler("OAuth API Route"));
-oauthApp.get("/auth/callback", (c) => handleOAuthCallback(c));
-oauthApp.post("/auth/callback", (c) => handleOAuthCallback(c));
-oauthApp.get("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
-oauthApp.post("/auth/antigravity/callback", (c) => handleAntigravityOAuthCallback(c));
-oauthApp.get("/auth/claude/callback", (c) => handleClaudeOAuthCallback(c));
-oauthApp.post("/auth/claude/callback", (c) => handleClaudeOAuthCallback(c));
-oauthApp.get("/auth/qoder/callback", (c) => handleQoderOAuthCallback(c));
-oauthApp.post("/auth/qoder/callback", (c) => handleQoderOAuthCallback(c));
+oauthApp.get("/auth/callback", (c) => CodexOAuthCallback(c));
+oauthApp.post("/auth/callback", (c) => CodexOAuthCallback(c));
+oauthApp.get("/auth/antigravity/callback", (c) => AntigravityOAuthCallback(c));
+oauthApp.post("/auth/antigravity/callback", (c) => AntigravityOAuthCallback(c));
+oauthApp.get("/auth/claude/callback", (c) => ClaudeOAuthCallback(c));
+oauthApp.post("/auth/claude/callback", (c) => ClaudeOAuthCallback(c));
+oauthApp.get("/auth/qoder/callback", (c) => QoderOAuthCallback(c));
+oauthApp.post("/auth/qoder/callback", (c) => QoderOAuthCallback(c));
 oauthApp.route("/v1", messagesRoute);
 oauthApp.route("/v1", chatRoute);
 oauthApp.route("/v1", modelsRoute);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,7 +21,7 @@ import { providersRoute } from "@/routes/v1/providers.js";
 import { quotaRoute } from "@/routes/v1/quota.js";
 import { settingsRoute } from "@/routes/v1/settings.js";
 import { tunnelRoute } from "@/routes/v1/tunnel.js";
-import { adminAuth } from "@/middleware/adminAuth.js";
+import { requireAdmin } from "@/middleware/adminAuth.js";
 import { startTokenRefreshSweeper } from "@/services/tokenRefresh.js";
 import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry } from "@/services/registry.js";
@@ -147,10 +147,10 @@ app.route("/v1", settingsRoute);
 
 // Cloudflare Tunnel management (admin-only; status readable via API key too)
 app.route("/v1", tunnelRoute);
-app.use("/v1/tunnel/start", adminAuth);
-app.use("/v1/tunnel/stop", adminAuth);
-app.use("/v1/tunnel/config", adminAuth);
-app.use("/v1/tunnel/install", adminAuth);
+app.use("/v1/tunnel/start", requireAdmin);
+app.use("/v1/tunnel/stop", requireAdmin);
+app.use("/v1/tunnel/config", requireAdmin);
+app.use("/v1/tunnel/install", requireAdmin);
 
 // Mount /v1/v1 compatibility routes for SDKs that append /v1 to a baseURL containing /v1
 app.route("/v1/v1", messagesRoute);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,7 +21,7 @@ import { providersRoute } from "@/routes/v1/providers.js";
 import { quotaRoute } from "@/routes/v1/quota.js";
 import { settingsRoute } from "@/routes/v1/settings.js";
 import { tunnelRoute } from "@/routes/v1/tunnel.js";
-import { requireAdmin } from "@/middleware/adminAuth.js";
+import { RequireAdmin } from "@/middleware/adminAuth.js";
 import { startTokenRefreshSweeper } from "@/services/tokenRefresh.js";
 import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry } from "@/services/registry.js";
@@ -147,10 +147,10 @@ app.route("/v1", settingsRoute);
 
 // Cloudflare Tunnel management (admin-only; status readable via API key too)
 app.route("/v1", tunnelRoute);
-app.use("/v1/tunnel/start", requireAdmin);
-app.use("/v1/tunnel/stop", requireAdmin);
-app.use("/v1/tunnel/config", requireAdmin);
-app.use("/v1/tunnel/install", requireAdmin);
+app.use("/v1/tunnel/start", RequireAdmin);
+app.use("/v1/tunnel/stop", RequireAdmin);
+app.use("/v1/tunnel/config", RequireAdmin);
+app.use("/v1/tunnel/install", RequireAdmin);
 
 // Mount /v1/v1 compatibility routes for SDKs that append /v1 to a baseURL containing /v1
 app.route("/v1/v1", messagesRoute);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import {
-    authRoute,
+    AuthRouter,
     handleAntigravityOAuthCallback,
     handleClaudeOAuthCallback,
     handleOAuthCallback,
@@ -141,7 +141,7 @@ app.route("/v1", messagesRoute);
 app.route("/v1", providersRoute);
 app.route("/v1", keysRoute);
 app.route("/v1", logsRoute);
-app.route("/v1", authRoute);
+app.route("/v1", AuthRouter);
 app.route("/v1", quotaRoute);
 app.route("/v1", settingsRoute);
 

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -55,7 +55,7 @@ function initiatePKCEFor(handler: AuthProviderHandler, params: OAuthLoginParams)
     const redirectUri = resolveRedirectUri(handler, params);
     const prompt = params.prompt;
 
-    const oauthInstance = new handler.oauthClass!({ clientId, redirectUri, prompt });
+    const oAuthInstance = new handler.oauthClass!({ clientId, redirectUri, prompt });
 
     const pkce = generatePKCE();
     saveOAuthSessionDB({
@@ -66,7 +66,7 @@ function initiatePKCEFor(handler: AuthProviderHandler, params: OAuthLoginParams)
         createdAt: Date.now()
     });
 
-    const authorizeUrl = oauthInstance.getAuthorizationUrl!(pkce);
+    const authorizeUrl = oAuthInstance.getAuthorizationUrl!(pkce);
 
     return {
         authorizeUrl,
@@ -90,12 +90,12 @@ async function processOAuthCallbackFor(
 
     deleteOAuthSessionDB(state);
 
-    const oauthInstance = new handler.oauthClass!({
+    const oAuthInstance = new handler.oauthClass!({
         clientId: session.clientId,
         redirectUri: session.redirectUri
     });
 
-    const rawTokens = await oauthInstance.exchangeCodeForTokens!(
+    const rawTokens = await oAuthInstance.exchangeCodeForTokens!(
         code,
         session.codeVerifier || ""
     );

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -35,9 +35,9 @@ import {
     seekAIAuthHandler,
     tabiTokenAuthHandler,
     tokenRouterAuthHandler
-} from "./auth.providers.js";
+} from "@/services/authHandlers.js";
 
-export type { OAuthLoginParams, OAuthLoginResult, TokenImportParams } from "./auth.providers.js";
+export type { OAuthLoginParams, OAuthLoginResult, TokenImportParams } from "@srouter/types";
 
 const PKCE_SESSION_MAX_AGE_MS = 15 * 60 * 1000;
 

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -15,6 +15,12 @@ import { CodeBuddyCNOAuth, CodeBuddyOAuth, generatePKCE, QoderOAuth } from "@sro
 import { CodeBuddyExecutor, QoderExecutor } from "@srouter/executors";
 import type { ProviderConfig } from "@srouter/types";
 import { registry } from "@/services/registry.js";
+import type {
+    AuthProviderHandler,
+    OAuthLoginParams,
+    OAuthLoginResult,
+    TokenImportParams
+} from "@srouter/types";
 import {
     anthropicAuthHandler,
     antigravityAuthHandler,
@@ -28,11 +34,7 @@ import {
     qoderAuthHandler,
     seekAIAuthHandler,
     tabiTokenAuthHandler,
-    tokenRouterAuthHandler,
-    type AuthProviderHandler,
-    type OAuthLoginParams,
-    type OAuthLoginResult,
-    type TokenImportParams
+    tokenRouterAuthHandler
 } from "./auth.providers.js";
 
 export type { OAuthLoginParams, OAuthLoginResult, TokenImportParams } from "./auth.providers.js";

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -21,21 +21,7 @@ import type {
     OAuthLoginResult,
     TokenImportParams
 } from "@srouter/types";
-import {
-    anthropicAuthHandler,
-    antigravityAuthHandler,
-    bluesMindsAuthHandler,
-    claudeAuthHandler,
-    codeBuddyAuthHandler,
-    codeBuddyCNAuthHandler,
-    commandCodeAuthHandler,
-    goRouterAuthHandler,
-    openaiCodexAuthHandler,
-    qoderAuthHandler,
-    seekAIAuthHandler,
-    tabiTokenAuthHandler,
-    tokenRouterAuthHandler
-} from "@/services/authHandlers.js";
+import { AuthHandlers } from "@/services/authHandlers.js";
 
 export type { OAuthLoginParams, OAuthLoginResult, TokenImportParams } from "@srouter/types";
 
@@ -80,7 +66,7 @@ function initiatePKCEFor(handler: AuthProviderHandler, params: OAuthLoginParams)
         createdAt: Date.now()
     });
 
-    const authorizeUrl = oauthInstance.getAuthorizationUrl(pkce);
+    const authorizeUrl = oauthInstance.getAuthorizationUrl!(pkce);
 
     return {
         authorizeUrl,
@@ -109,7 +95,10 @@ async function processOAuthCallbackFor(
         redirectUri: session.redirectUri
     });
 
-    const rawTokens = await oauthInstance.exchangeCodeForTokens(code, session.codeVerifier);
+    const rawTokens = await oauthInstance.exchangeCodeForTokens!(
+        code,
+        session.codeVerifier || ""
+    );
     const tokens = handler.mapOAuthTokens?.(rawTokens) ?? {
         accessToken: rawTokens.accessToken,
         refreshToken: rawTokens.refreshToken,
@@ -436,39 +425,39 @@ const registerEntry = (
 };
 
 registerEntry("openai", {
-    initiate: (params) => initiatePKCEFor(openaiCodexAuthHandler, params),
-    callback: (code, state) => processOAuthCallbackFor(openaiCodexAuthHandler, code, state),
-    importToken: (params) => processTokenImportFor(openaiCodexAuthHandler, params)
+    initiate: (params) => initiatePKCEFor(AuthHandlers.OpenAI, params),
+    callback: (code, state) => processOAuthCallbackFor(AuthHandlers.OpenAI, code, state),
+    importToken: (params) => processTokenImportFor(AuthHandlers.OpenAI, params)
 });
 registerEntry("antigravity", {
-    initiate: (params) => initiatePKCEFor(antigravityAuthHandler, params),
-    callback: (code, state) => processOAuthCallbackFor(antigravityAuthHandler, code, state),
-    importToken: (params) => processTokenImportFor(antigravityAuthHandler, params)
+    initiate: (params) => initiatePKCEFor(AuthHandlers.Antigravity, params),
+    callback: (code, state) => processOAuthCallbackFor(AuthHandlers.Antigravity, code, state),
+    importToken: (params) => processTokenImportFor(AuthHandlers.Antigravity, params)
 });
 registerEntry("claude", {
-    initiate: (params) => initiatePKCEFor(claudeAuthHandler, params),
-    callback: (code, state) => processOAuthCallbackFor(claudeAuthHandler, code, state),
-    importToken: (params) => processTokenImportFor(claudeAuthHandler, params)
+    initiate: (params) => initiatePKCEFor(AuthHandlers.Claude, params),
+    callback: (code, state) => processOAuthCallbackFor(AuthHandlers.Claude, code, state),
+    importToken: (params) => processTokenImportFor(AuthHandlers.Claude, params)
 });
 registerEntry("qoder", {
-    initiate: (params) => initiatePKCEFor(qoderAuthHandler, params),
-    callback: (code, state) => processOAuthCallbackFor(qoderAuthHandler, code, state),
-    importToken: (params) => processTokenImportFor(qoderAuthHandler, params)
+    initiate: (params) => initiatePKCEFor(AuthHandlers.Qoder, params),
+    callback: (code, state) => processOAuthCallbackFor(AuthHandlers.Qoder, code, state),
+    importToken: (params) => processTokenImportFor(AuthHandlers.Qoder, params)
 });
 registerEntry("codebuddy", {
-    importToken: (params) => processTokenImportFor(codeBuddyAuthHandler, params)
+    importToken: (params) => processTokenImportFor(AuthHandlers.CodeBuddy, params)
 });
 registerEntry("codebuddy-cn", {
-    importToken: (params) => processTokenImportFor(codeBuddyCNAuthHandler, params)
+    importToken: (params) => processTokenImportFor(AuthHandlers.CodeBuddyCN, params)
 });
 for (const [key, handler] of [
-    ["commandcode", commandCodeAuthHandler],
-    ["anthropic", anthropicAuthHandler],
-    ["gorouter", goRouterAuthHandler],
-    ["bluesminds", bluesMindsAuthHandler],
-    ["seekai", seekAIAuthHandler],
-    ["tabitoken", tabiTokenAuthHandler],
-    ["tokenrouter", tokenRouterAuthHandler]
+    ["commandcode", AuthHandlers.CommandCode],
+    ["anthropic", AuthHandlers.Anthropic],
+    ["gorouter", AuthHandlers.GoRouter],
+    ["bluesminds", AuthHandlers.BluesMinds],
+    ["seekai", AuthHandlers.SeekAI],
+    ["tabitoken", AuthHandlers.TabiToken],
+    ["tokenrouter", AuthHandlers.TokenRouter]
 ] as const) {
     registerEntry(key, {
         importToken: (params) => processTokenImportFor(handler, params)

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -95,10 +95,7 @@ async function processOAuthCallbackFor(
         redirectUri: session.redirectUri
     });
 
-    const rawTokens = await oAuthInstance.exchangeCodeForTokens!(
-        code,
-        session.codeVerifier || ""
-    );
+    const rawTokens = await oAuthInstance.exchangeCodeForTokens!(code, session.codeVerifier || "");
     const tokens = handler.mapOAuthTokens?.(rawTokens) ?? {
         accessToken: rawTokens.accessToken,
         refreshToken: rawTokens.refreshToken,

--- a/apps/api/src/logic/auth.providers.ts
+++ b/apps/api/src/logic/auth.providers.ts
@@ -37,113 +37,27 @@ import {
     OpenAICodexOAuth,
     QoderOAuth
 } from "@srouter/providers";
-import type { AIProvider, ProviderCategory, ProviderProtocol } from "@srouter/types";
+import type {
+    AuthProviderHandler,
+    ExecutorFactory,
+    ImportTokenMapping,
+    OAuthClientClass,
+    OAuthLoginParams,
+    OAuthLoginResult,
+    OAuthTokens,
+    TokenImportParams
+} from "@srouter/types";
 
-export interface OAuthLoginParams {
-    clientId?: string;
-    redirectUri?: string;
-    prompt?: string;
-}
-
-export interface OAuthLoginResult {
-    authorizeUrl: string;
-    state: string;
-    codeVerifier: string;
-    redirectUri: string;
-}
-
-export interface TokenImportParams {
-    id?: string;
-    accessToken: string;
-    refreshToken?: string;
-    accountId?: string;
-    baseUrl?: string;
-    name?: string;
-}
-
-/**
- * A raw OAuth token response as returned by a provider's `exchangeCodeForTokens`.
- * Kept structurally compatible with @srouter/providers' OAuthTokenResponse.
- */
-export interface OAuthTokens {
-    accessToken: string;
-    refreshToken?: string;
-    accountId?: string;
-    organizationId?: string;
-    expiresIn?: number;
-}
-
-/**
- * Builds a concrete executor from normalized token data.
- * Each provider's constructor differs (Codex needs accountId, api-key providers need apiKey + baseUrl), so
- * the factory lives per handler.
- */
-export type ExecutorFactory = (args: {
-    id: string;
-    name: string;
-    accountId?: string;
-    organizationId?: string;
-    baseUrl?: string;
-    apiKey?: string;
-    accessToken?: string;
-    refreshToken?: string;
-}) => AIProvider;
-
-/**
- * An OAuth (PKCE) client class usable for login/callback/token-refresh.
- */
-export interface OAuthClientClass {
-    new (options?: { clientId?: string; redirectUri?: string; prompt?: string }): {
-        getAuthorizationUrl(pkce: { codeChallenge: string; state: string }): string;
-        exchangeCodeForTokens(code: string, codeVerifier: string): Promise<OAuthTokens>;
-        refreshTokens(refreshToken: string): Promise<OAuthTokens>;
-    };
-}
-
-/**
- * Normalizes a raw token import payload into the DB/executor field placements for a provider.
- * api-key providers place the token in `apiKey`; OAuth providers place it in `accessToken`.
- */
-export interface ImportTokenMapping {
-    accessToken?: string;
-    refreshToken?: string;
-    accountId?: string;
-    organizationId?: string;
-    baseUrl?: string;
-    apiKey?: string;
-}
-
-export interface AuthProviderHandler {
-    providerId: string;
-    displayName: string;
-    category: ProviderCategory;
-    protocol: ProviderProtocol;
-    /** Prefix for generated account ids (`${idPrefix}_${Date.now()}`). */
-    idPrefix: string;
-    /** Resolve the OAuth client id at call time (env-first, matching today's behavior). */
-    clientId?: () => string | undefined;
-    defaultRedirectUri?: string;
-    /** Resolve the base URL at call time (env-first). OAuth callback uses this for saved providers. */
-    baseUrl?: () => string | undefined;
-    /** Message returned on successful OAuth login (preserved verbatim). */
-    oauthSuccessMessage: string;
-    /** Message returned on successful token import (preserved verbatim). */
-    tokenImportMessage: string;
-    /** Maps raw OAuth tokens to the fields a provider stores/executes with. */
-    mapOAuthTokens?: (tokens: OAuthTokens) => {
-        accessToken: string;
-        refreshToken?: string;
-        accountId?: string;
-        organizationId?: string;
-        expiresIn?: number;
-        baseUrl?: string;
-    };
-    /** Maps a token-import payload to DB/executor field placements. */
-    mapImportTokens?: (params: TokenImportParams) => ImportTokenMapping;
-    buildExecutor: ExecutorFactory;
-    /** Present only for OAuth-backed providers. */
-    oauthClass?: OAuthClientClass;
-}
+export type {
+    AuthProviderHandler,
+    ExecutorFactory,
+    ImportTokenMapping,
+    OAuthClientClass,
+    OAuthLoginParams,
+    OAuthLoginResult,
+    OAuthTokens,
+    TokenImportParams
+};
 
 export const openaiCodexAuthHandler: AuthProviderHandler = {
     providerId: "openai_codex",

--- a/apps/api/src/middleware/adminAuth.ts
+++ b/apps/api/src/middleware/adminAuth.ts
@@ -29,4 +29,5 @@ export function createAdminAuthMiddleware(
     };
 }
 
-export const adminAuth = createAdminAuthMiddleware();
+export const requireAdmin = createAdminAuthMiddleware();
+export const adminAuth = requireAdmin;

--- a/apps/api/src/middleware/adminAuth.ts
+++ b/apps/api/src/middleware/adminAuth.ts
@@ -29,5 +29,6 @@ export function createAdminAuthMiddleware(
     };
 }
 
-export const requireAdmin = createAdminAuthMiddleware();
-export const adminAuth = requireAdmin;
+export const RequireAdmin = createAdminAuthMiddleware();
+export const requireAdmin = RequireAdmin;
+export const adminAuth = RequireAdmin;

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { AuthController } from "@/controllers/auth.controller.js";
-import { adminAuth } from "@/middleware/adminAuth.js";
+import { requireAdmin } from "@/middleware/adminAuth.js";
 
 export const authRoute = new Hono();
 
@@ -9,48 +9,48 @@ export const handleAntigravityOAuthCallback = AuthController.handleAntigravityOA
 export const handleClaudeOAuthCallback = AuthController.handleClaudeOAuthCallback;
 export const handleQoderOAuthCallback = AuthController.handleQoderOAuthCallback;
 
-authRoute.get("/auth/openai/login", adminAuth, AuthController.loginOpenAI);
+authRoute.get("/auth/openai/login", requireAdmin, AuthController.loginOpenAI);
 authRoute.get("/auth/openai/callback", AuthController.handleOAuthCallback);
 authRoute.post("/auth/openai/callback", AuthController.handleOAuthCallback);
-authRoute.post("/auth/openai/token", adminAuth, AuthController.importToken);
+authRoute.post("/auth/openai/token", requireAdmin, AuthController.importToken);
 
-authRoute.get("/auth/antigravity/login", adminAuth, AuthController.loginAntigravity);
+authRoute.get("/auth/antigravity/login", requireAdmin, AuthController.loginAntigravity);
 authRoute.get("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
 authRoute.post("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
-authRoute.post("/auth/antigravity/token", adminAuth, AuthController.importAntigravityToken);
+authRoute.post("/auth/antigravity/token", requireAdmin, AuthController.importAntigravityToken);
 
-authRoute.post("/auth/commandcode/token", adminAuth, AuthController.importCommandCodeToken);
+authRoute.post("/auth/commandcode/token", requireAdmin, AuthController.importCommandCodeToken);
 
-authRoute.post("/auth/anthropic/token", adminAuth, AuthController.importAnthropicToken);
+authRoute.post("/auth/anthropic/token", requireAdmin, AuthController.importAnthropicToken);
 
-authRoute.get("/auth/claude/login", adminAuth, AuthController.loginClaude);
+authRoute.get("/auth/claude/login", requireAdmin, AuthController.loginClaude);
 authRoute.get("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
 authRoute.post("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
-authRoute.post("/auth/claude/token", adminAuth, AuthController.importClaudeToken);
+authRoute.post("/auth/claude/token", requireAdmin, AuthController.importClaudeToken);
 
-authRoute.post("/auth/gorouter/token", adminAuth, AuthController.importGoRouterToken);
+authRoute.post("/auth/gorouter/token", requireAdmin, AuthController.importGoRouterToken);
 
-authRoute.post("/auth/bluesminds/token", adminAuth, AuthController.importBluesMindsToken);
+authRoute.post("/auth/bluesminds/token", requireAdmin, AuthController.importBluesMindsToken);
 
-authRoute.post("/auth/seekai/token", adminAuth, AuthController.importSeekAIToken);
+authRoute.post("/auth/seekai/token", requireAdmin, AuthController.importSeekAIToken);
 
-authRoute.post("/auth/tabitoken/token", adminAuth, AuthController.importTabiTokenToken);
+authRoute.post("/auth/tabitoken/token", requireAdmin, AuthController.importTabiTokenToken);
 
-authRoute.post("/auth/tokenrouter/token", adminAuth, AuthController.importTokenRouterToken);
+authRoute.post("/auth/tokenrouter/token", requireAdmin, AuthController.importTokenRouterToken);
 
-authRoute.get("/auth/codebuddy/login", adminAuth, AuthController.loginCodeBuddy);
-authRoute.get("/auth/codebuddy/poll", adminAuth, AuthController.pollCodeBuddy);
-authRoute.post("/auth/codebuddy/poll", adminAuth, AuthController.pollCodeBuddy);
-authRoute.post("/auth/codebuddy/token", adminAuth, AuthController.importCodeBuddyToken);
+authRoute.get("/auth/codebuddy/login", requireAdmin, AuthController.loginCodeBuddy);
+authRoute.get("/auth/codebuddy/poll", requireAdmin, AuthController.pollCodeBuddy);
+authRoute.post("/auth/codebuddy/poll", requireAdmin, AuthController.pollCodeBuddy);
+authRoute.post("/auth/codebuddy/token", requireAdmin, AuthController.importCodeBuddyToken);
 
-authRoute.get("/auth/codebuddy-cn/login", adminAuth, AuthController.loginCodeBuddyCN);
-authRoute.get("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
-authRoute.post("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
-authRoute.post("/auth/codebuddy-cn/token", adminAuth, AuthController.importCodeBuddyCNToken);
+authRoute.get("/auth/codebuddy-cn/login", requireAdmin, AuthController.loginCodeBuddyCN);
+authRoute.get("/auth/codebuddy-cn/poll", requireAdmin, AuthController.pollCodeBuddyCN);
+authRoute.post("/auth/codebuddy-cn/poll", requireAdmin, AuthController.pollCodeBuddyCN);
+authRoute.post("/auth/codebuddy-cn/token", requireAdmin, AuthController.importCodeBuddyCNToken);
 
-authRoute.get("/auth/qoder/login", adminAuth, AuthController.loginQoder);
+authRoute.get("/auth/qoder/login", requireAdmin, AuthController.loginQoder);
 authRoute.get("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
 authRoute.post("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
-authRoute.get("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
-authRoute.post("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
-authRoute.post("/auth/qoder/token", adminAuth, AuthController.importQoderToken);
+authRoute.get("/auth/qoder/poll", requireAdmin, AuthController.pollQoder);
+authRoute.post("/auth/qoder/poll", requireAdmin, AuthController.pollQoder);
+authRoute.post("/auth/qoder/token", requireAdmin, AuthController.importQoderToken);

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -2,55 +2,56 @@ import { Hono } from "hono";
 import { AuthController } from "@/controllers/auth.controller.js";
 import { RequireAdmin } from "@/middleware/adminAuth.js";
 
-export const authRoute = new Hono();
+export const AuthRouter = new Hono();
+export const authRoute = AuthRouter;
 
 export const handleOAuthCallback = AuthController.OpenAI.Callback;
 export const handleAntigravityOAuthCallback = AuthController.Antigravity.Callback;
 export const handleClaudeOAuthCallback = AuthController.Claude.Callback;
 export const handleQoderOAuthCallback = AuthController.Qoder.Callback;
 
-authRoute.get("/auth/openai/login", RequireAdmin, AuthController.OpenAI.OAuth);
-authRoute.get("/auth/openai/callback", AuthController.OpenAI.Callback);
-authRoute.post("/auth/openai/callback", AuthController.OpenAI.Callback);
-authRoute.post("/auth/openai/token", RequireAdmin, AuthController.OpenAI.ImportToken);
+AuthRouter.get("/auth/openai/login", RequireAdmin, AuthController.OpenAI.OAuth);
+AuthRouter.get("/auth/openai/callback", AuthController.OpenAI.Callback);
+AuthRouter.post("/auth/openai/callback", AuthController.OpenAI.Callback);
+AuthRouter.post("/auth/openai/token", RequireAdmin, AuthController.OpenAI.ImportToken);
 
-authRoute.get("/auth/antigravity/login", RequireAdmin, AuthController.Antigravity.OAuth);
-authRoute.get("/auth/antigravity/callback", AuthController.Antigravity.Callback);
-authRoute.post("/auth/antigravity/callback", AuthController.Antigravity.Callback);
-authRoute.post("/auth/antigravity/token", RequireAdmin, AuthController.Antigravity.ImportToken);
+AuthRouter.get("/auth/antigravity/login", RequireAdmin, AuthController.Antigravity.OAuth);
+AuthRouter.get("/auth/antigravity/callback", AuthController.Antigravity.Callback);
+AuthRouter.post("/auth/antigravity/callback", AuthController.Antigravity.Callback);
+AuthRouter.post("/auth/antigravity/token", RequireAdmin, AuthController.Antigravity.ImportToken);
 
-authRoute.post("/auth/commandcode/token", RequireAdmin, AuthController.CommandCode.ImportToken);
+AuthRouter.post("/auth/commandcode/token", RequireAdmin, AuthController.CommandCode.ImportToken);
 
-authRoute.post("/auth/anthropic/token", RequireAdmin, AuthController.Anthropic.ImportToken);
+AuthRouter.post("/auth/anthropic/token", RequireAdmin, AuthController.Anthropic.ImportToken);
 
-authRoute.get("/auth/claude/login", RequireAdmin, AuthController.Claude.OAuth);
-authRoute.get("/auth/claude/callback", AuthController.Claude.Callback);
-authRoute.post("/auth/claude/callback", AuthController.Claude.Callback);
-authRoute.post("/auth/claude/token", RequireAdmin, AuthController.Claude.ImportToken);
+AuthRouter.get("/auth/claude/login", RequireAdmin, AuthController.Claude.OAuth);
+AuthRouter.get("/auth/claude/callback", AuthController.Claude.Callback);
+AuthRouter.post("/auth/claude/callback", AuthController.Claude.Callback);
+AuthRouter.post("/auth/claude/token", RequireAdmin, AuthController.Claude.ImportToken);
 
-authRoute.post("/auth/gorouter/token", RequireAdmin, AuthController.GoRouter.ImportToken);
+AuthRouter.post("/auth/gorouter/token", RequireAdmin, AuthController.GoRouter.ImportToken);
 
-authRoute.post("/auth/bluesminds/token", RequireAdmin, AuthController.BluesMinds.ImportToken);
+AuthRouter.post("/auth/bluesminds/token", RequireAdmin, AuthController.BluesMinds.ImportToken);
 
-authRoute.post("/auth/seekai/token", RequireAdmin, AuthController.SeekAI.ImportToken);
+AuthRouter.post("/auth/seekai/token", RequireAdmin, AuthController.SeekAI.ImportToken);
 
-authRoute.post("/auth/tabitoken/token", RequireAdmin, AuthController.TabiToken.ImportToken);
+AuthRouter.post("/auth/tabitoken/token", RequireAdmin, AuthController.TabiToken.ImportToken);
 
-authRoute.post("/auth/tokenrouter/token", RequireAdmin, AuthController.TokenRouter.ImportToken);
+AuthRouter.post("/auth/tokenrouter/token", RequireAdmin, AuthController.TokenRouter.ImportToken);
 
-authRoute.get("/auth/codebuddy/login", RequireAdmin, AuthController.CodeBuddy.OAuth);
-authRoute.get("/auth/codebuddy/poll", RequireAdmin, AuthController.CodeBuddy.Poll);
-authRoute.post("/auth/codebuddy/poll", RequireAdmin, AuthController.CodeBuddy.Poll);
-authRoute.post("/auth/codebuddy/token", RequireAdmin, AuthController.CodeBuddy.ImportToken);
+AuthRouter.get("/auth/codebuddy/login", RequireAdmin, AuthController.CodeBuddy.OAuth);
+AuthRouter.get("/auth/codebuddy/poll", RequireAdmin, AuthController.CodeBuddy.Poll);
+AuthRouter.post("/auth/codebuddy/poll", RequireAdmin, AuthController.CodeBuddy.Poll);
+AuthRouter.post("/auth/codebuddy/token", RequireAdmin, AuthController.CodeBuddy.ImportToken);
 
-authRoute.get("/auth/codebuddy-cn/login", RequireAdmin, AuthController.CodeBuddyCN.OAuth);
-authRoute.get("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.CodeBuddyCN.Poll);
-authRoute.post("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.CodeBuddyCN.Poll);
-authRoute.post("/auth/codebuddy-cn/token", RequireAdmin, AuthController.CodeBuddyCN.ImportToken);
+AuthRouter.get("/auth/codebuddy-cn/login", RequireAdmin, AuthController.CodeBuddyCN.OAuth);
+AuthRouter.get("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.CodeBuddyCN.Poll);
+AuthRouter.post("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.CodeBuddyCN.Poll);
+AuthRouter.post("/auth/codebuddy-cn/token", RequireAdmin, AuthController.CodeBuddyCN.ImportToken);
 
-authRoute.get("/auth/qoder/login", RequireAdmin, AuthController.Qoder.OAuth);
-authRoute.get("/auth/qoder/callback", AuthController.Qoder.Callback);
-authRoute.post("/auth/qoder/callback", AuthController.Qoder.Callback);
-authRoute.get("/auth/qoder/poll", RequireAdmin, AuthController.Qoder.Poll);
-authRoute.post("/auth/qoder/poll", RequireAdmin, AuthController.Qoder.Poll);
-authRoute.post("/auth/qoder/token", RequireAdmin, AuthController.Qoder.ImportToken);
+AuthRouter.get("/auth/qoder/login", RequireAdmin, AuthController.Qoder.OAuth);
+AuthRouter.get("/auth/qoder/callback", AuthController.Qoder.Callback);
+AuthRouter.post("/auth/qoder/callback", AuthController.Qoder.Callback);
+AuthRouter.get("/auth/qoder/poll", RequireAdmin, AuthController.Qoder.Poll);
+AuthRouter.post("/auth/qoder/poll", RequireAdmin, AuthController.Qoder.Poll);
+AuthRouter.post("/auth/qoder/token", RequireAdmin, AuthController.Qoder.ImportToken);

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -13,52 +13,40 @@ authRoute.get("/auth/openai/login", adminAuth, AuthController.loginOpenAI);
 authRoute.get("/auth/openai/callback", AuthController.handleOAuthCallback);
 authRoute.post("/auth/openai/callback", AuthController.handleOAuthCallback);
 authRoute.post("/auth/openai/token", adminAuth, AuthController.importToken);
-authRoute.post("/auth/openai/import-token", adminAuth, AuthController.importToken);
 
 authRoute.get("/auth/antigravity/login", adminAuth, AuthController.loginAntigravity);
 authRoute.get("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
 authRoute.post("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
 authRoute.post("/auth/antigravity/token", adminAuth, AuthController.importAntigravityToken);
-authRoute.post("/auth/antigravity/import-token", adminAuth, AuthController.importAntigravityToken);
 
 authRoute.post("/auth/commandcode/token", adminAuth, AuthController.importCommandCodeToken);
-authRoute.post("/auth/commandcode/import-token", adminAuth, AuthController.importCommandCodeToken);
 
 authRoute.post("/auth/anthropic/token", adminAuth, AuthController.importAnthropicToken);
-authRoute.post("/auth/anthropic/import-token", adminAuth, AuthController.importAnthropicToken);
 
 authRoute.get("/auth/claude/login", adminAuth, AuthController.loginClaude);
 authRoute.get("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
 authRoute.post("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
 authRoute.post("/auth/claude/token", adminAuth, AuthController.importClaudeToken);
-authRoute.post("/auth/claude/import-token", adminAuth, AuthController.importClaudeToken);
 
 authRoute.post("/auth/gorouter/token", adminAuth, AuthController.importGoRouterToken);
-authRoute.post("/auth/gorouter/import-token", adminAuth, AuthController.importGoRouterToken);
 
 authRoute.post("/auth/bluesminds/token", adminAuth, AuthController.importBluesMindsToken);
-authRoute.post("/auth/bluesminds/import-token", adminAuth, AuthController.importBluesMindsToken);
 
 authRoute.post("/auth/seekai/token", adminAuth, AuthController.importSeekAIToken);
-authRoute.post("/auth/seekai/import-token", adminAuth, AuthController.importSeekAIToken);
 
 authRoute.post("/auth/tabitoken/token", adminAuth, AuthController.importTabiTokenToken);
-authRoute.post("/auth/tabitoken/import-token", adminAuth, AuthController.importTabiTokenToken);
 
 authRoute.post("/auth/tokenrouter/token", adminAuth, AuthController.importTokenRouterToken);
-authRoute.post("/auth/tokenrouter/import-token", adminAuth, AuthController.importTokenRouterToken);
 
 authRoute.get("/auth/codebuddy/login", adminAuth, AuthController.loginCodeBuddy);
 authRoute.get("/auth/codebuddy/poll", adminAuth, AuthController.pollCodeBuddy);
 authRoute.post("/auth/codebuddy/poll", adminAuth, AuthController.pollCodeBuddy);
 authRoute.post("/auth/codebuddy/token", adminAuth, AuthController.importCodeBuddyToken);
-authRoute.post("/auth/codebuddy/import-token", adminAuth, AuthController.importCodeBuddyToken);
 
 authRoute.get("/auth/codebuddy-cn/login", adminAuth, AuthController.loginCodeBuddyCN);
 authRoute.get("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
 authRoute.post("/auth/codebuddy-cn/poll", adminAuth, AuthController.pollCodeBuddyCN);
 authRoute.post("/auth/codebuddy-cn/token", adminAuth, AuthController.importCodeBuddyCNToken);
-authRoute.post("/auth/codebuddy-cn/import-token", adminAuth, AuthController.importCodeBuddyCNToken);
 
 authRoute.get("/auth/qoder/login", adminAuth, AuthController.loginQoder);
 authRoute.get("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
@@ -66,4 +54,3 @@ authRoute.post("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
 authRoute.get("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
 authRoute.post("/auth/qoder/poll", adminAuth, AuthController.pollQoder);
 authRoute.post("/auth/qoder/token", adminAuth, AuthController.importQoderToken);
-authRoute.post("/auth/qoder/import-token", adminAuth, AuthController.importQoderToken);

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { AuthController } from "@/controllers/auth.controller.js";
-import { requireAdmin } from "@/middleware/adminAuth.js";
+import { RequireAdmin } from "@/middleware/adminAuth.js";
 
 export const authRoute = new Hono();
 
@@ -9,48 +9,48 @@ export const handleAntigravityOAuthCallback = AuthController.handleAntigravityOA
 export const handleClaudeOAuthCallback = AuthController.handleClaudeOAuthCallback;
 export const handleQoderOAuthCallback = AuthController.handleQoderOAuthCallback;
 
-authRoute.get("/auth/openai/login", requireAdmin, AuthController.loginOpenAI);
+authRoute.get("/auth/openai/login", RequireAdmin, AuthController.loginOpenAI);
 authRoute.get("/auth/openai/callback", AuthController.handleOAuthCallback);
 authRoute.post("/auth/openai/callback", AuthController.handleOAuthCallback);
-authRoute.post("/auth/openai/token", requireAdmin, AuthController.importToken);
+authRoute.post("/auth/openai/token", RequireAdmin, AuthController.importToken);
 
-authRoute.get("/auth/antigravity/login", requireAdmin, AuthController.loginAntigravity);
+authRoute.get("/auth/antigravity/login", RequireAdmin, AuthController.loginAntigravity);
 authRoute.get("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
 authRoute.post("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
-authRoute.post("/auth/antigravity/token", requireAdmin, AuthController.importAntigravityToken);
+authRoute.post("/auth/antigravity/token", RequireAdmin, AuthController.importAntigravityToken);
 
-authRoute.post("/auth/commandcode/token", requireAdmin, AuthController.importCommandCodeToken);
+authRoute.post("/auth/commandcode/token", RequireAdmin, AuthController.importCommandCodeToken);
 
-authRoute.post("/auth/anthropic/token", requireAdmin, AuthController.importAnthropicToken);
+authRoute.post("/auth/anthropic/token", RequireAdmin, AuthController.importAnthropicToken);
 
-authRoute.get("/auth/claude/login", requireAdmin, AuthController.loginClaude);
+authRoute.get("/auth/claude/login", RequireAdmin, AuthController.loginClaude);
 authRoute.get("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
 authRoute.post("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
-authRoute.post("/auth/claude/token", requireAdmin, AuthController.importClaudeToken);
+authRoute.post("/auth/claude/token", RequireAdmin, AuthController.importClaudeToken);
 
-authRoute.post("/auth/gorouter/token", requireAdmin, AuthController.importGoRouterToken);
+authRoute.post("/auth/gorouter/token", RequireAdmin, AuthController.importGoRouterToken);
 
-authRoute.post("/auth/bluesminds/token", requireAdmin, AuthController.importBluesMindsToken);
+authRoute.post("/auth/bluesminds/token", RequireAdmin, AuthController.importBluesMindsToken);
 
-authRoute.post("/auth/seekai/token", requireAdmin, AuthController.importSeekAIToken);
+authRoute.post("/auth/seekai/token", RequireAdmin, AuthController.importSeekAIToken);
 
-authRoute.post("/auth/tabitoken/token", requireAdmin, AuthController.importTabiTokenToken);
+authRoute.post("/auth/tabitoken/token", RequireAdmin, AuthController.importTabiTokenToken);
 
-authRoute.post("/auth/tokenrouter/token", requireAdmin, AuthController.importTokenRouterToken);
+authRoute.post("/auth/tokenrouter/token", RequireAdmin, AuthController.importTokenRouterToken);
 
-authRoute.get("/auth/codebuddy/login", requireAdmin, AuthController.loginCodeBuddy);
-authRoute.get("/auth/codebuddy/poll", requireAdmin, AuthController.pollCodeBuddy);
-authRoute.post("/auth/codebuddy/poll", requireAdmin, AuthController.pollCodeBuddy);
-authRoute.post("/auth/codebuddy/token", requireAdmin, AuthController.importCodeBuddyToken);
+authRoute.get("/auth/codebuddy/login", RequireAdmin, AuthController.loginCodeBuddy);
+authRoute.get("/auth/codebuddy/poll", RequireAdmin, AuthController.pollCodeBuddy);
+authRoute.post("/auth/codebuddy/poll", RequireAdmin, AuthController.pollCodeBuddy);
+authRoute.post("/auth/codebuddy/token", RequireAdmin, AuthController.importCodeBuddyToken);
 
-authRoute.get("/auth/codebuddy-cn/login", requireAdmin, AuthController.loginCodeBuddyCN);
-authRoute.get("/auth/codebuddy-cn/poll", requireAdmin, AuthController.pollCodeBuddyCN);
-authRoute.post("/auth/codebuddy-cn/poll", requireAdmin, AuthController.pollCodeBuddyCN);
-authRoute.post("/auth/codebuddy-cn/token", requireAdmin, AuthController.importCodeBuddyCNToken);
+authRoute.get("/auth/codebuddy-cn/login", RequireAdmin, AuthController.loginCodeBuddyCN);
+authRoute.get("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.pollCodeBuddyCN);
+authRoute.post("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.pollCodeBuddyCN);
+authRoute.post("/auth/codebuddy-cn/token", RequireAdmin, AuthController.importCodeBuddyCNToken);
 
-authRoute.get("/auth/qoder/login", requireAdmin, AuthController.loginQoder);
+authRoute.get("/auth/qoder/login", RequireAdmin, AuthController.loginQoder);
 authRoute.get("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
 authRoute.post("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
-authRoute.get("/auth/qoder/poll", requireAdmin, AuthController.pollQoder);
-authRoute.post("/auth/qoder/poll", requireAdmin, AuthController.pollQoder);
-authRoute.post("/auth/qoder/token", requireAdmin, AuthController.importQoderToken);
+authRoute.get("/auth/qoder/poll", RequireAdmin, AuthController.pollQoder);
+authRoute.post("/auth/qoder/poll", RequireAdmin, AuthController.pollQoder);
+authRoute.post("/auth/qoder/token", RequireAdmin, AuthController.importQoderToken);

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -5,10 +5,11 @@ import { RequireAdmin } from "@/middleware/adminAuth.js";
 export const AuthRouter = new Hono();
 export const authRoute = AuthRouter;
 
-export const handleOAuthCallback = AuthController.OpenAI.Callback;
-export const handleAntigravityOAuthCallback = AuthController.Antigravity.Callback;
-export const handleClaudeOAuthCallback = AuthController.Claude.Callback;
-export const handleQoderOAuthCallback = AuthController.Qoder.Callback;
+export const CodexOAuthCallback = AuthController.OpenAI.Callback;
+export const OpenAIAuthCallback = CodexOAuthCallback;
+export const AntigravityOAuthCallback = AuthController.Antigravity.Callback;
+export const ClaudeOAuthCallback = AuthController.Claude.Callback;
+export const QoderOAuthCallback = AuthController.Qoder.Callback;
 
 AuthRouter.get("/auth/openai/login", RequireAdmin, AuthController.OpenAI.OAuth);
 AuthRouter.get("/auth/openai/callback", AuthController.OpenAI.Callback);

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -4,53 +4,53 @@ import { RequireAdmin } from "@/middleware/adminAuth.js";
 
 export const authRoute = new Hono();
 
-export const handleOAuthCallback = AuthController.handleOAuthCallback;
-export const handleAntigravityOAuthCallback = AuthController.handleAntigravityOAuthCallback;
-export const handleClaudeOAuthCallback = AuthController.handleClaudeOAuthCallback;
-export const handleQoderOAuthCallback = AuthController.handleQoderOAuthCallback;
+export const handleOAuthCallback = AuthController.OpenAI.Callback;
+export const handleAntigravityOAuthCallback = AuthController.Antigravity.Callback;
+export const handleClaudeOAuthCallback = AuthController.Claude.Callback;
+export const handleQoderOAuthCallback = AuthController.Qoder.Callback;
 
-authRoute.get("/auth/openai/login", RequireAdmin, AuthController.loginOpenAI);
-authRoute.get("/auth/openai/callback", AuthController.handleOAuthCallback);
-authRoute.post("/auth/openai/callback", AuthController.handleOAuthCallback);
-authRoute.post("/auth/openai/token", RequireAdmin, AuthController.importToken);
+authRoute.get("/auth/openai/login", RequireAdmin, AuthController.OpenAI.OAuth);
+authRoute.get("/auth/openai/callback", AuthController.OpenAI.Callback);
+authRoute.post("/auth/openai/callback", AuthController.OpenAI.Callback);
+authRoute.post("/auth/openai/token", RequireAdmin, AuthController.OpenAI.ImportToken);
 
-authRoute.get("/auth/antigravity/login", RequireAdmin, AuthController.loginAntigravity);
-authRoute.get("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
-authRoute.post("/auth/antigravity/callback", AuthController.handleAntigravityOAuthCallback);
-authRoute.post("/auth/antigravity/token", RequireAdmin, AuthController.importAntigravityToken);
+authRoute.get("/auth/antigravity/login", RequireAdmin, AuthController.Antigravity.OAuth);
+authRoute.get("/auth/antigravity/callback", AuthController.Antigravity.Callback);
+authRoute.post("/auth/antigravity/callback", AuthController.Antigravity.Callback);
+authRoute.post("/auth/antigravity/token", RequireAdmin, AuthController.Antigravity.ImportToken);
 
-authRoute.post("/auth/commandcode/token", RequireAdmin, AuthController.importCommandCodeToken);
+authRoute.post("/auth/commandcode/token", RequireAdmin, AuthController.CommandCode.ImportToken);
 
-authRoute.post("/auth/anthropic/token", RequireAdmin, AuthController.importAnthropicToken);
+authRoute.post("/auth/anthropic/token", RequireAdmin, AuthController.Anthropic.ImportToken);
 
-authRoute.get("/auth/claude/login", RequireAdmin, AuthController.loginClaude);
-authRoute.get("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
-authRoute.post("/auth/claude/callback", AuthController.handleClaudeOAuthCallback);
-authRoute.post("/auth/claude/token", RequireAdmin, AuthController.importClaudeToken);
+authRoute.get("/auth/claude/login", RequireAdmin, AuthController.Claude.OAuth);
+authRoute.get("/auth/claude/callback", AuthController.Claude.Callback);
+authRoute.post("/auth/claude/callback", AuthController.Claude.Callback);
+authRoute.post("/auth/claude/token", RequireAdmin, AuthController.Claude.ImportToken);
 
-authRoute.post("/auth/gorouter/token", RequireAdmin, AuthController.importGoRouterToken);
+authRoute.post("/auth/gorouter/token", RequireAdmin, AuthController.GoRouter.ImportToken);
 
-authRoute.post("/auth/bluesminds/token", RequireAdmin, AuthController.importBluesMindsToken);
+authRoute.post("/auth/bluesminds/token", RequireAdmin, AuthController.BluesMinds.ImportToken);
 
-authRoute.post("/auth/seekai/token", RequireAdmin, AuthController.importSeekAIToken);
+authRoute.post("/auth/seekai/token", RequireAdmin, AuthController.SeekAI.ImportToken);
 
-authRoute.post("/auth/tabitoken/token", RequireAdmin, AuthController.importTabiTokenToken);
+authRoute.post("/auth/tabitoken/token", RequireAdmin, AuthController.TabiToken.ImportToken);
 
-authRoute.post("/auth/tokenrouter/token", RequireAdmin, AuthController.importTokenRouterToken);
+authRoute.post("/auth/tokenrouter/token", RequireAdmin, AuthController.TokenRouter.ImportToken);
 
-authRoute.get("/auth/codebuddy/login", RequireAdmin, AuthController.loginCodeBuddy);
-authRoute.get("/auth/codebuddy/poll", RequireAdmin, AuthController.pollCodeBuddy);
-authRoute.post("/auth/codebuddy/poll", RequireAdmin, AuthController.pollCodeBuddy);
-authRoute.post("/auth/codebuddy/token", RequireAdmin, AuthController.importCodeBuddyToken);
+authRoute.get("/auth/codebuddy/login", RequireAdmin, AuthController.CodeBuddy.OAuth);
+authRoute.get("/auth/codebuddy/poll", RequireAdmin, AuthController.CodeBuddy.Poll);
+authRoute.post("/auth/codebuddy/poll", RequireAdmin, AuthController.CodeBuddy.Poll);
+authRoute.post("/auth/codebuddy/token", RequireAdmin, AuthController.CodeBuddy.ImportToken);
 
-authRoute.get("/auth/codebuddy-cn/login", RequireAdmin, AuthController.loginCodeBuddyCN);
-authRoute.get("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.pollCodeBuddyCN);
-authRoute.post("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.pollCodeBuddyCN);
-authRoute.post("/auth/codebuddy-cn/token", RequireAdmin, AuthController.importCodeBuddyCNToken);
+authRoute.get("/auth/codebuddy-cn/login", RequireAdmin, AuthController.CodeBuddyCN.OAuth);
+authRoute.get("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.CodeBuddyCN.Poll);
+authRoute.post("/auth/codebuddy-cn/poll", RequireAdmin, AuthController.CodeBuddyCN.Poll);
+authRoute.post("/auth/codebuddy-cn/token", RequireAdmin, AuthController.CodeBuddyCN.ImportToken);
 
-authRoute.get("/auth/qoder/login", RequireAdmin, AuthController.loginQoder);
-authRoute.get("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
-authRoute.post("/auth/qoder/callback", AuthController.handleQoderOAuthCallback);
-authRoute.get("/auth/qoder/poll", RequireAdmin, AuthController.pollQoder);
-authRoute.post("/auth/qoder/poll", RequireAdmin, AuthController.pollQoder);
-authRoute.post("/auth/qoder/token", RequireAdmin, AuthController.importQoderToken);
+authRoute.get("/auth/qoder/login", RequireAdmin, AuthController.Qoder.OAuth);
+authRoute.get("/auth/qoder/callback", AuthController.Qoder.Callback);
+authRoute.post("/auth/qoder/callback", AuthController.Qoder.Callback);
+authRoute.get("/auth/qoder/poll", RequireAdmin, AuthController.Qoder.Poll);
+authRoute.post("/auth/qoder/poll", RequireAdmin, AuthController.Qoder.Poll);
+authRoute.post("/auth/qoder/token", RequireAdmin, AuthController.Qoder.ImportToken);

--- a/apps/api/src/routes/v1/keys.ts
+++ b/apps/api/src/routes/v1/keys.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { KeysController } from "@/controllers/keys.controller.js";
-import { requireAdmin } from "@/middleware/adminAuth.js";
+import { RequireAdmin } from "@/middleware/adminAuth.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const keysRoute = new Hono();
 
-// GET /v1/keys - List all virtual API keys
+// List API keys
 keysRoute.get("/keys", apiKeyAuth, KeysController.listKeys);
 
 // Mutation endpoints require Admin Auth
-keysRoute.post("/keys", requireAdmin, KeysController.createKey);
-keysRoute.delete("/keys/:id", requireAdmin, KeysController.deleteKey);
+keysRoute.post("/keys", RequireAdmin, KeysController.createKey);
+keysRoute.delete("/keys/:id", RequireAdmin, KeysController.deleteKey);

--- a/apps/api/src/routes/v1/keys.ts
+++ b/apps/api/src/routes/v1/keys.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { KeysController } from "@/controllers/keys.controller.js";
-import { adminAuth } from "@/middleware/adminAuth.js";
+import { requireAdmin } from "@/middleware/adminAuth.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const keysRoute = new Hono();
@@ -9,5 +9,5 @@ export const keysRoute = new Hono();
 keysRoute.get("/keys", apiKeyAuth, KeysController.listKeys);
 
 // Mutation endpoints require Admin Auth
-keysRoute.post("/keys", adminAuth, KeysController.createKey);
-keysRoute.delete("/keys/:id", adminAuth, KeysController.deleteKey);
+keysRoute.post("/keys", requireAdmin, KeysController.createKey);
+keysRoute.delete("/keys/:id", requireAdmin, KeysController.deleteKey);

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { ProvidersController } from "@/controllers/providers.controller.js";
-import { adminAuth } from "@/middleware/adminAuth.js";
+import { requireAdmin } from "@/middleware/adminAuth.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const providersRoute = new Hono();
@@ -15,14 +15,14 @@ providersRoute.get("/providers/catalog", apiKeyAuth, ProvidersController.getCata
 providersRoute.get("/providers/:providerId", apiKeyAuth, ProvidersController.getProvider);
 
 // Mutation endpoints require Admin Auth
-providersRoute.post("/providers/verify", adminAuth, ProvidersController.verifyProvider);
-providersRoute.post("/providers", adminAuth, ProvidersController.addProvider);
-providersRoute.delete("/providers/:id", adminAuth, ProvidersController.deleteProvider);
+providersRoute.post("/providers/verify", requireAdmin, ProvidersController.verifyProvider);
+providersRoute.post("/providers", requireAdmin, ProvidersController.addProvider);
+providersRoute.delete("/providers/:id", requireAdmin, ProvidersController.deleteProvider);
 
 // Custom (user-added) models per provider driver
-providersRoute.post("/providers/:providerId/models", adminAuth, ProvidersController.addCustomModel);
+providersRoute.post("/providers/:providerId/models", requireAdmin, ProvidersController.addCustomModel);
 providersRoute.delete(
     "/providers/:providerId/models/:modelId{.+}",
-    adminAuth,
+    requireAdmin,
     ProvidersController.deleteCustomModel
 );

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -20,7 +20,11 @@ providersRoute.post("/providers", RequireAdmin, ProvidersController.addProvider)
 providersRoute.delete("/providers/:id", RequireAdmin, ProvidersController.deleteProvider);
 
 // Custom (user-added) models per provider driver
-providersRoute.post("/providers/:providerId/models", RequireAdmin, ProvidersController.addCustomModel);
+providersRoute.post(
+    "/providers/:providerId/models",
+    RequireAdmin,
+    ProvidersController.addCustomModel
+);
 providersRoute.delete(
     "/providers/:providerId/models/:modelId{.+}",
     RequireAdmin,

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { ProvidersController } from "@/controllers/providers.controller.js";
-import { requireAdmin } from "@/middleware/adminAuth.js";
+import { RequireAdmin } from "@/middleware/adminAuth.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const providersRoute = new Hono();
@@ -15,14 +15,14 @@ providersRoute.get("/providers/catalog", apiKeyAuth, ProvidersController.getCata
 providersRoute.get("/providers/:providerId", apiKeyAuth, ProvidersController.getProvider);
 
 // Mutation endpoints require Admin Auth
-providersRoute.post("/providers/verify", requireAdmin, ProvidersController.verifyProvider);
-providersRoute.post("/providers", requireAdmin, ProvidersController.addProvider);
-providersRoute.delete("/providers/:id", requireAdmin, ProvidersController.deleteProvider);
+providersRoute.post("/providers/verify", RequireAdmin, ProvidersController.verifyProvider);
+providersRoute.post("/providers", RequireAdmin, ProvidersController.addProvider);
+providersRoute.delete("/providers/:id", RequireAdmin, ProvidersController.deleteProvider);
 
 // Custom (user-added) models per provider driver
-providersRoute.post("/providers/:providerId/models", requireAdmin, ProvidersController.addCustomModel);
+providersRoute.post("/providers/:providerId/models", RequireAdmin, ProvidersController.addCustomModel);
 providersRoute.delete(
     "/providers/:providerId/models/:modelId{.+}",
-    requireAdmin,
+    RequireAdmin,
     ProvidersController.deleteCustomModel
 );

--- a/apps/api/src/routes/v1/settings.ts
+++ b/apps/api/src/routes/v1/settings.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { SettingsController } from "@/controllers/settings.controller.js";
 import { TokenSaverController } from "@/controllers/tokenSaver.controller.js";
 import { FallbacksController } from "@/controllers/fallbacks.controller.js";
-import { requireAdmin } from "@/middleware/adminAuth.js";
+import { RequireAdmin } from "@/middleware/adminAuth.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const settingsRoute = new Hono();
@@ -13,12 +13,12 @@ settingsRoute.get("/settings/token-saver", apiKeyAuth, TokenSaverController.getS
 settingsRoute.get("/settings/fallbacks", apiKeyAuth, FallbacksController.getFallbacks);
 
 // Mutations require an authenticated admin session
-settingsRoute.patch("/settings", requireAdmin, SettingsController.updateSettings);
-settingsRoute.post("/settings", requireAdmin, SettingsController.updateSettings);
-settingsRoute.patch("/settings/token-saver", requireAdmin, TokenSaverController.updateSettings);
-settingsRoute.put("/settings/token-saver", requireAdmin, TokenSaverController.updateSettings);
-settingsRoute.post("/settings/token-saver/test", requireAdmin, TokenSaverController.preview);
-settingsRoute.post("/settings/fallbacks", requireAdmin, FallbacksController.createFallback);
-settingsRoute.put("/settings/fallbacks/:id", requireAdmin, FallbacksController.updateFallback);
-settingsRoute.patch("/settings/fallbacks/:id", requireAdmin, FallbacksController.updateFallback);
-settingsRoute.delete("/settings/fallbacks/:id", requireAdmin, FallbacksController.deleteFallback);
+settingsRoute.patch("/settings", RequireAdmin, SettingsController.updateSettings);
+settingsRoute.post("/settings", RequireAdmin, SettingsController.updateSettings);
+settingsRoute.patch("/settings/token-saver", RequireAdmin, TokenSaverController.updateSettings);
+settingsRoute.put("/settings/token-saver", RequireAdmin, TokenSaverController.updateSettings);
+settingsRoute.post("/settings/token-saver/test", RequireAdmin, TokenSaverController.preview);
+settingsRoute.post("/settings/fallbacks", RequireAdmin, FallbacksController.createFallback);
+settingsRoute.put("/settings/fallbacks/:id", RequireAdmin, FallbacksController.updateFallback);
+settingsRoute.patch("/settings/fallbacks/:id", RequireAdmin, FallbacksController.updateFallback);
+settingsRoute.delete("/settings/fallbacks/:id", RequireAdmin, FallbacksController.deleteFallback);

--- a/apps/api/src/routes/v1/settings.ts
+++ b/apps/api/src/routes/v1/settings.ts
@@ -1,24 +1,24 @@
 import { Hono } from "hono";
-import { FallbacksController } from "@/controllers/fallbacks.controller.js";
 import { SettingsController } from "@/controllers/settings.controller.js";
 import { TokenSaverController } from "@/controllers/tokenSaver.controller.js";
-import { adminAuth } from "@/middleware/adminAuth.js";
+import { FallbacksController } from "@/controllers/fallbacks.controller.js";
+import { requireAdmin } from "@/middleware/adminAuth.js";
 import { apiKeyAuth } from "@/middleware/apiKeyAuth.js";
 
 export const settingsRoute = new Hono();
 
-// Read Endpoints (allow via apiKeyAuth / local auth-free)
+// GET routes accept either an API key or an active admin session
 settingsRoute.get("/settings", apiKeyAuth, SettingsController.getSettings);
 settingsRoute.get("/settings/token-saver", apiKeyAuth, TokenSaverController.getSettings);
 settingsRoute.get("/settings/fallbacks", apiKeyAuth, FallbacksController.getFallbacks);
 
-// Mutation Endpoints (require Admin Auth)
-settingsRoute.patch("/settings", adminAuth, SettingsController.updateSettings);
-settingsRoute.post("/settings", adminAuth, SettingsController.updateSettings);
-settingsRoute.patch("/settings/token-saver", adminAuth, TokenSaverController.updateSettings);
-settingsRoute.put("/settings/token-saver", adminAuth, TokenSaverController.updateSettings);
-settingsRoute.post("/settings/token-saver/test", adminAuth, TokenSaverController.preview);
-settingsRoute.post("/settings/fallbacks", adminAuth, FallbacksController.createFallback);
-settingsRoute.put("/settings/fallbacks/:id", adminAuth, FallbacksController.updateFallback);
-settingsRoute.patch("/settings/fallbacks/:id", adminAuth, FallbacksController.updateFallback);
-settingsRoute.delete("/settings/fallbacks/:id", adminAuth, FallbacksController.deleteFallback);
+// Mutations require an authenticated admin session
+settingsRoute.patch("/settings", requireAdmin, SettingsController.updateSettings);
+settingsRoute.post("/settings", requireAdmin, SettingsController.updateSettings);
+settingsRoute.patch("/settings/token-saver", requireAdmin, TokenSaverController.updateSettings);
+settingsRoute.put("/settings/token-saver", requireAdmin, TokenSaverController.updateSettings);
+settingsRoute.post("/settings/token-saver/test", requireAdmin, TokenSaverController.preview);
+settingsRoute.post("/settings/fallbacks", requireAdmin, FallbacksController.createFallback);
+settingsRoute.put("/settings/fallbacks/:id", requireAdmin, FallbacksController.updateFallback);
+settingsRoute.patch("/settings/fallbacks/:id", requireAdmin, FallbacksController.updateFallback);
+settingsRoute.delete("/settings/fallbacks/:id", requireAdmin, FallbacksController.deleteFallback);

--- a/apps/api/src/services/authHandlers.ts
+++ b/apps/api/src/services/authHandlers.ts
@@ -39,7 +39,7 @@ import {
 } from "@srouter/providers";
 import type { AuthProviderHandler } from "@srouter/types";
 
-export const openaiCodexAuthHandler: AuthProviderHandler = {
+const openaiCodex: AuthProviderHandler = {
     providerId: "openai_codex",
     displayName: "OpenAI Codex",
     category: "oauth",
@@ -66,7 +66,7 @@ export const openaiCodexAuthHandler: AuthProviderHandler = {
         new CodexExecutor({ id, name, accessToken, refreshToken, accountId })
 };
 
-export const antigravityAuthHandler: AuthProviderHandler = {
+const antigravity: AuthProviderHandler = {
     providerId: "antigravity",
     displayName: "Antigravity",
     category: "oauth",
@@ -93,7 +93,7 @@ export const antigravityAuthHandler: AuthProviderHandler = {
         new AntigravityExecutor({ id, name, baseUrl, accessToken, refreshToken })
 };
 
-export const commandCodeAuthHandler: AuthProviderHandler = {
+const commandCode: AuthProviderHandler = {
     providerId: "commandcode",
     displayName: "Command Code",
     category: "api_key",
@@ -111,7 +111,7 @@ export const commandCodeAuthHandler: AuthProviderHandler = {
         new CommandCodeExecutor({ id, name, baseUrl, apiKey })
 };
 
-export const anthropicAuthHandler: AuthProviderHandler = {
+const anthropic: AuthProviderHandler = {
     providerId: "anthropic",
     displayName: "Anthropic",
     category: "api_key",
@@ -129,7 +129,7 @@ export const anthropicAuthHandler: AuthProviderHandler = {
         new AnthropicExecutor({ id, name, baseUrl, apiKey })
 };
 
-export const claudeAuthHandler: AuthProviderHandler = {
+const claude: AuthProviderHandler = {
     providerId: "claude",
     displayName: "Claude Code",
     category: "oauth",
@@ -154,7 +154,7 @@ export const claudeAuthHandler: AuthProviderHandler = {
         new AnthropicExecutor({ id, name, accessToken, refreshToken, organizationId })
 };
 
-export const qoderAuthHandler: AuthProviderHandler = {
+const qoder: AuthProviderHandler = {
     providerId: "qoder",
     displayName: "Qoder",
     category: "oauth",
@@ -180,7 +180,7 @@ export const qoderAuthHandler: AuthProviderHandler = {
         new QoderExecutor({ id, name, baseUrl, apiKey, accessToken, refreshToken })
 };
 
-export const goRouterAuthHandler: AuthProviderHandler = {
+const goRouter: AuthProviderHandler = {
     providerId: "gorouter",
     displayName: "GoRouter",
     category: "api_key",
@@ -198,7 +198,7 @@ export const goRouterAuthHandler: AuthProviderHandler = {
         new GoRouterExecutor({ id, name, baseUrl: baseUrl || GOROUTER_BASE_URL, apiKey })
 };
 
-export const bluesMindsAuthHandler: AuthProviderHandler = {
+const bluesMinds: AuthProviderHandler = {
     providerId: "bluesminds",
     displayName: "BluesMinds",
     category: "api_key",
@@ -216,7 +216,7 @@ export const bluesMindsAuthHandler: AuthProviderHandler = {
         new BluesMindsExecutor({ id, name, baseUrl: baseUrl || BLUESMINDS_BASE_URL, apiKey })
 };
 
-export const seekAIAuthHandler: AuthProviderHandler = {
+const seekAI: AuthProviderHandler = {
     providerId: "seekai",
     displayName: "SeekAI",
     category: "api_key",
@@ -234,7 +234,7 @@ export const seekAIAuthHandler: AuthProviderHandler = {
         new SeekAIExecutor({ id, name, baseUrl: baseUrl || SEEKAI_BASE_URL, apiKey })
 };
 
-export const tabiTokenAuthHandler: AuthProviderHandler = {
+const tabiToken: AuthProviderHandler = {
     providerId: "tabitoken",
     displayName: "TabiToken",
     category: "api_key",
@@ -252,7 +252,7 @@ export const tabiTokenAuthHandler: AuthProviderHandler = {
         new TabiTokenExecutor({ id, name, baseUrl: baseUrl || TABITOKEN_BASE_URL, apiKey })
 };
 
-export const tokenRouterAuthHandler: AuthProviderHandler = {
+const tokenRouter: AuthProviderHandler = {
     providerId: "tokenrouter",
     displayName: "TokenRouter",
     category: "api_key",
@@ -270,7 +270,7 @@ export const tokenRouterAuthHandler: AuthProviderHandler = {
         new TokenRouterExecutor({ id, name, baseUrl: baseUrl || TOKENROUTER_BASE_URL, apiKey })
 };
 
-export const codeBuddyAuthHandler: AuthProviderHandler = {
+const codeBuddy: AuthProviderHandler = {
     providerId: "codebuddy",
     displayName: "CodeBuddy",
     category: "oauth",
@@ -299,7 +299,7 @@ export const codeBuddyAuthHandler: AuthProviderHandler = {
         })
 };
 
-export const codeBuddyCNAuthHandler: AuthProviderHandler = {
+const codeBuddyCN: AuthProviderHandler = {
     providerId: "codebuddy-cn",
     displayName: "CodeBuddy CN",
     category: "oauth",
@@ -310,8 +310,8 @@ export const codeBuddyCNAuthHandler: AuthProviderHandler = {
     tokenImportMessage:
         "CodeBuddy CN Access Token registered and saved directly to SQLite database!",
     oauthClass: CodeBuddyCNOAuth,
-    mapOAuthTokens: codeBuddyAuthHandler.mapOAuthTokens,
-    mapImportTokens: codeBuddyAuthHandler.mapImportTokens,
+    mapOAuthTokens: codeBuddy.mapOAuthTokens,
+    mapImportTokens: codeBuddy.mapImportTokens,
     buildExecutor: ({ id, name, baseUrl, accessToken, apiKey }) =>
         new CodeBuddyExecutor({
             id,
@@ -325,18 +325,34 @@ export const codeBuddyCNAuthHandler: AuthProviderHandler = {
         })
 };
 
+export const AuthHandlers = {
+    OpenAI: openaiCodex,
+    Antigravity: antigravity,
+    CommandCode: commandCode,
+    Anthropic: anthropic,
+    Claude: claude,
+    Qoder: qoder,
+    GoRouter: goRouter,
+    BluesMinds: bluesMinds,
+    SeekAI: seekAI,
+    TabiToken: tabiToken,
+    TokenRouter: tokenRouter,
+    CodeBuddy: codeBuddy,
+    CodeBuddyCN: codeBuddyCN
+} as const;
+
 export const authProviderHandlers: Record<string, AuthProviderHandler> = {
-    openai_codex: openaiCodexAuthHandler,
-    antigravity: antigravityAuthHandler,
-    commandcode: commandCodeAuthHandler,
-    anthropic: anthropicAuthHandler,
-    claude: claudeAuthHandler,
-    qoder: qoderAuthHandler,
-    gorouter: goRouterAuthHandler,
-    bluesminds: bluesMindsAuthHandler,
-    seekai: seekAIAuthHandler,
-    tabitoken: tabiTokenAuthHandler,
-    tokenrouter: tokenRouterAuthHandler,
-    codebuddy: codeBuddyAuthHandler,
-    "codebuddy-cn": codeBuddyCNAuthHandler
+    openai_codex: AuthHandlers.OpenAI,
+    antigravity: AuthHandlers.Antigravity,
+    commandcode: AuthHandlers.CommandCode,
+    anthropic: AuthHandlers.Anthropic,
+    claude: AuthHandlers.Claude,
+    qoder: AuthHandlers.Qoder,
+    gorouter: AuthHandlers.GoRouter,
+    bluesminds: AuthHandlers.BluesMinds,
+    seekai: AuthHandlers.SeekAI,
+    tabitoken: AuthHandlers.TabiToken,
+    tokenrouter: AuthHandlers.TokenRouter,
+    codebuddy: AuthHandlers.CodeBuddy,
+    "codebuddy-cn": AuthHandlers.CodeBuddyCN
 };

--- a/apps/api/src/services/authHandlers.ts
+++ b/apps/api/src/services/authHandlers.ts
@@ -37,27 +37,7 @@ import {
     OpenAICodexOAuth,
     QoderOAuth
 } from "@srouter/providers";
-import type {
-    AuthProviderHandler,
-    ExecutorFactory,
-    ImportTokenMapping,
-    OAuthClientClass,
-    OAuthLoginParams,
-    OAuthLoginResult,
-    OAuthTokens,
-    TokenImportParams
-} from "@srouter/types";
-
-export type {
-    AuthProviderHandler,
-    ExecutorFactory,
-    ImportTokenMapping,
-    OAuthClientClass,
-    OAuthLoginParams,
-    OAuthLoginResult,
-    OAuthTokens,
-    TokenImportParams
-};
+import type { AuthProviderHandler } from "@srouter/types";
 
 export const openaiCodexAuthHandler: AuthProviderHandler = {
     providerId: "openai_codex",
@@ -65,7 +45,6 @@ export const openaiCodexAuthHandler: AuthProviderHandler = {
     category: "oauth",
     protocol: "openai",
     idPrefix: "openai_codex",
-    // Matches the original logic: Codex client id is hardcoded (the env var is only read by the OAuth class itself).
     clientId: () => CODEX_OAUTH_CLIENT_ID,
     defaultRedirectUri: CODEX_OAUTH_REDIRECT_URI,
     oauthSuccessMessage: "Login OpenAI Codex Berhasil!",

--- a/apps/api/src/services/tokenRefresh.ts
+++ b/apps/api/src/services/tokenRefresh.ts
@@ -1,7 +1,7 @@
 import { providerTypeForAlias } from "@srouter/constants";
 import { getAllProvidersDB, updateProviderTokensDB, getProviderByIdDB } from "@srouter/db";
 import type { AIProvider, ProviderConfig } from "@srouter/types";
-import { authProviderHandlers } from "@/logic/auth.providers.js";
+import { authProviderHandlers } from "@/services/authHandlers.js";
 import { registry } from "./registry.js";
 
 // Refresh tokens before they expire — lead time in ms

--- a/apps/api/tests/auth-providers.test.ts
+++ b/apps/api/tests/auth-providers.test.ts
@@ -8,7 +8,7 @@ import {
     commandCodeAuthHandler,
     openaiCodexAuthHandler,
     type AuthProviderHandler
-} from "../src/logic/auth.providers.js";
+} from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 

--- a/apps/api/tests/auth-providers.test.ts
+++ b/apps/api/tests/auth-providers.test.ts
@@ -4,11 +4,8 @@ import { deleteProviderDB, getProviderByIdDB } from "@srouter/db";
 import type { AIProvider, ProviderConfig } from "@srouter/types";
 import { registry } from "../src/services/registry.js";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import {
-    commandCodeAuthHandler,
-    openaiCodexAuthHandler,
-    type AuthProviderHandler
-} from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
+import type { AuthProviderHandler } from "@srouter/types";
 
 const createdIds: string[] = [];
 
@@ -70,15 +67,15 @@ test("generic logic (initiatePKCEFor) produces an authorizeUrl with expected sta
 });
 
 test("auth provider handlers carry preserved per-provider messages", () => {
-    assert.equal(openaiCodexAuthHandler.oauthSuccessMessage, "Login OpenAI Codex Berhasil!");
+    assert.equal(AuthHandlers.OpenAI.oauthSuccessMessage, "Login OpenAI Codex Berhasil!");
     assert.equal(
-        commandCodeAuthHandler.tokenImportMessage,
+        AuthHandlers.CommandCode.tokenImportMessage,
         "Command Code API Key registered and saved directly to SQLite database!"
     );
 });
 
 test("processTokenImportFor honors provided id and name", () => {
-    const handler: AuthProviderHandler = openaiCodexAuthHandler;
+    const handler: AuthProviderHandler = AuthHandlers.OpenAI;
     // Uses AuthLogic.processTokenImport (Codex handler) with explicit id/name
     const config = AuthLogic.processTokenImport({
         id: "my-custom-id",

--- a/apps/api/tests/bluesminds-provider.test.ts
+++ b/apps/api/tests/bluesminds-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { bluesMindsAuthHandler } from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;
@@ -67,7 +67,7 @@ test("processBluesMindsTokenImport creates and registers BluesMinds provider con
     assert.equal(config.apiKey, "test-bluesminds-key");
     assert.equal(config.enabled, true);
     assert.equal(
-        bluesMindsAuthHandler.tokenImportMessage,
+        AuthHandlers.BluesMinds.tokenImportMessage,
         "BluesMinds API Key registered and saved directly to SQLite database!"
     );
 });

--- a/apps/api/tests/bluesminds-provider.test.ts
+++ b/apps/api/tests/bluesminds-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { bluesMindsAuthHandler } from "../src/logic/auth.providers.js";
+import { bluesMindsAuthHandler } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;

--- a/apps/api/tests/codebuddy-provider.test.ts
+++ b/apps/api/tests/codebuddy-provider.test.ts
@@ -4,7 +4,7 @@ import { deleteProviderDB, fetchCodeBuddyCNLiveQuota, saveOAuthSessionDB, upsert
 import { CODEBUDDY_CN_BASE_URL, providerById } from "@srouter/constants";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { codeBuddyAuthHandler, codeBuddyCNAuthHandler } from "../src/logic/auth.providers.js";
+import { codeBuddyAuthHandler, codeBuddyCNAuthHandler } from "../src/services/authHandlers.js";
 import { CodeBuddyCNOAuth } from "@srouter/providers";
 import { ProvidersLogic } from "../src/logic/providers.logic.js";
 

--- a/apps/api/tests/codebuddy-provider.test.ts
+++ b/apps/api/tests/codebuddy-provider.test.ts
@@ -4,7 +4,7 @@ import { deleteProviderDB, fetchCodeBuddyCNLiveQuota, saveOAuthSessionDB, upsert
 import { CODEBUDDY_CN_BASE_URL, providerById } from "@srouter/constants";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { codeBuddyAuthHandler, codeBuddyCNAuthHandler } from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
 import { CodeBuddyCNOAuth } from "@srouter/providers";
 import { ProvidersLogic } from "../src/logic/providers.logic.js";
 
@@ -61,7 +61,7 @@ test("processCodeBuddyTokenImport creates and registers CodeBuddy provider confi
     assert.equal(config.accessToken, "test-codebuddy-key");
     assert.equal(config.enabled, true);
     assert.equal(
-        codeBuddyAuthHandler.tokenImportMessage,
+        AuthHandlers.CodeBuddy.tokenImportMessage,
         "CodeBuddy Access Token registered and saved directly to SQLite database!"
     );
 });
@@ -90,7 +90,7 @@ test("CodeBuddy CN token import creates a CN provider connection", () => {
     assert.equal(config.baseUrl, CODEBUDDY_CN_BASE_URL);
     assert.equal(config.accessToken, "test-codebuddy-cn-token");
     assert.equal(
-        codeBuddyCNAuthHandler.tokenImportMessage,
+        AuthHandlers.CodeBuddyCN.tokenImportMessage,
         "CodeBuddy CN Access Token registered and saved directly to SQLite database!"
     );
 });

--- a/apps/api/tests/gorouter-provider.test.ts
+++ b/apps/api/tests/gorouter-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { goRouterAuthHandler } from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;
@@ -67,7 +67,7 @@ test("processGoRouterTokenImport creates and registers GoRouter provider config"
     assert.equal(config.apiKey, "test-gorouter-key");
     assert.equal(config.enabled, true);
     assert.equal(
-        goRouterAuthHandler.tokenImportMessage,
+        AuthHandlers.GoRouter.tokenImportMessage,
         "GoRouter API Key registered and saved directly to SQLite database!"
     );
 });

--- a/apps/api/tests/gorouter-provider.test.ts
+++ b/apps/api/tests/gorouter-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { goRouterAuthHandler } from "../src/logic/auth.providers.js";
+import { goRouterAuthHandler } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;

--- a/apps/api/tests/qoder-provider.test.ts
+++ b/apps/api/tests/qoder-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, getProviderByIdDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { qoderAuthHandler } from "../src/logic/auth.providers.js";
+import { qoderAuthHandler } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;

--- a/apps/api/tests/qoder-provider.test.ts
+++ b/apps/api/tests/qoder-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, getProviderByIdDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { qoderAuthHandler } from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;
@@ -71,7 +71,7 @@ test("initiateQoderOAuthPKCE generates valid Qoder authorization parameters", ()
     assert.ok(authorizeUrl.includes("challenge_method=S256"));
     assert.ok(authorizeUrl.includes(`nonce=${encodeURIComponent(state)}`));
     assert.ok(codeVerifier.length > 0);
-    assert.equal(qoderAuthHandler.oauthSuccessMessage, "Login Qoder Berhasil!");
+    assert.equal(AuthHandlers.Qoder.oauthSuccessMessage, "Login Qoder Berhasil!");
 });
 
 test("pollQoderDeviceToken polls upstream and creates provider when user authorizes", async () => {

--- a/apps/api/tests/seekai-provider.test.ts
+++ b/apps/api/tests/seekai-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { seekAIAuthHandler } from "../src/logic/auth.providers.js";
+import { seekAIAuthHandler } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;

--- a/apps/api/tests/seekai-provider.test.ts
+++ b/apps/api/tests/seekai-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { seekAIAuthHandler } from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;
@@ -67,7 +67,7 @@ test("processSeekAITokenImport creates and registers SeekAI provider config", ()
     assert.equal(config.apiKey, "test-seekai-key");
     assert.equal(config.enabled, true);
     assert.equal(
-        seekAIAuthHandler.tokenImportMessage,
+        AuthHandlers.SeekAI.tokenImportMessage,
         "SeekAI API Key registered and saved directly to SQLite database!"
     );
 });

--- a/apps/api/tests/tabitoken-provider.test.ts
+++ b/apps/api/tests/tabitoken-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { tabiTokenAuthHandler } from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;
@@ -67,7 +67,7 @@ test("processTabiTokenTokenImport creates and registers TabiToken provider confi
     assert.equal(config.apiKey, "test-tabitoken-key");
     assert.equal(config.enabled, true);
     assert.equal(
-        tabiTokenAuthHandler.tokenImportMessage,
+        AuthHandlers.TabiToken.tokenImportMessage,
         "TabiToken API Key registered and saved directly to SQLite database!"
     );
 });

--- a/apps/api/tests/tabitoken-provider.test.ts
+++ b/apps/api/tests/tabitoken-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { tabiTokenAuthHandler } from "../src/logic/auth.providers.js";
+import { tabiTokenAuthHandler } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;

--- a/apps/api/tests/tokenrouter-provider.test.ts
+++ b/apps/api/tests/tokenrouter-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { tokenRouterAuthHandler } from "../src/services/authHandlers.js";
+import { AuthHandlers } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;
@@ -67,7 +67,7 @@ test("processTokenRouterTokenImport creates and registers TokenRouter provider c
     assert.equal(config.apiKey, "test-tokenrouter-key");
     assert.equal(config.enabled, true);
     assert.equal(
-        tokenRouterAuthHandler.tokenImportMessage,
+        AuthHandlers.TokenRouter.tokenImportMessage,
         "TokenRouter API Key registered and saved directly to SQLite database!"
     );
 });

--- a/apps/api/tests/tokenrouter-provider.test.ts
+++ b/apps/api/tests/tokenrouter-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, test } from "node:test";
 import { deleteProviderDB, upsertProviderDB } from "@srouter/db";
 import type { ProviderConfig } from "@srouter/types";
 import { AuthLogic } from "../src/logic/auth.logic.js";
-import { tokenRouterAuthHandler } from "../src/logic/auth.providers.js";
+import { tokenRouterAuthHandler } from "../src/services/authHandlers.js";
 
 const createdIds: string[] = [];
 const originalFetch = globalThis.fetch;

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,96 @@
+import type { AIProvider, ProviderCategory, ProviderProtocol } from "./provider.js";
+
+export interface OAuthLoginParams {
+    clientId?: string;
+    redirectUri?: string;
+    prompt?: string;
+}
+
+export interface OAuthLoginResult {
+    authorizeUrl: string;
+    state: string;
+    codeVerifier: string;
+    redirectUri: string;
+}
+
+export interface TokenImportParams {
+    id?: string;
+    accessToken: string;
+    refreshToken?: string;
+    accountId?: string;
+    baseUrl?: string;
+    name?: string;
+}
+
+export interface OAuthTokens {
+    accessToken: string;
+    refreshToken?: string;
+    accountId?: string;
+    organizationId?: string;
+    expiresIn?: number;
+}
+
+export type ExecutorFactory = (args: {
+    id: string;
+    name: string;
+    accountId?: string;
+    organizationId?: string;
+    baseUrl?: string;
+    apiKey?: string;
+    accessToken?: string;
+    refreshToken?: string;
+}) => AIProvider;
+
+export interface OAuthClientClass {
+    new (options?: { clientId?: string; redirectUri?: string; prompt?: string }): {
+        getAuthorizationUrl(pkce: { codeChallenge: string; state: string }): string;
+        exchangeCodeForTokens(code: string, codeVerifier: string): Promise<OAuthTokens>;
+        refreshTokens(refreshToken: string): Promise<OAuthTokens>;
+    };
+}
+
+export interface ImportTokenMapping {
+    accessToken?: string;
+    refreshToken?: string;
+    accountId?: string;
+    organizationId?: string;
+    baseUrl?: string;
+    apiKey?: string;
+}
+
+export interface AuthProviderHandler {
+    providerId: string;
+    displayName: string;
+    category: ProviderCategory;
+    protocol: ProviderProtocol;
+    idPrefix: string;
+    clientId?: () => string | undefined;
+    defaultRedirectUri?: string;
+    baseUrl?: () => string | undefined;
+    oauthSuccessMessage: string;
+    tokenImportMessage: string;
+    mapOAuthTokens?: (tokens: OAuthTokens) => {
+        accessToken: string;
+        refreshToken?: string;
+        accountId?: string;
+        organizationId?: string;
+        expiresIn?: number;
+        baseUrl?: string;
+    };
+    mapImportTokens?: (params: TokenImportParams) => ImportTokenMapping;
+    buildExecutor: ExecutorFactory;
+    oauthClass?: OAuthClientClass;
+}
+
+export interface OAuthCallbackBody {
+    code?: string;
+    state?: string;
+    callbackUrl?: string;
+}
+
+export interface TokenImportBody {
+    accessToken: string;
+    refreshToken?: string;
+    baseUrl?: string;
+    name?: string;
+}

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -41,13 +41,35 @@ export type ExecutorFactory = (args: {
     refreshToken?: string;
 }) => AIProvider;
 
+export interface OAuthClientOptions {
+    clientId?: string;
+    clientSecret?: string;
+    redirectUri?: string;
+    scope?: string;
+    authorizeUrl?: string;
+    tokenUrl?: string;
+    prompt?: string;
+    stateUrl?: string;
+    refreshUrl?: string;
+    loginUrl?: string;
+    deviceTokenUrl?: string;
+    userInfoUrl?: string;
+    platform?: string;
+    userAgent?: string;
+    origin?: string;
+    domain?: string;
+    ioa?: boolean;
+    refreshBearer?: boolean;
+}
+
+export interface OAuthClientInstance {
+    getAuthorizationUrl?(pkce: { codeChallenge: string; state: string }): string;
+    exchangeCodeForTokens?(code: string, codeVerifier: string): Promise<OAuthTokens>;
+    refreshTokens?(refreshToken: string): Promise<OAuthTokens>;
+}
+
 export interface OAuthClientClass {
-    new (options?: any): {
-        getAuthorizationUrl?(pkce: { codeChallenge: string; state: string }): string;
-        exchangeCodeForTokens?(code: string, codeVerifier: string): Promise<OAuthTokens>;
-        refreshTokens?(refreshToken: string): Promise<OAuthTokens>;
-        [key: string]: any;
-    };
+    new (options?: OAuthClientOptions): OAuthClientInstance;
 }
 
 export interface ImportTokenMapping {

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -112,7 +112,7 @@ export interface OAuthCallbackBody {
 }
 
 export interface TokenImportBody {
-    accessToken: string;
+    accessToken?: string;
     refreshToken?: string;
     baseUrl?: string;
     name?: string;

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -42,10 +42,11 @@ export type ExecutorFactory = (args: {
 }) => AIProvider;
 
 export interface OAuthClientClass {
-    new (options?: { clientId?: string; redirectUri?: string; prompt?: string }): {
-        getAuthorizationUrl(pkce: { codeChallenge: string; state: string }): string;
-        exchangeCodeForTokens(code: string, codeVerifier: string): Promise<OAuthTokens>;
-        refreshTokens(refreshToken: string): Promise<OAuthTokens>;
+    new (options?: any): {
+        getAuthorizationUrl?(pkce: { codeChallenge: string; state: string }): string;
+        exchangeCodeForTokens?(code: string, codeVerifier: string): Promise<OAuthTokens>;
+        refreshTokens?(refreshToken: string): Promise<OAuthTokens>;
+        [key: string]: any;
     };
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -7,3 +7,4 @@ export * from "./logs.js";
 export * from "./apiKeys.js";
 export * from "./fallbacks.js";
 export * from "./tokenSaver.js";
+export * from "./auth.js";


### PR DESCRIPTION
## Summary
- Move all auth interfaces and contracts into `@srouter/types`.
- Remove `auth.providers.ts` from `src/logic/` and relocate handler definitions into `src/services/authHandlers.ts` under the unified `AuthHandlers` namespace.
- Replace ad-hoc inline request body types with shared `TokenImportBody` and `OAuthCallbackBody`.
- Clean up variable naming and eliminate loose `any` types across auth client definitions.

## Key Changes
- **`packages/types/src/auth.ts`**: Added strongly-typed auth contracts (`OAuthLoginParams`, `OAuthLoginResult`, `TokenImportParams`, `OAuthTokens`, `OAuthClientOptions`, `OAuthClientClass`, `AuthProviderHandler`, `OAuthCallbackBody`, `TokenImportBody`).
- **`apps/api/src/services/authHandlers.ts`**: Grouped provider handlers under the `AuthHandlers` namespace (`AuthHandlers.Antigravity`, `AuthHandlers.OpenAI`, etc.) and moved out of `src/logic/`.
- **`apps/api/src/controllers/auth.controller.ts`**: Adopted shared types and cleaned up request parsing.
- **`apps/api/src/logic/auth.logic.ts`**: Standardized on `oAuthInstance` and consumed shared types.

## Verification
- `pnpm --filter @srouter/types build` completed successfully.
- `pnpm run lint` passed across all packages.
- `pnpm exec tsx --test 'tests/**/*.test.ts'` passed (89/89 tests passing).