### PR TITLE
feat(cli): add 'srouter init' command for Docker and Source Code execution

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,6 +2,16 @@
     "name": "api",
     "version": "0.1.3",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "apps/api"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
     "scripts": {
         "dev": "tsx watch src/index.ts",
         "build": "tsup",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -3,6 +3,16 @@
     "version": "0.1.3-rc.3",
     "description": "CLI tool to seamlessly connect and configure AI coding tools with SRouter Gateway",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "apps/cli"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
     "bin": {
         "srouter": "bin/srouter.js"
     },

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,0 +1,338 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import * as p from "@clack/prompts";
+import { SROUTER_DIR } from "@srouter/db";
+import { formatError, formatInfo, formatSuccess, formatWarning, pc } from "../lib/ui.js";
+import { isExecutableInPath } from "../lib/platform.js";
+
+export interface InitCommandOptions {
+    mode?: "docker" | "source";
+    port?: string;
+    dir?: string;
+    yes?: boolean;
+    detached?: boolean;
+}
+
+const DEFAULT_PORT = "3000";
+const REPO_URL = "https://github.com/seaavey/SRouter.git";
+const DOCKER_IMAGE = "ghcr.io/seaavey/srouter:latest";
+
+function runProcess(
+    command: string,
+    args: string[],
+    options?: { cwd?: string; stdio?: "inherit" | "pipe" }
+): Promise<{ code: number; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+        const child = spawn(command, args, {
+            cwd: options?.cwd,
+            stdio: options?.stdio ?? "inherit"
+        });
+
+        let stdout = "";
+        let stderr = "";
+
+        if (options?.stdio === "pipe") {
+            child.stdout?.on("data", (d) => (stdout += d.toString()));
+            child.stderr?.on("data", (d) => (stderr += d.toString()));
+        }
+
+        child.on("close", (code) => {
+            resolve({ code: code ?? 0, stdout, stderr });
+        });
+        child.on("error", (err) => {
+            resolve({ code: 1, stdout, stderr: err.message });
+        });
+    });
+}
+
+async function initDocker(port: string, detached: boolean): Promise<void> {
+    const s = p.spinner();
+    s.start("Checking Docker environment");
+
+    const hasDocker = await isExecutableInPath("docker");
+    if (!hasDocker) {
+        s.stop(formatError("Docker is not installed or not available in PATH."));
+        
+        const fallbackChoice = await p.select({
+            message: "Docker was not found. What would you like to do?",
+            options: [
+                {
+                    value: "source",
+                    label: "Run from Source Code instead (Node.js & pnpm)",
+                    hint: "Clones repo and builds locally without Docker"
+                },
+                {
+                    value: "guide",
+                    label: "View Docker installation instructions",
+                    hint: "Get download link for your OS"
+                },
+                {
+                    value: "exit",
+                    label: "Exit",
+                    hint: "Cancel initialization"
+                }
+            ]
+        });
+
+        if (p.isCancel(fallbackChoice) || fallbackChoice === "exit") {
+            p.outro("Initialization cancelled. Install Docker from https://docs.docker.com/get-docker/ and try again.");
+            return;
+        }
+
+        if (fallbackChoice === "guide") {
+            p.log.message(
+                [
+                    "📦 " + pc.bold("How to install Docker:"),
+                    `• Windows / macOS: ${pc.cyan("https://www.docker.com/products/docker-desktop/")}`,
+                    `• Linux (Ubuntu/Debian): ${pc.yellow("curl -fsSL https://get.docker.com | sh")}`,
+                    `• Linux (Arch): ${pc.yellow("sudo pacman -S docker && sudo systemctl enable --now docker")}`
+                ].join("\n")
+            );
+            p.outro("Run 'srouter init' again after installing Docker.");
+            return;
+        }
+
+        if (fallbackChoice === "source") {
+            const defaultDir = path.join(os.homedir(), "srouter");
+            await initSource(defaultDir, port);
+            return;
+        }
+    }
+
+    s.message("Verifying Docker daemon status");
+    const checkDaemon = await runProcess("docker", ["info"], { stdio: "pipe" });
+    if (checkDaemon.code !== 0) {
+        s.stop(formatError("Docker daemon is not running."));
+        p.log.info("Please start the Docker service/daemon and try again.");
+        process.exitCode = 1;
+        return;
+    }
+
+    const dataDir = path.join(SROUTER_DIR, "data");
+    fs.mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+
+    s.message(`Pulling latest SRouter Docker image (${DOCKER_IMAGE})`);
+    const pullRes = await runProcess("docker", ["pull", DOCKER_IMAGE], { stdio: "inherit" });
+    if (pullRes.code !== 0) {
+        s.stop(formatWarning("Failed to pull image from registry, checking local image cache"));
+    }
+
+    // Stop and remove existing container if running
+    await runProcess("docker", ["rm", "-f", "srouter"], { stdio: "pipe" });
+
+    s.message(`Starting SRouter Gateway container on port ${port}`);
+    const dockerArgs = [
+        "run",
+        detached ? "-d" : "-it",
+        "--name",
+        "srouter",
+        "--restart",
+        "unless-stopped",
+        "-p",
+        `${port}:3000`,
+        "-p",
+        "1455:1455",
+        "-v",
+        `${dataDir}:/app/data`,
+        "-e",
+        `PORT=${port}`,
+        "-e",
+        "OAUTH_PORT=1455",
+        "-e",
+        "DATABASE_PATH=/app/data/srouter.db",
+        DOCKER_IMAGE
+    ];
+
+    if (detached) {
+        const runRes = await runProcess("docker", dockerArgs, { stdio: "pipe" });
+        if (runRes.code !== 0) {
+            s.stop(formatError("Failed to start SRouter Docker container."));
+            p.log.error(runRes.stderr);
+            process.exitCode = 1;
+            return;
+        }
+        s.stop(formatSuccess("SRouter Docker container started successfully!"));
+        p.log.message(
+            [
+                `🚀 Gateway URL:  ${pc.bold(pc.cyan(`http://localhost:${port}`))}`,
+                `📊 Web Dashboard: ${pc.bold(pc.cyan(`http://localhost:${port}`))}`,
+                `💾 Persistent Data: ${pc.dim(dataDir)}`,
+                "",
+                `To inspect logs: ${pc.yellow("docker logs -f srouter")}`,
+                `To stop:         ${pc.yellow("docker stop srouter")}`
+            ].join("\n")
+        );
+        p.outro("SRouter is ready to use!");
+    } else {
+        s.stop("Launching container in foreground mode...");
+        await runProcess("docker", dockerArgs, { stdio: "inherit" });
+    }
+}
+
+async function initSource(targetDir: string, port: string): Promise<void> {
+    const s = p.spinner();
+
+    // Check prerequisites: git, node, pnpm
+    s.start("Checking prerequisites (git, node, pnpm)");
+    const hasGit = await isExecutableInPath("git");
+    const hasPnpm = await isExecutableInPath("pnpm");
+
+    if (!hasGit) {
+        s.stop(formatError("Git is required to clone SRouter repository."));
+        process.exitCode = 1;
+        return;
+    }
+
+    const resolvedDir = path.resolve(targetDir);
+
+    // 1. Clone repository if folder doesn't already have package.json
+    if (!fs.existsSync(path.join(resolvedDir, "package.json"))) {
+        s.message(`Cloning SRouter into ${pc.bold(resolvedDir)}`);
+        fs.mkdirSync(resolvedDir, { recursive: true });
+        const cloneRes = await runProcess("git", ["clone", REPO_URL, resolvedDir], {
+            stdio: "inherit"
+        });
+        if (cloneRes.code !== 0) {
+            s.stop(formatError("Failed to clone SRouter repository."));
+            process.exitCode = 1;
+            return;
+        }
+    } else {
+        p.log.info(`Using existing SRouter repository at ${pc.bold(resolvedDir)}`);
+    }
+
+    // 2. Install dependencies
+    s.message("Installing dependencies with pnpm");
+    const pnpmCmd = hasPnpm ? "pnpm" : "npx";
+    const installArgs = hasPnpm ? ["install"] : ["pnpm", "install"];
+
+    const installRes = await runProcess(pnpmCmd, installArgs, {
+        cwd: resolvedDir,
+        stdio: "inherit"
+    });
+    if (installRes.code !== 0) {
+        s.stop(formatError("Dependency installation failed."));
+        process.exitCode = 1;
+        return;
+    }
+
+    // 3. Build project
+    s.message("Building SRouter packages, API, and Dashboard");
+    const buildArgs = hasPnpm ? ["run", "build"] : ["pnpm", "run", "build"];
+    const buildRes = await runProcess(pnpmCmd, buildArgs, {
+        cwd: resolvedDir,
+        stdio: "inherit"
+    });
+    if (buildRes.code !== 0) {
+        s.stop(formatError("Build step failed."));
+        process.exitCode = 1;
+        return;
+    }
+
+    s.stop(formatSuccess("SRouter built successfully!"));
+
+    p.log.message(
+        [
+            `📁 Project Directory: ${pc.bold(resolvedDir)}`,
+            `🚀 Start Dev Server:  ${pc.yellow(`cd ${resolvedDir} && pnpm dev`)}`,
+            `⚡ Start Production:  ${pc.yellow(`PORT=${port} cd ${resolvedDir}/apps/api && pnpm start`)}`
+        ].join("\n")
+    );
+
+    const startNow = await p.confirm({
+        message: "Start SRouter API & Web server now?",
+        initialValue: true
+    });
+
+    if (startNow === true) {
+        p.outro(`Starting SRouter Gateway on port ${port}...`);
+        process.env.PORT = port;
+        const startArgs = hasPnpm
+            ? ["--filter", "api", "start"]
+            : ["pnpm", "--filter", "api", "start"];
+        await runProcess(pnpmCmd, startArgs, {
+            cwd: resolvedDir,
+            stdio: "inherit"
+        });
+    } else {
+        p.outro("Setup complete! You can start SRouter anytime.");
+    }
+}
+
+export async function initCommand(options: InitCommandOptions): Promise<void> {
+    p.intro(pc.bold(pc.cyan("⚡ SRouter Gateway Initialization")));
+
+    let mode = options.mode;
+    if (!mode) {
+        const choice = await p.select({
+            message: "How would you like to run SRouter?",
+            options: [
+                {
+                    value: "docker",
+                    label: "Docker (Recommended)",
+                    hint: "Zero-config container with isolated environment & persistent database"
+                },
+                {
+                    value: "source",
+                    label: "Source Code (Node.js & pnpm)",
+                    hint: "Clone repository, build from source, and run natively"
+                }
+            ]
+        });
+
+        if (p.isCancel(choice)) {
+            p.outro("Initialization cancelled.");
+            return;
+        }
+        mode = choice as "docker" | "source";
+    }
+
+    let port = options.port;
+    if (!port && !options.yes) {
+        const inputPort = await p.text({
+            message: "Gateway Port:",
+            defaultValue: DEFAULT_PORT,
+            placeholder: DEFAULT_PORT,
+            validate: (val) => {
+                const n = Number(val);
+                if (Number.isNaN(n) || n <= 0 || n > 65535) {
+                    return "Please enter a valid port number (1-65535).";
+                }
+            }
+        });
+
+        if (p.isCancel(inputPort)) {
+            p.outro("Initialization cancelled.");
+            return;
+        }
+        port = inputPort || DEFAULT_PORT;
+    } else {
+        port = port || DEFAULT_PORT;
+    }
+
+    if (mode === "docker") {
+        const detached = options.detached ?? true;
+        await initDocker(port, detached);
+    } else {
+        const defaultDir = path.join(os.homedir(), "srouter");
+        let targetDir = options.dir;
+        if (!targetDir && !options.yes) {
+            const inputDir = await p.text({
+                message: "Target directory for SRouter source code:",
+                defaultValue: defaultDir,
+                placeholder: defaultDir
+            });
+            if (p.isCancel(inputDir)) {
+                p.outro("Initialization cancelled.");
+                return;
+            }
+            targetDir = inputDir || defaultDir;
+        } else {
+            targetDir = targetDir || defaultDir;
+        }
+
+        await initSource(targetDir, port);
+    }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { CLI_VERSION } from "@srouter/constants";
 import { setupCommand } from "./commands/setup.js";
+import { initCommand } from "./commands/init.js";
 import { linkCommand } from "./commands/link.js";
 import { unlinkCommand } from "./commands/unlink.js";
 import { syncCommand } from "./commands/sync.js";
@@ -42,6 +43,18 @@ export function createCli(): Command {
         )
         .action(async (opts) => {
             await setupCommand(opts);
+        });
+
+    program
+        .command("init")
+        .description("Initialize and run SRouter Gateway (Docker container or Source Code)")
+        .option("-m, --mode <mode>", "Run mode (docker or source)")
+        .option("-p, --port <port>", "Gateway port (default: 3000)")
+        .option("-d, --dir <dir>", "Source code clone directory (default: ~/srouter)")
+        .option("-y, --yes", "Accept default values without interactive prompt")
+        .option("--detached", "Run docker container in background (default: true)")
+        .action(async (opts) => {
+            await initCommand(opts);
         });
 
     program

--- a/apps/cli/tests/init.test.ts
+++ b/apps/cli/tests/init.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createCli } from "../src/index.js";
+
+test("CLI - init command registration", () => {
+    const program = createCli();
+    const initCmd = program.commands.find((c) => c.name() === "init");
+    assert.ok(initCmd, "Init command should be registered");
+
+    const optionFlags = initCmd.options.map((o) => o.long);
+    assert.ok(optionFlags.includes("--mode"));
+    assert.ok(optionFlags.includes("--port"));
+    assert.ok(optionFlags.includes("--dir"));
+    assert.ok(optionFlags.includes("--yes"));
+    assert.ok(optionFlags.includes("--detached"));
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,16 @@
     "version": "0.1.3",
     "type": "module",
     "private": true,
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "apps/web"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
     "scripts": {
         "dev": "vite",
         "build": "tsc -b && vite build",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,15 @@
         "chatgpt",
         "router"
     ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
     "scripts": {
         "dev": "turbo dev",
         "start": "turbo start",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,7 +2,17 @@
     "name": "@srouter/constants",
     "version": "0.1.3",
     "type": "module",
-    "main": "./dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "packages/constants"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
+    "main": "dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,7 +2,17 @@
     "name": "@srouter/db",
     "version": "0.1.3",
     "type": "module",
-    "main": "./dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "packages/db"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
+    "main": "dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {

--- a/packages/executors/package.json
+++ b/packages/executors/package.json
@@ -2,7 +2,17 @@
     "name": "@srouter/executors",
     "version": "0.1.3",
     "type": "module",
-    "main": "./dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "packages/executors"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
+    "main": "dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -2,7 +2,17 @@
     "name": "@srouter/pricing",
     "version": "0.1.3",
     "type": "module",
-    "main": "./dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "packages/pricing"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
+    "main": "dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -2,7 +2,17 @@
     "name": "@srouter/providers",
     "version": "0.1.3",
     "type": "module",
-    "main": "./dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "packages/providers"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
+    "main": "dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {

--- a/packages/translator/package.json
+++ b/packages/translator/package.json
@@ -2,7 +2,17 @@
     "name": "@srouter/translator",
     "version": "0.1.3",
     "type": "module",
-    "main": "./dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "packages/translator"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
+    "main": "dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,7 +2,17 @@
     "name": "@srouter/types",
     "version": "0.1.3",
     "type": "module",
-    "main": "./dist/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/seaavey/SRouter.git",
+        "directory": "packages/types"
+    },
+    "homepage": "https://github.com/seaavey/SRouter#readme",
+    "bugs": {
+        "url": "https://github.com/seaavey/SRouter/issues"
+    },
+    "license": "MIT",
+    "main": "dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {


### PR DESCRIPTION
## Summary
- Introduces `srouter init` command to initialize and run SRouter Gateway.
- Supports **Docker container** (pulls `ghcr.io/seaavey/srouter:latest`, mounts `~/.srouter/data`, and sets up isolated environment).
- Gracefully handles missing Docker daemon/binary with an interactive fallback (run from source, view OS install instructions, or exit).
- Supports **Source Code** mode (clones repo into `~/srouter`, runs `pnpm install`, builds, and starts the API/Dashboard).
- Includes flags `-m, --mode <docker|source>`, `-p, --port <port>`, `-d, --dir <dir>`, and `-y, --yes`.

## Verification
- Added `apps/cli/tests/init.test.ts` unit test suite (17/17 tests passing).
- Manual smoke tests performed across both branch & test runners.

Closes #68