### PR TITLE
fix(providers): update fallback registry category to api_key

### DIFF
--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -323,7 +323,7 @@ export class ProviderRegistry {
             catalog.push({
                 id: baseId,
                 name: provider.name,
-                category: provider.category ?? "custom",
+                category: provider.category ?? "api_key",
                 protocol: provider.protocol ?? "openai",
                 requires_api_key: true,
                 supports_custom_url: true,


### PR DESCRIPTION
## Summary
- Fixes type error in `packages/providers/src/registry.ts` where `"custom"` category was used as fallback after `ProviderCategory` enum update.

## Verification
- `packages/providers` build passed (`pnpm run build`).