### PR TITLE
refactor(middleware): remove redundant adminAuth/requireAdmin aliases and enforce PascalCase

### DIFF
--- a/apps/api/src/middleware/adminAuth.ts
+++ b/apps/api/src/middleware/adminAuth.ts
@@ -9,15 +9,15 @@ export interface AdminAuthMiddlewareOptions {
     now?: () => number;
 }
 
-export function createAdminAuthMiddleware(
-    options: AdminAuthMiddlewareOptions = {}
+export function CreateAdminAuthMiddleware(
+    Options: AdminAuthMiddlewareOptions = {}
 ): MiddlewareHandler {
-    const store = options.store ?? adminAuthStore;
-    const now = options.now ?? (() => Date.now());
+    const Store = Options.store ?? adminAuthStore;
+    const Now = Options.now ?? (() => Date.now());
 
     return async (c: Context, next: Next) => {
-        const sessionToken = getCookie(c, ADMIN_SESSION_COOKIE);
-        if (!verifyAdminSession(store, sessionToken, now())) {
+        const SessionToken = getCookie(c, ADMIN_SESSION_COOKIE);
+        if (!verifyAdminSession(Store, SessionToken, Now())) {
             return Err(c, "Admin authentication is required", 401, {
                 code: "authentication_required"
             });
@@ -28,6 +28,4 @@ export function createAdminAuthMiddleware(
     };
 }
 
-export const RequireAdmin = createAdminAuthMiddleware();
-export const requireAdmin = RequireAdmin;
-export const adminAuth = RequireAdmin;
+export const RequireAdmin = CreateAdminAuthMiddleware();

--- a/apps/api/tests/admin-auth-middleware.test.ts
+++ b/apps/api/tests/admin-auth-middleware.test.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { AdminAuthStore } from "../../../packages/db/src/adminAuth.js";
 import { setRequireApiKeyDB } from "@srouter/db";
 import { ADMIN_SESSION_COOKIE, createAdminSession } from "../src/services/adminAuth.js";
-import { createAdminAuthMiddleware } from "../src/middleware/adminAuth.js";
+import { CreateAdminAuthMiddleware } from "../src/middleware/adminAuth.js";
 import { createApiKeyAuth } from "../src/middleware/apiKeyAuth.js";
 
 afterEach(() => {
@@ -16,7 +16,7 @@ test("admin middleware requires a valid session cookie", async () => {
     const store = new AdminAuthStore(new DatabaseSync(":memory:"));
     store.createAdminAccount("hash");
     const app = new Hono();
-    app.use("/*", createAdminAuthMiddleware({ store }));
+    app.use("/*", CreateAdminAuthMiddleware({ store }));
     app.get("/providers", (c) => c.json({ ok: true }));
 
     const rejected = await app.request("/providers");


### PR DESCRIPTION
## Summary
- Removed redundant lowercase aliases (`requireAdmin`, `adminAuth`) in `apps/api/src/middleware/adminAuth.ts`.
- Standardized factory function to `CreateAdminAuthMiddleware` and export only `RequireAdmin`.
- Updated middleware tests accordingly.

## Verification
- All 89 API tests passed.