### PR TITLE
fix(providers): restore custom models feature

### DIFF
--- a/apps/api/src/controllers/providers.controller.ts
+++ b/apps/api/src/controllers/providers.controller.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono";
 import type { CreateProviderPayload } from "@/logic/providers.logic.js";
 import { ProvidersLogic } from "@/logic/providers.logic.js";
 import { deleteProviderDB } from "@srouter/db";
-import { CreateProviderSchema, VerifyProviderSchema } from "@srouter/types";
+import { AddCustomModelSchema, CreateProviderSchema, VerifyProviderSchema } from "@srouter/types";
 import { loadSavedProvidersFromDB, registry } from "@/services/registry.js";
 import { Err, Ok } from "@/utils/response.js";
 
@@ -65,5 +65,38 @@ export class ProvidersController {
 
         const Result = await ProvidersLogic.VerifyConnection(Parsed.data);
         return Ok(c, Result);
+    }
+
+    public static async AddCustomModel(c: Context): Promise<Response> {
+        const ProviderId = c.req.param("providerId");
+        if (!ProviderId) return Err(c, "Provider ID is required", 400);
+
+        const RawBody = await c.req.json().catch(() => null);
+        const Parsed = AddCustomModelSchema.safeParse(RawBody);
+        if (!Parsed.success) {
+            return Err(c, Parsed.error.issues[0]?.message || "Invalid model payload", 400);
+        }
+
+        try {
+            const Model = ProvidersLogic.AddCustomModel(ProviderId, Parsed.data.modelId);
+            return Ok(c, Model, 201);
+        } catch (error) {
+            return Err(c, error instanceof Error ? error.message : "Invalid model payload", 400);
+        }
+    }
+
+    public static DeleteCustomModel(c: Context): Response {
+        const ProviderId = c.req.param("providerId");
+        const ModelId = c.req.param("modelId");
+        if (!ProviderId || !ModelId) {
+            return Err(c, "Provider ID and model ID are required", 400);
+        }
+
+        try {
+            ProvidersLogic.DeleteCustomModel(ProviderId, decodeURIComponent(ModelId));
+            return Ok(c, { message: "Custom model deleted" });
+        } catch (error) {
+            return Err(c, error instanceof Error ? error.message : "Failed to delete model", 404);
+        }
     }
 }

--- a/apps/api/src/logic/models.logic.ts
+++ b/apps/api/src/logic/models.logic.ts
@@ -1,4 +1,6 @@
 import type { ModelObject } from "@srouter/types";
+import { getAllCustomModelsDB } from "@srouter/db";
+import { providerAlias, providerBaseId } from "@srouter/constants";
 import { registry } from "@/services/registry.js";
 
 export class ModelsLogic {
@@ -6,7 +8,35 @@ export class ModelsLogic {
         Provider?: string,
         ForceRefresh = false
     ): Promise<ModelObject[]> {
-        return registry.listAllModels(Provider, ForceRefresh);
+        const Models = await registry.listAllModels(Provider, ForceRefresh);
+        return this.MergeCustomModels(Models, Provider);
+    }
+
+    private static MergeCustomModels(
+        Models: ModelObject[],
+        ProviderFilter?: string
+    ): ModelObject[] {
+        const Rows = getAllCustomModelsDB();
+        if (Rows.length === 0) return Models;
+
+        const Merged = new Map<string, ModelObject>();
+        for (const M of Models) {
+            Merged.set(M.id.toLowerCase(), M);
+        }
+        for (const Row of Rows) {
+            const Alias = providerAlias(providerBaseId(Row.providerId));
+            const Id = `${Alias}/${Row.modelId}`;
+            if (ProviderFilter && !Alias.toLowerCase().startsWith(ProviderFilter.toLowerCase())) {
+                continue;
+            }
+            Merged.set(Id.toLowerCase(), {
+                id: Id,
+                object: "model",
+                owned_by: Alias,
+                custom: true
+            });
+        }
+        return Array.from(Merged.values());
     }
 
     public static async GetModelById(

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_PROVIDER_MAP, isProviderCategory, isSeedProvider } from "@srouter/constants";
+import {
+    DEFAULT_PROVIDER_MAP,
+    isProviderCategory,
+    isSeedProvider,
+    providerAlias
+} from "@srouter/constants";
 import type {
     CreateProviderZod,
     ModelObject,
@@ -8,7 +13,13 @@ import type {
     ProviderProtocol,
     VerifyProviderZod
 } from "@srouter/types";
-import { getAllProvidersDB, upsertProviderDB } from "@srouter/db";
+import {
+    addCustomModelDB,
+    deleteCustomModelDB,
+    getAllProvidersDB,
+    getCustomModelsByProviderDB,
+    upsertProviderDB
+} from "@srouter/db";
 import { loadSavedProvidersFromDB, registry } from "@/services/registry.js";
 
 export interface GroupedCatalog {
@@ -190,6 +201,18 @@ export class ProvidersLogic {
             }
         }
 
+        const CustomModels = ProvidersLogic.ListCustomModels(ProviderId);
+        if (CustomModels.length > 0) {
+            const Merged = new Map<string, ModelObject>();
+            for (const M of LiveModels) {
+                Merged.set(M.id.toLowerCase(), M);
+            }
+            for (const M of CustomModels) {
+                Merged.set(M.id.toLowerCase(), M);
+            }
+            LiveModels = Array.from(Merged.values());
+        }
+
         return {
             ...Provider,
             connections: Connections,
@@ -250,13 +273,50 @@ export class ProvidersLogic {
         return ProviderDefinitionFromConfig(Config);
     }
 
+    public static AddCustomModel(ProviderId: string, ModelId: string): ModelObject {
+        const Id = ProviderId.toLowerCase();
+        if (
+            !DEFAULT_PROVIDER_MAP[Id] &&
+            !getAllProvidersDB().some((P) => BaseIdOf(P.providerId || P.id) === Id)
+        ) {
+            throw new Error(`Provider '${ProviderId}' not found`);
+        }
+        const Trimmed = ModelId.trim();
+        if (!Trimmed) throw new Error("Model ID is required");
+        if (Trimmed.length > 200 || !/^[A-Za-z0-9._\-/: ]+$/.test(Trimmed))
+            throw new Error(
+                "Model ID may only contain letters, numbers, dots, dashes, underscores, slashes, colons, and spaces"
+            );
+
+        addCustomModelDB(Id, Trimmed);
+        const FullId = `${providerAlias(Id)}/${Trimmed}`;
+        registry.clearModelsCache();
+        return { id: FullId, object: "model", owned_by: providerAlias(Id) };
+    }
+
+    public static DeleteCustomModel(ProviderId: string, ModelId: string): void {
+        const Deleted = deleteCustomModelDB(ProviderId.toLowerCase(), ModelId);
+        if (!Deleted) throw new Error(`Custom model '${ModelId}' not found for '${ProviderId}'`);
+        registry.clearModelsCache();
+    }
+
+    public static ListCustomModels(ProviderId: string): ModelObject[] {
+        const Alias = providerAlias(ProviderId.toLowerCase());
+        return getCustomModelsByProviderDB(ProviderId.toLowerCase()).map((Row) => ({
+            id: `${Alias}/${Row.modelId}`,
+            object: "model" as const,
+            owned_by: Alias,
+            custom: true
+        }));
+    }
+
     public static async VerifyConnection(Payload: VerifyProviderZod): Promise<{
         success: boolean;
         message: string;
         modelsCount?: number;
     }> {
         const Protocol = Payload.protocol || "openai";
-        const BaseUrl = (Payload.base_url?.trim() || "").replace(/\/+$/, "");
+        const BaseUrl = (Payload.baseUrl?.trim() || "").replace(/\/+$/, "");
         const ApiKey = Payload.apiKey?.trim();
 
         if (BaseUrl) {

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -13,3 +13,15 @@ ProvidersRouter.get("/providers/:providerId", ApiKeyAuth, ProvidersController.Ge
 ProvidersRouter.post("/providers/verify", RequireAdmin, ProvidersController.VerifyProvider);
 ProvidersRouter.post("/providers", RequireAdmin, ProvidersController.AddProvider);
 ProvidersRouter.delete("/providers/:id", RequireAdmin, ProvidersController.DeleteProvider);
+
+// Custom (user-added) models per provider driver
+ProvidersRouter.post(
+    "/providers/:providerId/models",
+    RequireAdmin,
+    ProvidersController.AddCustomModel
+);
+ProvidersRouter.delete(
+    "/providers/:providerId/models/:modelId{.+}",
+    RequireAdmin,
+    ProvidersController.DeleteCustomModel
+);

--- a/apps/web/src/components/providers/AddModelDialog.tsx
+++ b/apps/web/src/components/providers/AddModelDialog.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Bot, Loader2 } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface AddModelDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    providerName: string;
+    isPending: boolean;
+    onSubmit: (modelId: string) => void;
+}
+
+export function AddModelDialog({
+    open,
+    onOpenChange,
+    providerName,
+    isPending,
+    onSubmit
+}: AddModelDialogProps) {
+    const [modelId, setModelId] = useState("");
+    const [error, setError] = useState("");
+
+    const handleSubmit = () => {
+        const trimmed = modelId.trim();
+        if (!trimmed) {
+            setError("Model ID is required");
+            return;
+        }
+        setError("");
+        onSubmit(trimmed);
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(next) => {
+                if (!next) {
+                    setModelId("");
+                    setError("");
+                }
+                onOpenChange(next);
+            }}
+        >
+            <DialogContent className="sm:max-w-md font-mono">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2 text-sm">
+                        <Bot className="size-4 text-amber-500" />
+                        Add Custom Model
+                    </DialogTitle>
+                    <DialogDescription className="text-xs">
+                        Manually register a model under <b>{providerName}</b>. Requests to{" "}
+                        <code className="rounded bg-secondary px-1 py-0.5 text-[10px]">
+                            &lt;alias&gt;/&lt;model-id&gt;
+                        </code>{" "}
+                        will route through this provider's active connections.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-2 py-2">
+                    <Input
+                        autoFocus
+                        placeholder="e.g. gemini-3.0-ultra-preview"
+                        value={modelId}
+                        onChange={(e) => setModelId(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") handleSubmit();
+                        }}
+                        className="h-9 font-mono text-xs"
+                    />
+                    {error && <p className="text-[11px] text-destructive">{error}</p>}
+                </div>
+
+                <DialogFooter className="gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 text-xs cursor-pointer"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        type="button"
+                        size="sm"
+                        className="h-8 text-xs cursor-pointer gap-1.5"
+                        disabled={isPending}
+                        onClick={handleSubmit}
+                    >
+                        {isPending && <Loader2 className="size-3.5 animate-spin" />}
+                        Add Model
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/web/src/components/providers/ProviderModelCard.tsx
+++ b/apps/web/src/components/providers/ProviderModelCard.tsx
@@ -99,6 +99,11 @@ export function ProviderModelCard({ model, copied, onCopy, onDelete }: ProviderM
                             ★ Pinned
                         </span>
                     )}
+                    {model.custom && (
+                        <span className="inline-flex items-center gap-0.5 rounded-[4px] bg-sky-500/10 px-1.5 py-0.2 text-[9.5px] font-bold text-sky-600 dark:text-sky-400 border border-sky-500/20">
+                            Custom
+                        </span>
+                    )}
                 </div>
 
                 <Link

--- a/apps/web/src/components/providers/ProviderModelTable.tsx
+++ b/apps/web/src/components/providers/ProviderModelTable.tsx
@@ -240,6 +240,11 @@ export function ProviderModelTable({
                             >
                                 {model.id}
                             </span>
+                            {model.custom && (
+                                <span className="inline-flex items-center rounded-[4px] bg-sky-500/10 px-1.5 py-0.2 text-[9.5px] font-bold text-sky-600 dark:text-sky-400 border border-sky-500/20 shrink-0">
+                                    Custom
+                                </span>
+                            )}
 
                             <button
                                 type="button"

--- a/apps/web/src/hooks/useProvider.ts
+++ b/apps/web/src/hooks/useProvider.ts
@@ -58,5 +58,33 @@ export function useProvider(providerId: string) {
         }
     });
 
-    return { ...query, addMutation, deleteMutation };
+    const addModelMutation = useMutation({
+        mutationFn: (modelId: string) =>
+            api.post<ModelObject>(`/v1/providers/${providerId}/models`, { modelId }),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
+            void queryClient.invalidateQueries({ queryKey: ["models"] });
+            toast.success("Custom model added");
+        },
+        onError: (err: Error) => {
+            toast.error(err.message || "Failed to add custom model");
+        }
+    });
+
+    const deleteModelMutation = useMutation({
+        mutationFn: (modelId: string) =>
+            api.delete<{ message: string }>(
+                `/v1/providers/${providerId}/models/${encodeURIComponent(modelId)}`
+            ),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
+            void queryClient.invalidateQueries({ queryKey: ["models"] });
+            toast.success("Custom model deleted");
+        },
+        onError: (err: Error) => {
+            toast.error(err.message || "Failed to delete custom model");
+        }
+    });
+
+    return { ...query, addMutation, deleteMutation, addModelMutation, deleteModelMutation };
 }

--- a/apps/web/src/routes/providers/$providerId.tsx
+++ b/apps/web/src/routes/providers/$providerId.tsx
@@ -21,6 +21,7 @@ import { useFavorites } from "@/hooks/useFavorites";
 import { toast } from "sonner";
 import { ConnectionCard } from "@/components/providers/ConnectionCard";
 import { ConnectionForm, type ConnectionFormInput } from "@/components/providers/ConnectionForm";
+import { AddModelDialog } from "@/components/providers/AddModelDialog";
 import { ProviderModelCard } from "@/components/providers/ProviderModelCard";
 import { ProviderModelTable } from "@/components/providers/ProviderModelTable";
 import { ProviderDetailSkeleton } from "@/components/skeletons";
@@ -39,7 +40,9 @@ function ProviderDetailPage() {
         error,
         refetch,
         addMutation,
-        deleteMutation
+        deleteMutation,
+        addModelMutation,
+        deleteModelMutation
     } = useProvider(providerId);
 
     const [modelSearch, setModelSearch] = useState("");
@@ -47,6 +50,7 @@ function ProviderDetailPage() {
     const [roundRobin, setRoundRobin] = useState(false);
     const [isAddOpen, setIsAddOpen] = useState(false);
     const [isOAuthModalOpen, setIsOAuthModalOpen] = useState(false);
+    const [isAddModelOpen, setIsAddModelOpen] = useState(false);
     const [formError, setFormError] = useState("");
     const { copied, copy } = useCopy();
     const { isFavorite } = useFavorites();
@@ -304,6 +308,15 @@ function ProviderDetailPage() {
                 <div className="flex shrink-0 items-center gap-2">
                     <Button
                         type="button"
+                        variant="outline"
+                        onClick={() => setIsAddModelOpen(true)}
+                        className="h-8 text-xs font-semibold cursor-pointer shadow-xs gap-1.5"
+                    >
+                        <Plus className="size-3.5" />
+                        <span>Add Model</span>
+                    </Button>
+                    <Button
+                        type="button"
                         onClick={handleAddConnection}
                         className="h-8 text-xs font-semibold cursor-pointer shadow-xs gap-1.5"
                     >
@@ -478,6 +491,22 @@ function ProviderDetailPage() {
                 provider={provider}
                 open={isOAuthModalOpen}
                 onOpenChange={setIsOAuthModalOpen}
+            />
+
+            {/* Add Custom Model Dialog */}
+            <AddModelDialog
+                open={isAddModelOpen}
+                onOpenChange={setIsAddModelOpen}
+                providerName={provider.name}
+                isPending={addModelMutation.isPending}
+                onSubmit={(modelId) =>
+                    addModelMutation.mutate(modelId, {
+                        onSuccess: () => {
+                            setIsAddModelOpen(false);
+                            toast.success(`Model "${modelId}" added to ${provider.name}`);
+                        }
+                    })
+                }
             />
         </div>
     );

--- a/packages/db/src/customModels.ts
+++ b/packages/db/src/customModels.ts
@@ -1,0 +1,55 @@
+import { db } from "./db.js";
+import { num, str } from "./row-utils.js";
+
+export interface CustomModelRow {
+    providerId: string;
+    modelId: string;
+    createdAt: number;
+}
+
+interface CustomModelDBShape {
+    provider_id: string;
+    model_id: string;
+    created_at: number;
+}
+
+export function getAllCustomModelsDB(): CustomModelRow[] {
+    const Rows = db
+        .prepare("SELECT * FROM custom_models ORDER BY created_at ASC")
+        .all() as unknown as CustomModelDBShape[];
+
+    return Rows.map(mapCustomModelRow);
+}
+
+export function getCustomModelsByProviderDB(providerId: string): CustomModelRow[] {
+    const Rows = db
+        .prepare("SELECT * FROM custom_models WHERE provider_id = ? ORDER BY created_at ASC")
+        .all(providerId) as unknown as CustomModelDBShape[];
+
+    return Rows.map(mapCustomModelRow);
+}
+
+export function addCustomModelDB(providerId: string, modelId: string): CustomModelRow {
+    const CreatedAt = Date.now();
+    db.prepare(
+        `INSERT OR IGNORE INTO custom_models (provider_id, model_id, created_at)
+         VALUES (?, ?, ?)`
+    ).run(providerId, modelId, CreatedAt);
+
+    return { providerId, modelId, createdAt: CreatedAt };
+}
+
+export function deleteCustomModelDB(providerId: string, modelId: string): boolean {
+    const Result = db
+        .prepare("DELETE FROM custom_models WHERE provider_id = ? AND model_id = ?")
+        .run(providerId, modelId);
+    return num(Result.changes) > 0;
+}
+
+function mapCustomModelRow(row: CustomModelDBShape): CustomModelRow {
+    return {
+        providerId: str(row.provider_id),
+        modelId: str(row.model_id),
+        createdAt: num(row.created_at)
+    };
+}

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -200,6 +200,16 @@ export function initDatabase(): void {
             value TEXT NOT NULL
         );
     `);
+
+    // 7. Table for user-added custom models per provider driver
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS custom_models (
+            provider_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (provider_id, model_id)
+        );
+    `);
 }
 
 // Auto-run schema initialization

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,4 +8,5 @@ export * from "./quota.js";
 export * from "./settings.js";
 export * from "./fallbacks.js";
 export * from "./tokenSaver.js";
+export * from "./customModels.js";
 export * from "./row-utils.js";

--- a/packages/types/src/openai.ts
+++ b/packages/types/src/openai.ts
@@ -137,6 +137,8 @@ export interface ModelObject {
     object: "model";
     created?: number;
     owned_by: string;
+    /** True when the entry was manually added by the user (custom_models table). */
+    custom?: boolean;
 }
 
 export interface ModelListResponse {

--- a/packages/types/src/schemas/providers.ts
+++ b/packages/types/src/schemas/providers.ts
@@ -28,3 +28,11 @@ export const VerifyProviderSchema = z.object({
 });
 
 export type VerifyProviderZod = z.infer<typeof VerifyProviderSchema>;
+
+export const AddCustomModelSchema = z.object({
+    modelId: z
+        .string({ required_error: "Field 'modelId' is required" })
+        .min(1, "Field 'modelId' cannot be empty")
+});
+
+export type AddCustomModelZod = z.infer<typeof AddCustomModelSchema>;


### PR DESCRIPTION
## Summary
- Reverts accidental deletion of user-added custom models feature from PR #58.
- Restores `custom_models` SQLite table, `AddModelDialog.tsx`, and custom model REST endpoints (`POST/DELETE /v1/providers/:providerId/models`).
- Restores custom model badge in table/card views and auto-merging in `ModelsLogic` and `ProvidersLogic`.

## Verification
- Touch-packages build passed (`packages/db`, `packages/types`, `packages/constants`, `apps/api`, `apps/web`).
- Full API unit test suite passed (89/89 tests).