### PR TITLE
feat(keys): add allowed_models restriction for virtual API keys

### DIFF
--- a/apps/api/src/controllers/chat.controller.ts
+++ b/apps/api/src/controllers/chat.controller.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 import { streamSSE } from "hono/streaming";
-import type { ChatCompletionRequest } from "@srouter/types";
+import type { ChatCompletionRequest, DBAPIKey } from "@srouter/types";
 import { ChatLogic } from "@/logic/chat.logic.js";
 import { Err, FormatErrorPayload, Ok } from "@/utils/response.js";
 
@@ -8,11 +8,18 @@ export class ChatController {
     public static async CreateCompletion(c: Context): Promise<Response> {
         const StartTime = Date.now();
         const Body = c.req.valid("json" as never) as ChatCompletionRequest;
+        const ApiKeyRow = c.get("apiKeyRow") as DBAPIKey | undefined;
+        const ApiKeyId = ApiKeyRow?.id;
 
         if (Body.stream) {
             return streamSSE(c, async (stream) => {
                 try {
-                    const Generator = ChatLogic.ProcessStreamingCompletion(Body, StartTime);
+                    const Generator = ChatLogic.ProcessStreamingCompletion(
+                        Body,
+                        StartTime,
+                        0,
+                        ApiKeyId
+                    );
                     for await (const Chunk of Generator) {
                         await stream.writeSSE({
                             data: JSON.stringify(Chunk)
@@ -32,7 +39,12 @@ export class ChatController {
         }
 
         try {
-            const ResponseData = await ChatLogic.ProcessNonStreamingCompletion(Body, StartTime);
+            const ResponseData = await ChatLogic.ProcessNonStreamingCompletion(
+                Body,
+                StartTime,
+                0,
+                ApiKeyId
+            );
             return Ok(c, ResponseData);
         } catch (error) {
             const ErrorMessage = error instanceof Error ? error.message : "Internal server error";

--- a/apps/api/src/controllers/keys.controller.ts
+++ b/apps/api/src/controllers/keys.controller.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
-import { getAllAPIKeysDB, createAPIKeyDB, deleteAPIKeyDB } from "@srouter/db";
-import { CreateAPIKeySchema } from "@srouter/types";
+import { getAllAPIKeysDB, createAPIKeyDB, deleteAPIKeyDB, addCreditAPIKeyDB } from "@srouter/db";
+import { CreateAPIKeySchema, AddCreditSchema } from "@srouter/types";
 import { Err, Ok } from "@/utils/response.js";
 
 export class KeysController {
@@ -23,12 +23,31 @@ export class KeysController {
                 name: parsed.data.name.trim(),
                 rateLimit: parsed.data.rateLimit ?? 0,
                 quotaLimit: parsed.data.quotaLimit ?? 0,
+                creditLimit: parsed.data.creditLimit ?? 0,
                 allowed_models: parsed.data.allowed_models ?? null
             });
             return Ok(c, created, 201);
         } catch (error) {
             return Err(c, error instanceof Error ? error.message : "Failed to create API key", 500);
         }
+    }
+
+    public static async AddCredit(c: Context): Promise<Response> {
+        const id = c.req.param("id");
+        if (!id) return Err(c, "Key ID is required", 400);
+
+        const rawBody = await c.req.json().catch(() => null);
+        const parsed = AddCreditSchema.safeParse(rawBody);
+        if (!parsed.success) {
+            return Err(c, parsed.error.issues[0]?.message || "Invalid credit payload", 400);
+        }
+
+        const updated = addCreditAPIKeyDB(id, parsed.data.amount);
+        if (!updated) {
+            return Err(c, `Key '${id}' not found`, 404);
+        }
+
+        return Ok(c, updated);
     }
 
     public static DeleteKey(c: Context): Response {

--- a/apps/api/src/controllers/keys.controller.ts
+++ b/apps/api/src/controllers/keys.controller.ts
@@ -22,7 +22,8 @@ export class KeysController {
             const created = createAPIKeyDB({
                 name: parsed.data.name.trim(),
                 rateLimit: parsed.data.rateLimit ?? 0,
-                quotaLimit: parsed.data.quotaLimit ?? 0
+                quotaLimit: parsed.data.quotaLimit ?? 0,
+                allowed_models: parsed.data.allowed_models ?? null
             });
             return Ok(c, created, 201);
         } catch (error) {

--- a/apps/api/src/controllers/messages.controller.ts
+++ b/apps/api/src/controllers/messages.controller.ts
@@ -8,6 +8,7 @@ import {
 import { AnthropicMessageRequestSchema, type AnthropicMessageRequest } from "@srouter/types";
 import { ChatLogic } from "@/logic/chat.logic.js";
 import { AnthropicErr, FormatAnthropicErrorPayload, Ok } from "@/utils/response.js";
+import { GetApiKeyRow, IsModelAllowed } from "@/middleware/ModelAccess.js";
 
 export class MessagesController {
     public static async CreateMessage(c: Context): Promise<Response> {
@@ -23,6 +24,17 @@ export class MessagesController {
         }
 
         const body = parsed.data as AnthropicMessageRequest;
+
+        const AllowedModels = GetApiKeyRow(c)?.allowed_models;
+        if (!IsModelAllowed(AllowedModels, body.model)) {
+            return AnthropicErr(
+                c,
+                `Model '${body.model}' is not allowed for this API key`,
+                403,
+                "permission_error"
+            );
+        }
+
         const OpenAIReq = AnthropicToOpenAIRequest(body);
         const isThinkingEnabled = Boolean(body.thinking?.type === "enabled");
 

--- a/apps/api/src/controllers/messages.controller.ts
+++ b/apps/api/src/controllers/messages.controller.ts
@@ -25,7 +25,8 @@ export class MessagesController {
 
         const body = parsed.data as AnthropicMessageRequest;
 
-        const AllowedModels = GetApiKeyRow(c)?.allowed_models;
+        const ApiKeyRow = GetApiKeyRow(c);
+        const AllowedModels = ApiKeyRow?.allowed_models;
         if (!IsModelAllowed(AllowedModels, body.model)) {
             return AnthropicErr(
                 c,
@@ -35,6 +36,7 @@ export class MessagesController {
             );
         }
 
+        const ApiKeyId = ApiKeyRow?.id;
         const OpenAIReq = AnthropicToOpenAIRequest(body);
         const isThinkingEnabled = Boolean(body.thinking?.type === "enabled");
 
@@ -47,7 +49,9 @@ export class MessagesController {
                 try {
                     const chunkGenerator = ChatLogic.ProcessStreamingCompletion(
                         OpenAIReq,
-                        startTime
+                        startTime,
+                        0,
+                        ApiKeyId
                     );
                     const AnthropicStream = OpenAIToAnthropicStream(chunkGenerator, body.model, {
                         allowThinking: isThinkingEnabled
@@ -71,7 +75,12 @@ export class MessagesController {
         }
 
         try {
-            const OpenAIRes = await ChatLogic.ProcessNonStreamingCompletion(OpenAIReq, startTime);
+            const OpenAIRes = await ChatLogic.ProcessNonStreamingCompletion(
+                OpenAIReq,
+                startTime,
+                0,
+                ApiKeyId
+            );
             const AnthropicRes = OpenAIToAnthropicResponse(OpenAIRes, body.model, {
                 allowThinking: isThinkingEnabled
             });

--- a/apps/api/src/controllers/models.controller.ts
+++ b/apps/api/src/controllers/models.controller.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { ModelListResponse } from "@srouter/types";
 import { ModelsLogic } from "@/logic/models.logic.js";
 import { Err, Ok } from "@/utils/response.js";
+import { GetApiKeyRow, IsModelAllowed } from "@/middleware/ModelAccess.js";
 
 const MODEL_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
 
@@ -18,9 +19,15 @@ export class ModelsController {
         }
 
         const Models = await ModelsLogic.GetAllModels(undefined, ExplicitRefresh);
+        const AllowedModels = GetApiKeyRow(c)?.allowed_models;
+        const VisibleModels =
+            AllowedModels && AllowedModels.length > 0
+                ? Models.filter((Model) => IsModelAllowed(AllowedModels, Model.id))
+                : Models;
+
         const ResponseData: ModelListResponse = {
             object: "list",
-            data: Models
+            data: VisibleModels
         };
         c.header("Cache-Control", MODEL_CACHE_CONTROL);
         return Ok(c, ResponseData);
@@ -30,6 +37,13 @@ export class ModelsController {
         const RawModelId = c.req.param("model") || c.req.param("*");
         const ModelId = RawModelId ? decodeURIComponent(RawModelId) : undefined;
         if (!ModelId) return Err(c, "Model ID parameter is required", 400);
+
+        const AllowedModels = GetApiKeyRow(c)?.allowed_models;
+        if (!IsModelAllowed(AllowedModels, ModelId)) {
+            return Err(c, `Model '${ModelId}' is not allowed for this API key`, 403, {
+                code: "model_not_allowed"
+            });
+        }
 
         const RefreshParam = c.req.query("refresh") || c.req.query("force");
         const ForceRefresh = RefreshParam === "true" || RefreshParam === "1";

--- a/apps/api/src/logic/chat.logic.ts
+++ b/apps/api/src/logic/chat.logic.ts
@@ -1,4 +1,9 @@
-import { findMatchingFallbackRulesDB, getTokenSaverSettingsDB, logRequestDB } from "@srouter/db";
+import {
+    findMatchingFallbackRulesDB,
+    getTokenSaverSettingsDB,
+    logRequestDB,
+    incrementAPIKeyUsageDB
+} from "@srouter/db";
 import { applyTokenSaver, estimateCostForUsage, extractUsageBreakdown } from "@srouter/translator";
 import type {
     ChatCompletionChunk,
@@ -93,6 +98,7 @@ function LogCompletion(
         fallbackOccurred?: boolean;
         fallbackPath?: string[];
         fallbackReason?: string;
+        apiKeyId?: string;
     }
 ): void {
     const breakdown = extractUsageBreakdown(providerId, options.usage);
@@ -100,8 +106,17 @@ function LogCompletion(
     const effectiveProvider = effectiveModel.includes("/")
         ? effectiveModel.split("/")[0]!
         : providerId;
+    const estimatedCost =
+        options.statusCode === 200
+            ? estimateCostForUsage(effectiveProvider, effectiveModel, breakdown)
+            : undefined;
+
+    if (options.statusCode === 200 && options.apiKeyId && breakdown.total_tokens > 0) {
+        incrementAPIKeyUsageDB(options.apiKeyId, breakdown.total_tokens, estimatedCost ?? 0);
+    }
 
     logRequestDB({
+        apiKeyId: options.apiKeyId,
         providerId,
         model,
         promptTokens: options.statusCode === 200 ? breakdown.prompt_tokens : 0,
@@ -111,10 +126,7 @@ function LogCompletion(
         cacheCreationTokens:
             options.statusCode === 200 ? breakdown.cache_creation_tokens : undefined,
         reasoningTokens: options.statusCode === 200 ? breakdown.reasoning_tokens : undefined,
-        estimatedCost:
-            options.statusCode === 200
-                ? estimateCostForUsage(effectiveProvider, effectiveModel, breakdown)
-                : undefined,
+        estimatedCost,
         fallbackOccurred: options.fallbackOccurred,
         fallbackPath: options.fallbackOccurred ? options.fallbackPath?.join(" -> ") : undefined,
         fallbackReason: options.fallbackReason,
@@ -127,7 +139,8 @@ export class ChatLogic {
     public static async ProcessNonStreamingCompletion(
         body: ChatCompletionRequest,
         startTime: number,
-        depth = 0
+        depth = 0,
+        apiKeyId?: string
     ): Promise<ChatCompletionResponse> {
         const effectiveBody =
             depth === 0 ? applyTokenSaver(body, getTokenSaverSettingsDB()).request : body;
@@ -196,7 +209,8 @@ export class ChatLogic {
                     return await this.ProcessNonStreamingCompletion(
                         followUpRequest,
                         startTime,
-                        depth + 1
+                        depth + 1,
+                        apiKeyId
                     );
                 }
 
@@ -205,7 +219,8 @@ export class ChatLogic {
                     usage: response.usage,
                     fallbackOccurred,
                     fallbackPath,
-                    fallbackReason
+                    fallbackReason,
+                    apiKeyId
                 });
 
                 return response;
@@ -226,7 +241,8 @@ export class ChatLogic {
             statusCode: 500,
             fallbackOccurred,
             fallbackPath,
-            fallbackReason
+            fallbackReason,
+            apiKeyId
         });
 
         throw lastError;
@@ -237,7 +253,8 @@ export class ChatLogic {
     public static async *ProcessStreamingCompletion(
         body: ChatCompletionRequest,
         startTime: number,
-        depth = 0
+        depth = 0,
+        apiKeyId?: string
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const effectiveBody =
             depth === 0 ? applyTokenSaver(body, getTokenSaverSettingsDB()).request : body;
@@ -364,7 +381,12 @@ export class ChatLogic {
                         ...currentReq,
                         messages: updatedMessages
                     };
-                    yield* this.ProcessStreamingCompletion(followUpRequest, startTime, depth + 1);
+                    yield* this.ProcessStreamingCompletion(
+                        followUpRequest,
+                        startTime,
+                        depth + 1,
+                        apiKeyId
+                    );
                     return;
                 }
 
@@ -377,7 +399,8 @@ export class ChatLogic {
                     usage,
                     fallbackOccurred,
                     fallbackPath,
-                    fallbackReason
+                    fallbackReason,
+                    apiKeyId
                 });
 
                 return;
@@ -396,7 +419,8 @@ export class ChatLogic {
                     statusCode: 500,
                     fallbackOccurred,
                     fallbackPath,
-                    fallbackReason
+                    fallbackReason,
+                    apiKeyId
                 });
                 throw err;
             }

--- a/apps/api/src/middleware/ApiKeyAuth.ts
+++ b/apps/api/src/middleware/ApiKeyAuth.ts
@@ -76,6 +76,31 @@ export function CreateApiKeyAuth(Options: ApiKeyAuthOptions = {}) {
                         code: "api_key_disabled"
                     });
                 }
+
+                if (ApiKeyRow.creditLimit > 0 && ApiKeyRow.usageCost >= ApiKeyRow.creditLimit) {
+                    return Err(
+                        c,
+                        "Insufficient credit balance. Your credit limit has been reached.",
+                        402,
+                        {
+                            type: "insufficient_quota",
+                            code: "insufficient_credit"
+                        }
+                    );
+                }
+
+                if (ApiKeyRow.quotaLimit > 0 && ApiKeyRow.usageTokens >= ApiKeyRow.quotaLimit) {
+                    return Err(
+                        c,
+                        "Token quota exceeded. Your lifetime token limit has been reached.",
+                        429,
+                        {
+                            type: "insufficient_quota",
+                            code: "quota_exceeded"
+                        }
+                    );
+                }
+
                 c.set("apiKeyRow", ApiKeyRow);
                 c.set("authType", "api_key");
                 return await next();

--- a/apps/api/src/middleware/ModelAccess.ts
+++ b/apps/api/src/middleware/ModelAccess.ts
@@ -1,0 +1,44 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { DBAPIKey } from "@srouter/types";
+import { Err } from "@/utils/response.js";
+
+function NormalizeModelId(model: string): string {
+    return model.replace(/^srouter\//, "");
+}
+
+export function IsModelAllowed(
+    allowedModels: string[] | null | undefined,
+    model: string
+): boolean {
+    if (!allowedModels || allowedModels.length === 0) return true;
+
+    const Requested = NormalizeModelId(model);
+    return allowedModels.some((allowed) => {
+        const Allowed = NormalizeModelId(allowed);
+        return Allowed === Requested || allowed === model;
+    });
+}
+
+export function GetApiKeyRow(c: Context): DBAPIKey | undefined {
+    return c.get("apiKeyRow") as DBAPIKey | undefined;
+}
+
+export function EnforceModelAccess(): MiddlewareHandler {
+    return async (c, next) => {
+        const ApiKeyRow = GetApiKeyRow(c);
+        const AllowedModels = ApiKeyRow?.allowed_models;
+
+        if (AllowedModels && AllowedModels.length > 0) {
+            const Body = c.req.valid("json" as never) as { model?: string } | undefined;
+            const Model = Body?.model;
+
+            if (Model && !IsModelAllowed(AllowedModels, Model)) {
+                return Err(c, `Model '${Model}' is not allowed for this API key`, 403, {
+                    code: "model_not_allowed"
+                });
+            }
+        }
+
+        return await next();
+    };
+}

--- a/apps/api/src/routes/v1/chat.ts
+++ b/apps/api/src/routes/v1/chat.ts
@@ -3,6 +3,7 @@ import { ChatCompletionRequestSchema } from "@srouter/types";
 import { ChatController } from "@/controllers/chat.controller.js";
 import { ValidateJson } from "@/middleware/Validation.js";
 import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
+import { EnforceModelAccess } from "@/middleware/ModelAccess.js";
 
 export const ChatRouter = new Hono();
 
@@ -10,11 +11,13 @@ ChatRouter.post(
     "/chat/completions",
     ApiKeyAuth,
     ValidateJson(ChatCompletionRequestSchema),
+    EnforceModelAccess(),
     ChatController.CreateCompletion
 );
 ChatRouter.post(
     "/chat/completion",
     ApiKeyAuth,
     ValidateJson(ChatCompletionRequestSchema),
+    EnforceModelAccess(),
     ChatController.CreateCompletion
 );

--- a/apps/api/src/routes/v1/keys.ts
+++ b/apps/api/src/routes/v1/keys.ts
@@ -9,4 +9,5 @@ KeysRouter.get("/keys", ApiKeyAuth, KeysController.ListKeys);
 
 // Mutation endpoints require Admin Auth
 KeysRouter.post("/keys", RequireAdmin, KeysController.CreateKey);
+KeysRouter.post("/keys/:id/credit", RequireAdmin, KeysController.AddCredit);
 KeysRouter.delete("/keys/:id", RequireAdmin, KeysController.DeleteKey);

--- a/apps/api/tests/api-keys-allowed-models.test.ts
+++ b/apps/api/tests/api-keys-allowed-models.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createAPIKeyDB, deleteAPIKeyDB, getAPIKeyByKeyDB } from "@srouter/db";
+import { IsModelAllowed } from "@/middleware/ModelAccess.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+test("createAPIKeyDB persists allowed_models and round-trips via lookup", () => {
+    const created = createAPIKeyDB({
+        name: "Restricted Key",
+        allowed_models: ["gpt-4o", "claude-3-5-sonnet-20241022"]
+    });
+    createdIds.push(created.id);
+
+    assert.deepEqual(created.allowed_models, ["gpt-4o", "claude-3-5-sonnet-20241022"]);
+
+    const lookup = getAPIKeyByKeyDB(created.key);
+    assert.ok(lookup);
+    assert.deepEqual(lookup?.allowed_models, ["gpt-4o", "claude-3-5-sonnet-20241022"]);
+});
+
+test("createAPIKeyDB normalizes empty allowed_models to null (unrestricted)", () => {
+    const created = createAPIKeyDB({
+        name: "Open Key",
+        allowed_models: []
+    });
+    createdIds.push(created.id);
+
+    assert.equal(created.allowed_models, null);
+
+    const lookup = getAPIKeyByKeyDB(created.key);
+    assert.equal(lookup?.allowed_models, null);
+});
+
+test("createAPIKeyDB defaults allowed_models to null when omitted", () => {
+    const created = createAPIKeyDB({ name: "Default Key" });
+    createdIds.push(created.id);
+
+    assert.equal(created.allowed_models, null);
+});
+
+test("IsModelAllowed permits any model when list is null or empty", () => {
+    assert.equal(IsModelAllowed(null, "gpt-4o"), true);
+    assert.equal(IsModelAllowed([], "gpt-4o"), true);
+    assert.equal(IsModelAllowed(undefined, "gpt-4o"), true);
+});
+
+test("IsModelAllowed enforces allow-list membership", () => {
+    const Allowed = ["gpt-4o", "claude-3-5-sonnet-20241022"];
+    assert.equal(IsModelAllowed(Allowed, "gpt-4o"), true);
+    assert.equal(IsModelAllowed(Allowed, "gpt-4o-mini"), false);
+    assert.equal(IsModelAllowed(Allowed, "claude-3-5-sonnet-20241022"), true);
+});
+
+test("IsModelAllowed ignores srouter/ prefix when matching", () => {
+    assert.equal(IsModelAllowed(["gpt-4o"], "srouter/gpt-4o"), true);
+    assert.equal(IsModelAllowed(["srouter/gpt-4o"], "gpt-4o"), true);
+});

--- a/apps/api/tests/api-keys-credit-db.test.ts
+++ b/apps/api/tests/api-keys-credit-db.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import {
+    addCreditAPIKeyDB,
+    createAPIKeyDB,
+    deleteAPIKeyDB,
+    getAPIKeyByKeyDB,
+    incrementAPIKeyUsageDB
+} from "@srouter/db";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+test("createAPIKeyDB stores creditLimit and usageCost default to 0", () => {
+    const key = createAPIKeyDB({
+        name: "Test Credit Key",
+        creditLimit: 15.5
+    });
+    createdIds.push(key.id);
+
+    assert.equal(key.creditLimit, 15.5);
+    assert.equal(key.usageCost, 0);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.ok(lookup);
+    assert.equal(lookup?.creditLimit, 15.5);
+    assert.equal(lookup?.usageCost, 0);
+});
+
+test("incrementAPIKeyUsageDB increments tokens and dollar cost", () => {
+    const key = createAPIKeyDB({
+        name: "Usage Test Key",
+        creditLimit: 20
+    });
+    createdIds.push(key.id);
+
+    incrementAPIKeyUsageDB(key.id, 500, 0.025);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.ok(lookup);
+    assert.equal(lookup?.usageTokens, 500);
+    assert.equal(Math.round((lookup?.usageCost ?? 0) * 1000) / 1000, 0.025);
+});
+
+test("addCreditAPIKeyDB increases creditLimit", () => {
+    const key = createAPIKeyDB({
+        name: "Add Credit Test Key",
+        creditLimit: 10
+    });
+    createdIds.push(key.id);
+
+    const updated = addCreditAPIKeyDB(key.id, 5.25);
+    assert.ok(updated);
+    assert.equal(updated?.creditLimit, 15.25);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.equal(lookup?.creditLimit, 15.25);
+});

--- a/apps/api/tests/api-keys-credit-route.test.ts
+++ b/apps/api/tests/api-keys-credit-route.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createAPIKeyDB, deleteAPIKeyDB, getAPIKeyByKeyDB } from "@srouter/db";
+import type { DBAPIKey } from "@srouter/types";
+import { Hono } from "hono";
+import { KeysRouter } from "@/routes/v1/keys.js";
+import { createAdminSession, ADMIN_SESSION_COOKIE } from "@/services/adminAuth.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+function createTestApp() {
+    const app = new Hono();
+    app.route("/v1", KeysRouter);
+    return app;
+}
+
+test("POST /v1/keys creates key with creditLimit", async () => {
+    const token = createAdminSession();
+    const app = createTestApp();
+    const res = await app.request("/v1/keys", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Cookie: `${ADMIN_SESSION_COOKIE}=${token}`
+        },
+        body: JSON.stringify({
+            name: "Credit API Key",
+            creditLimit: 25.5
+        })
+    });
+
+    assert.equal(res.status, 201);
+    const body = (await res.json()) as DBAPIKey;
+    createdIds.push(body.id);
+    assert.equal(body.creditLimit, 25.5);
+    assert.equal(body.usageCost, 0);
+});
+
+test("POST /v1/keys/:id/credit adds credit to existing key", async () => {
+    const token = createAdminSession();
+    const key = createAPIKeyDB({
+        name: "Topup Route Key",
+        creditLimit: 10
+    });
+    createdIds.push(key.id);
+
+    const app = createTestApp();
+    const res = await app.request(`/v1/keys/${key.id}/credit`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Cookie: `${ADMIN_SESSION_COOKIE}=${token}`
+        },
+        body: JSON.stringify({ amount: 15 })
+    });
+
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as DBAPIKey;
+    assert.equal(body.creditLimit, 25);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.equal(lookup?.creditLimit, 25);
+});
+
+test("POST /v1/keys/:id/credit rejects non-positive amount", async () => {
+    const token = createAdminSession();
+    const key = createAPIKeyDB({ name: "Validation Key" });
+    createdIds.push(key.id);
+
+    const app = createTestApp();
+    const res = await app.request(`/v1/keys/${key.id}/credit`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Cookie: `${ADMIN_SESSION_COOKIE}=${token}`
+        },
+        body: JSON.stringify({ amount: -5 })
+    });
+
+    assert.equal(res.status, 400);
+});

--- a/apps/api/tests/api-keys-quota-credit.test.ts
+++ b/apps/api/tests/api-keys-quota-credit.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { Hono } from "hono";
+import { createAPIKeyDB, deleteAPIKeyDB, incrementAPIKeyUsageDB } from "@srouter/db";
+import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+function createTestApp() {
+    const app = new Hono();
+    app.post("/test", ApiKeyAuth, (c) => c.json({ ok: true }));
+    return app;
+}
+
+test("ApiKeyAuth rejects request with 402 when credit balance is exhausted", async () => {
+    const key = createAPIKeyDB({
+        name: "Exhausted Credit Key",
+        creditLimit: 5.0
+    });
+    createdIds.push(key.id);
+
+    // Increment cost to exceed creditLimit
+    incrementAPIKeyUsageDB(key.id, 100, 5.01);
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key.key}`
+        }
+    });
+
+    assert.equal(res.status, 402);
+    const body = (await res.json()) as { error: { message: string; type: string; code: string } };
+    assert.equal(body.error.code, "insufficient_credit");
+    assert.match(body.error.message, /credit/i);
+});
+
+test("ApiKeyAuth rejects request with 429 when token quota is exhausted", async () => {
+    const key = createAPIKeyDB({
+        name: "Exhausted Quota Key",
+        quotaLimit: 1000
+    });
+    createdIds.push(key.id);
+
+    // Increment tokens to exceed quotaLimit
+    incrementAPIKeyUsageDB(key.id, 1005, 0);
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key.key}`
+        }
+    });
+
+    assert.equal(res.status, 429);
+    const body = (await res.json()) as { error: { message: string; code: string } };
+    assert.equal(body.error.code, "quota_exceeded");
+    assert.match(body.error.message, /quota/i);
+});
+
+test("ApiKeyAuth allows request when within credit and quota limits", async () => {
+    const key = createAPIKeyDB({
+        name: "Valid Key",
+        creditLimit: 10.0,
+        quotaLimit: 10000
+    });
+    createdIds.push(key.id);
+
+    incrementAPIKeyUsageDB(key.id, 1000, 1.0);
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key.key}`
+        }
+    });
+
+    assert.equal(res.status, 200);
+});

--- a/apps/api/tests/api-keys-usage-deduction.test.ts
+++ b/apps/api/tests/api-keys-usage-deduction.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createAPIKeyDB, deleteAPIKeyDB, getAPIKeyByKeyDB } from "@srouter/db";
+import { ChatLogic } from "@/logic/chat.logic.js";
+import { registry } from "@/services/registry.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+test("ChatLogic.ProcessNonStreamingCompletion records usage tokens and dollar cost for apiKeyId", async () => {
+    const key = createAPIKeyDB({
+        name: "Deduction Key",
+        creditLimit: 10
+    });
+    createdIds.push(key.id);
+
+    // Mock provider in registry
+    const origMethod = registry.chatCompletion;
+    registry.chatCompletion = async () => ({
+        id: "chatcmpl-mock",
+        object: "chat.completion",
+        created: Date.now(),
+        model: "openai_codex/gpt-4o",
+        choices: [
+            {
+                index: 0,
+                message: { role: "assistant", content: "Hello!" },
+                finish_reason: "stop"
+            }
+        ],
+        usage: {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            total_tokens: 150
+        }
+    });
+
+    try {
+        await ChatLogic.ProcessNonStreamingCompletion(
+            {
+                model: "openai_codex/gpt-4o",
+                messages: [{ role: "user", content: "Hi" }]
+            },
+            Date.now(),
+            0,
+            key.id
+        );
+
+        const updated = getAPIKeyByKeyDB(key.key);
+        assert.ok(updated);
+        assert.equal(updated?.usageTokens, 150);
+        assert.ok((updated?.usageCost ?? 0) > 0, "Usage cost should be greater than 0");
+    } finally {
+        registry.chatCompletion = origMethod;
+    }
+});
+
+test("ChatLogic.ProcessStreamingCompletion records usage tokens and dollar cost for apiKeyId", async () => {
+    const key = createAPIKeyDB({
+        name: "Streaming Deduction Key",
+        creditLimit: 10
+    });
+    createdIds.push(key.id);
+
+    const origStream = registry.chatCompletionStream;
+    registry.chatCompletionStream = async function* () {
+        yield {
+            id: "chatcmpl-mock",
+            object: "chat.completion.chunk",
+            created: Date.now(),
+            model: "openai_codex/gpt-4o",
+            choices: [{ index: 0, delta: { content: "Hello" } }]
+        };
+        yield {
+            id: "chatcmpl-mock",
+            object: "chat.completion.chunk",
+            created: Date.now(),
+            model: "openai_codex/gpt-4o",
+            choices: [{ index: 0, delta: {} }],
+            usage: {
+                prompt_tokens: 200,
+                completion_tokens: 100,
+                total_tokens: 300
+            }
+        };
+    };
+
+    try {
+        const stream = ChatLogic.ProcessStreamingCompletion(
+            {
+                model: "openai_codex/gpt-4o",
+                messages: [{ role: "user", content: "Hi" }],
+                stream: true
+            },
+            Date.now(),
+            0,
+            key.id
+        );
+
+        for await (const _ of stream) {
+            // consume stream
+        }
+
+        const updated = getAPIKeyByKeyDB(key.key);
+        assert.ok(updated);
+        assert.equal(updated?.usageTokens, 300);
+        assert.ok((updated?.usageCost ?? 0) > 0, "Streaming usage cost should be greater than 0");
+    } finally {
+        registry.chatCompletionStream = origStream;
+    }
+});

--- a/apps/web/src/components/keys/AddCreditDialog.tsx
+++ b/apps/web/src/components/keys/AddCreditDialog.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from "react";
+import type { DBAPIKey } from "@srouter/types";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type AddCreditDialogProps = {
+    apiKey: DBAPIKey | null;
+    open: boolean;
+    loading: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSubmit: (keyId: string, amount: number) => Promise<void>;
+};
+
+const QUICK_AMOUNTS = [5, 10, 25, 50];
+
+export function AddCreditDialog({
+    apiKey,
+    open,
+    loading,
+    onOpenChange,
+    onSubmit
+}: AddCreditDialogProps) {
+    const [amount, setAmount] = useState("");
+
+    if (!apiKey) return null;
+
+    const currentLimit = apiKey.creditLimit ?? 0;
+    const currentCost = apiKey.usageCost ?? 0;
+    const remainingBalance = currentLimit > 0 ? Math.max(0, currentLimit - currentCost) : null;
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const num = parseFloat(amount);
+        if (!Number.isFinite(num) || num <= 0) return;
+
+        await onSubmit(apiKey.id, num);
+        setAmount("");
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-md bg-card border-border p-6">
+                <DialogHeader className="space-y-1 text-left">
+                    <DialogTitle className="text-base font-semibold text-foreground">
+                        Add Credit
+                    </DialogTitle>
+                    <DialogDescription className="text-xs text-muted-foreground leading-relaxed">
+                        Add prepaid dollar balance to{" "}
+                        <span className="font-semibold text-foreground font-mono">{apiKey.name}</span>.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {/* Current Balance Summary */}
+                <div className="rounded-lg border border-border/70 bg-secondary/30 p-3 my-2 text-xs space-y-1.5">
+                    <div className="flex justify-between items-center">
+                        <span className="text-muted-foreground">Current Balance:</span>
+                        <span className="font-mono font-semibold text-foreground">
+                            {remainingBalance !== null
+                                ? `$${remainingBalance.toFixed(2)} USD`
+                                : "Unlimited"}
+                        </span>
+                    </div>
+                    <div className="flex justify-between items-center text-[11px] text-muted-foreground">
+                        <span>Lifetime Spent:</span>
+                        <span className="font-mono">${currentCost.toFixed(3)} USD</span>
+                    </div>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4 pt-1">
+                    <div className="space-y-2">
+                        <label
+                            htmlFor="add-amount"
+                            className="block text-xs font-medium text-foreground"
+                        >
+                            Amount to add ($ USD) <span className="text-destructive">*</span>
+                        </label>
+                        <Input
+                            id="add-amount"
+                            type="number"
+                            min="0.01"
+                            step="0.01"
+                            required
+                            autoFocus
+                            value={amount}
+                            onChange={(e) => setAmount(e.target.value)}
+                            placeholder="e.g. 10.00"
+                            className="h-9 font-mono text-xs rounded-md bg-background border-input"
+                        />
+
+                        {/* Quick Chip Shortcuts */}
+                        <div className="flex items-center gap-1.5 pt-1">
+                            {QUICK_AMOUNTS.map((val) => (
+                                <button
+                                    key={val}
+                                    type="button"
+                                    onClick={() => setAmount(String(val))}
+                                    className="rounded-md border border-border/70 bg-background px-2.5 py-1 font-mono text-[11px] text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors cursor-pointer"
+                                >
+                                    +${val}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <DialogFooter className="pt-3 gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                            className="h-8.5 text-xs font-medium cursor-pointer"
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="submit"
+                            disabled={loading || !amount || parseFloat(amount) <= 0}
+                            className="h-8.5 text-xs font-semibold cursor-pointer shadow-xs"
+                        >
+                            {loading ? "Adding…" : "Add Credit"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/web/src/components/keys/CreateKeyDialog.tsx
+++ b/apps/web/src/components/keys/CreateKeyDialog.tsx
@@ -1,4 +1,8 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Check, Search, X } from "lucide-react";
+import type { ModelListResponse } from "@srouter/types";
+import { api } from "@/lib/api";
 import {
     Dialog,
     DialogContent,
@@ -14,13 +18,52 @@ type CreateKeyDialogProps = {
     open: boolean;
     creating: boolean;
     onOpenChange: (open: boolean) => void;
-    onSubmit: (data: { name: string; rateLimit?: number; quotaLimit?: number }) => Promise<void>;
+    onSubmit: (data: {
+        name: string;
+        rateLimit?: number;
+        quotaLimit?: number;
+        allowed_models?: string[] | null;
+    }) => Promise<void>;
 };
+
+type ModelScope = "all" | "restricted";
 
 export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: CreateKeyDialogProps) {
     const [name, setName] = useState("");
     const [rateLimit, setRateLimit] = useState("");
     const [quotaLimit, setQuotaLimit] = useState("");
+    const [modelScope, setModelScope] = useState<ModelScope>("all");
+    const [selectedModels, setSelectedModels] = useState<string[]>([]);
+    const [modelSearch, setModelSearch] = useState("");
+
+    const { data: modelsData, isPending: modelsPending } = useQuery({
+        queryKey: ["models"],
+        queryFn: () => api.get<ModelListResponse>("/v1/models"),
+        enabled: open && modelScope === "restricted"
+    });
+
+    const models = useMemo(() => modelsData?.data ?? [], [modelsData]);
+
+    const filteredModels = useMemo(() => {
+        const query = modelSearch.trim().toLowerCase();
+        if (!query) return models;
+        return models.filter((m) => m.id.toLowerCase().includes(query));
+    }, [models, modelSearch]);
+
+    const resetForm = () => {
+        setName("");
+        setRateLimit("");
+        setQuotaLimit("");
+        setModelScope("all");
+        setSelectedModels([]);
+        setModelSearch("");
+    };
+
+    const toggleModel = (modelId: string) => {
+        setSelectedModels((prev) =>
+            prev.includes(modelId) ? prev.filter((id) => id !== modelId) : [...prev, modelId]
+        );
+    };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -29,16 +72,17 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
 
         const rateNum = rateLimit.trim() ? parseInt(rateLimit, 10) : undefined;
         const quotaNum = quotaLimit.trim() ? parseInt(quotaLimit, 10) : undefined;
+        const allowedModels =
+            modelScope === "restricted" && selectedModels.length > 0 ? selectedModels : null;
 
         await onSubmit({
             name: trimmedName,
             rateLimit: Number.isFinite(rateNum) && (rateNum ?? 0) > 0 ? rateNum : undefined,
-            quotaLimit: Number.isFinite(quotaNum) && (quotaNum ?? 0) > 0 ? quotaNum : undefined
+            quotaLimit: Number.isFinite(quotaNum) && (quotaNum ?? 0) > 0 ? quotaNum : undefined,
+            allowed_models: allowedModels
         });
 
-        setName("");
-        setRateLimit("");
-        setQuotaLimit("");
+        resetForm();
     };
 
     return (
@@ -128,6 +172,114 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
                                 Optional max lifetime tokens
                             </p>
                         </div>
+                    </div>
+
+                    {/* Allowed Models Scope */}
+                    <div className="space-y-2 pt-1">
+                        <label className="block text-xs font-medium text-foreground">
+                            Allowed models
+                        </label>
+                        <div className="grid grid-cols-2 gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setModelScope("all")}
+                                className={`rounded-md border px-3 py-2 text-left text-xs transition-colors cursor-pointer ${
+                                    modelScope === "all"
+                                        ? "border-primary bg-primary/10 text-foreground font-semibold"
+                                        : "border-input bg-background text-muted-foreground hover:text-foreground"
+                                }`}
+                            >
+                                All models
+                                <span className="block text-[10px] font-normal opacity-70">
+                                    Unrestricted access
+                                </span>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setModelScope("restricted")}
+                                className={`rounded-md border px-3 py-2 text-left text-xs transition-colors cursor-pointer ${
+                                    modelScope === "restricted"
+                                        ? "border-primary bg-primary/10 text-foreground font-semibold"
+                                        : "border-input bg-background text-muted-foreground hover:text-foreground"
+                                }`}
+                            >
+                                Specific models
+                                <span className="block text-[10px] font-normal opacity-70">
+                                    Restrict to a subset
+                                </span>
+                            </button>
+                        </div>
+
+                        {modelScope === "restricted" && (
+                            <div className="space-y-2 rounded-md border border-border/70 bg-background/50 p-2.5">
+                                <div className="relative">
+                                    <Search className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                                    <Input
+                                        type="text"
+                                        value={modelSearch}
+                                        onChange={(e) => setModelSearch(e.target.value)}
+                                        placeholder="Search models…"
+                                        className="h-8 pl-8 pr-7 font-mono text-xs rounded-md bg-background"
+                                    />
+                                    {modelSearch && (
+                                        <button
+                                            type="button"
+                                            onClick={() => setModelSearch("")}
+                                            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-xs p-0.5 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                            aria-label="Clear search"
+                                        >
+                                            <X className="size-3" />
+                                        </button>
+                                    )}
+                                </div>
+
+                                <div className="max-h-44 overflow-y-auto rounded-md">
+                                    {modelsPending ? (
+                                        <p className="py-4 text-center text-[11px] text-muted-foreground">
+                                            Loading models…
+                                        </p>
+                                    ) : filteredModels.length === 0 ? (
+                                        <p className="py-4 text-center text-[11px] text-muted-foreground">
+                                            No models matched your search.
+                                        </p>
+                                    ) : (
+                                        <ul className="space-y-0.5">
+                                            {filteredModels.map((model) => {
+                                                const isSelected = selectedModels.includes(
+                                                    model.id
+                                                );
+                                                return (
+                                                    <li key={model.id}>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => toggleModel(model.id)}
+                                                            className={`flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left font-mono text-[11px] transition-colors cursor-pointer ${
+                                                                isSelected
+                                                                    ? "bg-primary/10 text-foreground"
+                                                                    : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+                                                            }`}
+                                                        >
+                                                            <span className="truncate">
+                                                                {model.id}
+                                                            </span>
+                                                            {isSelected && (
+                                                                <Check className="size-3.5 shrink-0 text-primary" />
+                                                            )}
+                                                        </button>
+                                                    </li>
+                                                );
+                                            })}
+                                        </ul>
+                                    )}
+                                </div>
+
+                                <p className="text-[11px] text-muted-foreground">
+                                    {selectedModels.length > 0
+                                        ? `${selectedModels.length} model${selectedModels.length === 1 ? "" : "s"} selected`
+                                        : "Select at least one model, or the key stays unrestricted."}
+                                </p>
+                            </div>
+                        )}
                     </div>
 
                     <DialogFooter className="pt-3 gap-2">

--- a/apps/web/src/components/keys/CreateKeyDialog.tsx
+++ b/apps/web/src/components/keys/CreateKeyDialog.tsx
@@ -22,6 +22,7 @@ type CreateKeyDialogProps = {
         name: string;
         rateLimit?: number;
         quotaLimit?: number;
+        creditLimit?: number;
         allowed_models?: string[] | null;
     }) => Promise<void>;
 };
@@ -32,6 +33,7 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
     const [name, setName] = useState("");
     const [rateLimit, setRateLimit] = useState("");
     const [quotaLimit, setQuotaLimit] = useState("");
+    const [creditLimit, setCreditLimit] = useState("");
     const [modelScope, setModelScope] = useState<ModelScope>("all");
     const [selectedModels, setSelectedModels] = useState<string[]>([]);
     const [modelSearch, setModelSearch] = useState("");
@@ -54,6 +56,7 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
         setName("");
         setRateLimit("");
         setQuotaLimit("");
+        setCreditLimit("");
         setModelScope("all");
         setSelectedModels([]);
         setModelSearch("");
@@ -72,6 +75,7 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
 
         const rateNum = rateLimit.trim() ? parseInt(rateLimit, 10) : undefined;
         const quotaNum = quotaLimit.trim() ? parseInt(quotaLimit, 10) : undefined;
+        const creditNum = creditLimit.trim() ? parseFloat(creditLimit) : undefined;
         const allowedModels =
             modelScope === "restricted" && selectedModels.length > 0 ? selectedModels : null;
 
@@ -79,6 +83,7 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
             name: trimmedName,
             rateLimit: Number.isFinite(rateNum) && (rateNum ?? 0) > 0 ? rateNum : undefined,
             quotaLimit: Number.isFinite(quotaNum) && (quotaNum ?? 0) > 0 ? quotaNum : undefined,
+            creditLimit: Number.isFinite(creditNum) && (creditNum ?? 0) > 0 ? creditNum : undefined,
             allowed_models: allowedModels
         });
 
@@ -122,7 +127,7 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
                     </div>
 
                     {/* Limits Section */}
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-1">
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5 pt-1">
                         {/* Rate Limit */}
                         <div className="space-y-1.5">
                             <label
@@ -130,8 +135,8 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
                                 className="block text-xs font-medium text-foreground"
                             >
                                 Rate limit{" "}
-                                <span className="text-[11px] font-normal text-muted-foreground">
-                                    (req/min)
+                                <span className="text-[10px] font-normal text-muted-foreground">
+                                    (req/m)
                                 </span>
                             </label>
                             <Input
@@ -143,8 +148,8 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
                                 placeholder="Unlimited"
                                 className="h-9 font-mono text-xs rounded-md bg-background border-input"
                             />
-                            <p className="text-[11px] text-muted-foreground">
-                                Optional max requests/min
+                            <p className="text-[10px] text-muted-foreground">
+                                Max req/min
                             </p>
                         </div>
 
@@ -155,7 +160,7 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
                                 className="block text-xs font-medium text-foreground"
                             >
                                 Token quota{" "}
-                                <span className="text-[11px] font-normal text-muted-foreground">
+                                <span className="text-[10px] font-normal text-muted-foreground">
                                     (tokens)
                                 </span>
                             </label>
@@ -168,8 +173,34 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
                                 placeholder="Unlimited"
                                 className="h-9 font-mono text-xs rounded-md bg-background border-input"
                             />
-                            <p className="text-[11px] text-muted-foreground">
-                                Optional max lifetime tokens
+                            <p className="text-[10px] text-muted-foreground">
+                                Max tokens
+                            </p>
+                        </div>
+
+                        {/* Credit Limit */}
+                        <div className="space-y-1.5">
+                            <label
+                                htmlFor="credit-limit"
+                                className="block text-xs font-medium text-foreground"
+                            >
+                                Credit limit{" "}
+                                <span className="text-[10px] font-normal text-muted-foreground">
+                                    ($ USD)
+                                </span>
+                            </label>
+                            <Input
+                                id="credit-limit"
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                value={creditLimit}
+                                onChange={(e) => setCreditLimit(e.target.value)}
+                                placeholder="Unlimited"
+                                className="h-9 font-mono text-xs rounded-md bg-background border-input"
+                            />
+                            <p className="text-[10px] text-muted-foreground">
+                                Prepaid budget
                             </p>
                         </div>
                     </div>

--- a/apps/web/src/components/keys/KeySecretModal.tsx
+++ b/apps/web/src/components/keys/KeySecretModal.tsx
@@ -88,6 +88,27 @@ export function KeySecretModal({ newKey, onClose }: KeySecretModalProps) {
                             </Button>
                         </div>
                     </div>
+                    {newKey.allowed_models && newKey.allowed_models.length > 0 ? (
+                        <div className="space-y-1.5">
+                            <span className="block text-xs font-medium text-foreground">
+                                Allowed models
+                            </span>
+                            <div className="flex flex-wrap gap-1.5">
+                                {newKey.allowed_models.map((model) => (
+                                    <span
+                                        key={model}
+                                        className="inline-flex items-center rounded-full border border-border/60 bg-secondary/40 px-2 py-0.5 font-mono text-[10px] text-foreground"
+                                    >
+                                        {model}
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    ) : (
+                        <p className="text-[11px] text-muted-foreground">
+                            This key can access all models.
+                        </p>
+                    )}
                 </div>
 
                 <DialogFooter className="pt-2">

--- a/apps/web/src/components/keys/KeySecretModal.tsx
+++ b/apps/web/src/components/keys/KeySecretModal.tsx
@@ -88,6 +88,27 @@ export function KeySecretModal({ newKey, onClose }: KeySecretModalProps) {
                             </Button>
                         </div>
                     </div>
+                    {/* Key Limits / Credit Summary */}
+                    {(newKey.creditLimit > 0 || newKey.quotaLimit > 0 || newKey.rateLimit > 0) && (
+                        <div className="flex flex-wrap gap-2 text-[11px] font-mono text-muted-foreground pt-1">
+                            {newKey.creditLimit > 0 && (
+                                <span className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-emerald-600 dark:text-emerald-400 font-semibold">
+                                    Credit: ${newKey.creditLimit.toFixed(2)} USD
+                                </span>
+                            )}
+                            {newKey.quotaLimit > 0 && (
+                                <span className="rounded-md border border-border/60 bg-secondary/40 px-2 py-0.5">
+                                    Quota: {newKey.quotaLimit.toLocaleString()} tokens
+                                </span>
+                            )}
+                            {newKey.rateLimit > 0 && (
+                                <span className="rounded-md border border-border/60 bg-secondary/40 px-2 py-0.5">
+                                    Rate: {newKey.rateLimit.toLocaleString()} req/m
+                                </span>
+                            )}
+                        </div>
+                    )}
+
                     {newKey.allowed_models && newKey.allowed_models.length > 0 ? (
                         <div className="space-y-1.5">
                             <span className="block text-xs font-medium text-foreground">

--- a/apps/web/src/components/keys/KeyTable.tsx
+++ b/apps/web/src/components/keys/KeyTable.tsx
@@ -182,6 +182,7 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                 <th className="py-2.5 px-4 text-right font-semibold">
                                     Token Quota
                                 </th>
+                                <th className="py-2.5 px-4 font-semibold">Models</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">Usage</th>
                                 <th className="py-2.5 px-4 text-center font-semibold">Status</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">Created</th>
@@ -270,6 +271,23 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                             ) : (
                                                 <span className="text-muted-foreground/60">
                                                     Unlimited
+                                                </span>
+                                            )}
+                                        </td>
+
+                                        {/* Allowed Models Scope */}
+                                        <td className="py-3 px-4">
+                                            {k.allowed_models && k.allowed_models.length > 0 ? (
+                                                <span
+                                                    className="inline-flex items-center rounded-full border border-border/60 bg-secondary/40 px-2 py-0.5 font-mono text-[10px] font-medium text-foreground cursor-default"
+                                                    title={k.allowed_models.join("\n")}
+                                                >
+                                                    {k.allowed_models.length} model
+                                                    {k.allowed_models.length === 1 ? "" : "s"}
+                                                </span>
+                                            ) : (
+                                                <span className="font-mono text-[10px] text-muted-foreground/60">
+                                                    All
                                                 </span>
                                             )}
                                         </td>

--- a/apps/web/src/components/keys/KeyTable.tsx
+++ b/apps/web/src/components/keys/KeyTable.tsx
@@ -1,17 +1,18 @@
 import { useState, useMemo } from "react";
-import { Check, Copy, KeyRound, Plus, Search, Trash2, X } from "lucide-react";
+import { Check, CircleDollarSign, Copy, KeyRound, Plus, Search, Trash2, X } from "lucide-react";
 import type { DBAPIKey } from "@srouter/types";
 import { useDebounce } from "@/hooks/useDebounce";
 import { formatCompactNumber } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
-type KeyFilter = "all" | "active" | "with-quota" | "with-rate-limit";
+type KeyFilter = "all" | "active" | "with-credit" | "with-quota" | "with-rate-limit";
 
 type KeyTableProps = {
     keys: DBAPIKey[];
     deletingId: string | null;
     onCreateClick: () => void;
+    onAddCreditClick: (key: DBAPIKey) => void;
     onDeleteClick: (key: DBAPIKey) => void;
 };
 
@@ -20,7 +21,13 @@ function maskKey(key: string): string {
     return `${key.slice(0, 10)}••••••••${key.slice(-4)}`;
 }
 
-export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: KeyTableProps) {
+export function KeyTable({
+    keys,
+    deletingId,
+    onCreateClick,
+    onAddCreditClick,
+    onDeleteClick
+}: KeyTableProps) {
     const [search, setSearch] = useState("");
     const [filter, setFilter] = useState<KeyFilter>("all");
     const [copiedKeyId, setCopiedKeyId] = useState<string | null>(null);
@@ -40,6 +47,7 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
             if (!matchesText) return false;
 
             if (filter === "active") return k.enabled;
+            if (filter === "with-credit") return (k.creditLimit ?? 0) > 0;
             if (filter === "with-quota") return (k.quotaLimit ?? 0) > 0;
             if (filter === "with-rate-limit") return (k.rateLimit ?? 0) > 0;
 
@@ -136,6 +144,17 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                         </button>
                         <button
                             type="button"
+                            onClick={() => setFilter("with-credit")}
+                            className={`rounded-md px-2.5 py-1 text-[11px] font-mono transition-colors cursor-pointer whitespace-nowrap ${
+                                filter === "with-credit"
+                                    ? "bg-secondary text-foreground font-semibold"
+                                    : "text-muted-foreground hover:text-foreground hover:bg-secondary/40"
+                            }`}
+                        >
+                            With Credit ({keys.filter((k) => (k.creditLimit ?? 0) > 0).length})
+                        </button>
+                        <button
+                            type="button"
                             onClick={() => setFilter("with-quota")}
                             className={`rounded-md px-2.5 py-1 text-[11px] font-mono transition-colors cursor-pointer whitespace-nowrap ${
                                 filter === "with-quota"
@@ -179,11 +198,12 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                 <th className="py-2.5 px-4 font-semibold">Key Name & ID</th>
                                 <th className="py-2.5 px-4 font-semibold">Secret Key</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">Rate Limit</th>
+                                <th className="py-2.5 px-4 text-right font-semibold">Credit / Balance</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">
                                     Token Quota
                                 </th>
                                 <th className="py-2.5 px-4 font-semibold">Models</th>
-                                <th className="py-2.5 px-4 text-right font-semibold">Usage</th>
+                                <th className="py-2.5 px-4 text-right font-semibold">Tokens</th>
                                 <th className="py-2.5 px-4 text-center font-semibold">Status</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">Created</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">Action</th>
@@ -195,6 +215,14 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                 const isDeleting = deletingId === k.id;
                                 const quotaLimit = k.quotaLimit ?? 0;
                                 const usageTokens = k.usageTokens ?? 0;
+                                const creditLimit = k.creditLimit ?? 0;
+                                const usageCost = k.usageCost ?? 0;
+                                const remainingCredit =
+                                    creditLimit > 0 ? Math.max(0, creditLimit - usageCost) : null;
+                                const creditPercent =
+                                    creditLimit > 0
+                                        ? Math.min(100, Math.round((usageCost / creditLimit) * 100))
+                                        : null;
                                 const quotaPercent =
                                     quotaLimit > 0
                                         ? Math.min(
@@ -253,6 +281,56 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                                 <span className="text-muted-foreground/60">
                                                     Unlimited
                                                 </span>
+                                            )}
+                                        </td>
+
+                                        {/* Credit / Balance */}
+                                        <td className="py-3 px-4 text-right font-mono tabular-nums text-muted-foreground">
+                                            {creditLimit > 0 ? (
+                                                <div>
+                                                    <span
+                                                        className="text-foreground font-semibold text-emerald-500 cursor-default"
+                                                        title={`Credit: $${remainingCredit?.toFixed(2)} left of $${creditLimit.toFixed(2)}`}
+                                                    >
+                                                        ${remainingCredit?.toFixed(2)}{" "}
+                                                        <span className="text-[10px] text-muted-foreground font-normal">
+                                                            left
+                                                        </span>
+                                                    </span>
+                                                    {creditPercent !== null && (
+                                                        <div className="mt-1 flex items-center justify-end gap-1.5 text-[9.5px] text-muted-foreground">
+                                                            <div className="w-12 h-1 rounded-full bg-secondary overflow-hidden ring-1 ring-border/30">
+                                                                <div
+                                                                    className={`h-full transition-all duration-300 ${
+                                                                        creditPercent > 90
+                                                                            ? "bg-destructive"
+                                                                            : creditPercent > 70
+                                                                              ? "bg-amber-500"
+                                                                              : "bg-emerald-500"
+                                                                    }`}
+                                                                    style={{
+                                                                        width: `${creditPercent}%`
+                                                                    }}
+                                                                />
+                                                            </div>
+                                                            <span>{creditPercent}%</span>
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            ) : (
+                                                <div
+                                                    className="cursor-default"
+                                                    title={`Spent: $${usageCost.toFixed(3)}`}
+                                                >
+                                                    <span className="text-muted-foreground/60">
+                                                        Unlimited
+                                                    </span>
+                                                    {usageCost > 0 && (
+                                                        <div className="text-[9.5px] text-muted-foreground/80 font-mono mt-0.5">
+                                                            ${usageCost.toFixed(2)} spent
+                                                        </div>
+                                                    )}
+                                                </div>
                                             )}
                                         </td>
 
@@ -337,18 +415,29 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                             {new Date(k.createdAt).toLocaleDateString()}
                                         </td>
 
-                                        {/* Action: Revoke / Delete */}
+                                        {/* Action: Add Credit & Revoke / Delete */}
                                         <td className="py-3 px-4 text-right">
-                                            <button
-                                                type="button"
-                                                disabled={isDeleting}
-                                                onClick={() => onDeleteClick(k)}
-                                                className="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors disabled:opacity-30 cursor-pointer ml-auto"
-                                                title="Revoke and delete key"
-                                                aria-label={`Revoke key ${k.name}`}
-                                            >
-                                                <Trash2 className="size-3.5" />
-                                            </button>
+                                            <div className="flex items-center justify-end gap-1">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => onAddCreditClick(k)}
+                                                    className="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-emerald-500/10 hover:text-emerald-500 transition-colors cursor-pointer"
+                                                    title="Add credit / saldo"
+                                                    aria-label={`Add credit to key ${k.name}`}
+                                                >
+                                                    <CircleDollarSign className="size-3.5" />
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    disabled={isDeleting}
+                                                    onClick={() => onDeleteClick(k)}
+                                                    className="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors disabled:opacity-30 cursor-pointer"
+                                                    title="Revoke and delete key"
+                                                    aria-label={`Revoke key ${k.name}`}
+                                                >
+                                                    <Trash2 className="size-3.5" />
+                                                </button>
+                                            </div>
                                         </td>
                                     </tr>
                                 );

--- a/apps/web/src/hooks/useKeys.ts
+++ b/apps/web/src/hooks/useKeys.ts
@@ -8,6 +8,7 @@ export function useKeys() {
     const [loading, setLoading] = useState(true);
     const [creating, setCreating] = useState(false);
     const [deletingId, setDeletingId] = useState<string | null>(null);
+    const [addingCreditId, setAddingCreditId] = useState<string | null>(null);
     const [newlyCreatedKey, setNewlyCreatedKey] = useState<DBAPIKey | null>(null);
 
     const fetchKeys = useCallback(async () => {
@@ -31,6 +32,7 @@ export function useKeys() {
             name: string;
             rateLimit?: number;
             quotaLimit?: number;
+            creditLimit?: number;
             allowed_models?: string[] | null;
         }) => {
             if (!data.name.trim()) {
@@ -56,6 +58,27 @@ export function useKeys() {
         []
     );
 
+    const addCredit = useCallback(async (id: string, amount: number) => {
+        if (!Number.isFinite(amount) || amount <= 0) {
+            toast.error("Amount must be greater than 0");
+            return null;
+        }
+
+        setAddingCreditId(id);
+        try {
+            const updated = await api.post<DBAPIKey>(`/v1/keys/${id}/credit`, { amount });
+            setKeys((prev) => prev.map((k) => (k.id === id ? updated : k)));
+            toast.success(`Added $${amount.toFixed(2)} credit to "${updated.name}"`);
+            return updated;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "Failed to add credit";
+            toast.error(msg);
+            return null;
+        } finally {
+            setAddingCreditId(null);
+        }
+    }, []);
+
     const deleteKey = useCallback(async (id: string) => {
         setDeletingId(id);
         try {
@@ -77,10 +100,12 @@ export function useKeys() {
         loading,
         creating,
         deletingId,
+        addingCreditId,
         newlyCreatedKey,
         setNewlyCreatedKey,
         fetchKeys,
         createKey,
+        addCredit,
         deleteKey
     };
 }

--- a/apps/web/src/hooks/useKeys.ts
+++ b/apps/web/src/hooks/useKeys.ts
@@ -27,7 +27,12 @@ export function useKeys() {
     }, [fetchKeys]);
 
     const createKey = useCallback(
-        async (data: { name: string; rateLimit?: number; quotaLimit?: number }) => {
+        async (data: {
+            name: string;
+            rateLimit?: number;
+            quotaLimit?: number;
+            allowed_models?: string[] | null;
+        }) => {
             if (!data.name.trim()) {
                 toast.error("Key name is required");
                 return null;

--- a/apps/web/src/routes/keys.tsx
+++ b/apps/web/src/routes/keys.tsx
@@ -11,6 +11,7 @@ import { KeyTable } from "@/components/keys/KeyTable";
 import { CreateKeyDialog } from "@/components/keys/CreateKeyDialog";
 import { KeySecretModal } from "@/components/keys/KeySecretModal";
 import { KeyDeleteDialog } from "@/components/keys/KeyDeleteDialog";
+import { AddCreditDialog } from "@/components/keys/AddCreditDialog";
 
 export const Route = createFileRoute("/keys")({
     staticData: { title: "API Keys" },
@@ -23,14 +24,17 @@ function KeysPage() {
         loading,
         creating,
         deletingId,
+        addingCreditId,
         newlyCreatedKey,
         setNewlyCreatedKey,
         createKey,
+        addCredit,
         deleteKey
     } = useKeys();
 
     const [isCreateOpen, setIsCreateOpen] = useState(false);
     const [keyToDelete, setKeyToDelete] = useState<DBAPIKey | null>(null);
+    const [keyToAddCredit, setKeyToAddCredit] = useState<DBAPIKey | null>(null);
 
     const totalUsageTokens = keys.reduce((acc, k) => acc + (k.usageTokens || 0), 0);
     const activeKeysCount = keys.filter((k) => k.enabled).length;
@@ -39,6 +43,7 @@ function KeysPage() {
         name: string;
         rateLimit?: number;
         quotaLimit?: number;
+        creditLimit?: number;
         allowed_models?: string[] | null;
     }) => {
         const res = await createKey(data);
@@ -97,6 +102,7 @@ function KeysPage() {
                 keys={keys}
                 deletingId={deletingId}
                 onCreateClick={() => setIsCreateOpen(true)}
+                onAddCreditClick={(key) => setKeyToAddCredit(key)}
                 onDeleteClick={(key) => setKeyToDelete(key)}
             />
 
@@ -106,6 +112,16 @@ function KeysPage() {
                 creating={creating}
                 onOpenChange={setIsCreateOpen}
                 onSubmit={handleCreateKey}
+            />
+
+            <AddCreditDialog
+                apiKey={keyToAddCredit}
+                open={Boolean(keyToAddCredit)}
+                loading={Boolean(addingCreditId)}
+                onOpenChange={(open) => !open && setKeyToAddCredit(null)}
+                onSubmit={async (keyId, amount) => {
+                    await addCredit(keyId, amount);
+                }}
             />
 
             <KeySecretModal newKey={newlyCreatedKey} onClose={() => setNewlyCreatedKey(null)} />

--- a/apps/web/src/routes/keys.tsx
+++ b/apps/web/src/routes/keys.tsx
@@ -39,6 +39,7 @@ function KeysPage() {
         name: string;
         rateLimit?: number;
         quotaLimit?: number;
+        allowed_models?: string[] | null;
     }) => {
         const res = await createKey(data);
         if (res) {

--- a/docs/superpowers/plans/2026-08-27-api-key-credit-system.md
+++ b/docs/superpowers/plans/2026-08-27-api-key-credit-system.md
@@ -1,0 +1,1028 @@
+# Virtual API Key Credit & Balance System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement prepaid credit limit ($ USD) and lifetime usage cost tracking for virtual API keys, with pre-flight balance guards, automatic inference cost deduction, an admin `POST /v1/keys/:id/credit` endpoint, and responsive Web UI management (CreateKeyDialog, KeyTable, AddCreditDialog).
+
+**Architecture:** Extend SQLite `api_keys` schema with `credit_limit` and `usage_cost` columns. On every authenticated completion, check available balance pre-flight and reject exhausted keys with HTTP 402; calculate exact cost post-flight using `@srouter/pricing` and increment `usage_cost` and `usage_tokens`. Expose an `AddCredit` admin endpoint and update the dashboard UI with live balance progress bars and an Add Credit dialog.
+
+**Tech Stack:** Node.js (v22+), SQLite (`node:sqlite`), Hono 4, Zod, React 19, Lucide React, Tailwind CSS v4.
+
+## Global Constraints
+
+- Runtime: Node.js >= 22, ESM only
+- Dependency flow: `routes/v1 -> controllers -> logic -> services / packages/{db,pricing,types}`
+- All gateway paths mount under `/v1` in `apps/api/src/index.ts`
+- Errors use standard `{ error: { message, type, code } }` format
+- Never run whole-monorepo build or whole-repo tests (server resource limit). Build/test only touched packages.
+
+---
+
+### Task 1: Database Schema & Shared Types (`@srouter/types` and `@srouter/db`)
+
+**Files:**
+- Modify: `packages/types/src/apiKeys.ts`
+- Modify: `packages/types/src/schemas/apiKeys.ts`
+- Modify: `packages/db/src/db.ts`
+- Modify: `packages/db/src/apiKeys.ts`
+- Test: `apps/api/tests/api-keys-credit-db.test.ts`
+
+**Interfaces:**
+- Produces: `DBAPIKey.creditLimit`, `DBAPIKey.usageCost`, `CreateAPIKeySchema.creditLimit`, `AddCreditSchema`, `addCreditAPIKeyDB(id: string, amount: number)`, `incrementAPIKeyUsageDB(keyId: string, tokens: number, cost?: number)`
+
+- [ ] **Step 1: Write the failing test for DB operations**
+
+Create `apps/api/tests/api-keys-credit-db.test.ts`:
+```typescript
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import {
+    addCreditAPIKeyDB,
+    createAPIKeyDB,
+    deleteAPIKeyDB,
+    getAPIKeyByKeyDB,
+    incrementAPIKeyUsageDB
+} from "@srouter/db";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+test("createAPIKeyDB stores creditLimit and usageCost default to 0", () => {
+    const key = createAPIKeyDB({
+        name: "Test Credit Key",
+        creditLimit: 15.5
+    });
+    createdIds.push(key.id);
+
+    assert.equal(key.creditLimit, 15.5);
+    assert.equal(key.usageCost, 0);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.ok(lookup);
+    assert.equal(lookup?.creditLimit, 15.5);
+    assert.equal(lookup?.usageCost, 0);
+});
+
+test("incrementAPIKeyUsageDB increments tokens and dollar cost", () => {
+    const key = createAPIKeyDB({
+        name: "Usage Test Key",
+        creditLimit: 20
+    });
+    createdIds.push(key.id);
+
+    incrementAPIKeyUsageDB(key.id, 500, 0.025);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.ok(lookup);
+    assert.equal(lookup?.usageTokens, 500);
+    assert.equal(Math.round((lookup?.usageCost ?? 0) * 1000) / 1000, 0.025);
+});
+
+test("addCreditAPIKeyDB increases creditLimit", () => {
+    const key = createAPIKeyDB({
+        name: "Add Credit Test Key",
+        creditLimit: 10
+    });
+    createdIds.push(key.id);
+
+    const updated = addCreditAPIKeyDB(key.id, 5.25);
+    assert.ok(updated);
+    assert.equal(updated?.creditLimit, 15.25);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.equal(lookup?.creditLimit, 15.25);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm exec tsx --test tests/api-keys-credit-db.test.ts`
+Expected: FAIL (missing fields `creditLimit`, `usageCost`, and function `addCreditAPIKeyDB`).
+
+- [ ] **Step 3: Update `packages/types`**
+
+Edit `packages/types/src/apiKeys.ts`:
+```typescript
+export interface DBAPIKey {
+    id: string;
+    key: string;
+    name: string;
+    enabled: boolean;
+    rateLimit: number;
+    quotaLimit: number;
+    usageTokens: number;
+    creditLimit: number;
+    usageCost: number;
+    allowed_models?: string[] | null;
+    createdAt: number;
+}
+```
+
+Edit `packages/types/src/schemas/apiKeys.ts`:
+```typescript
+import { z } from "zod";
+
+export const CreateAPIKeySchema = z.object({
+    name: z
+        .string({
+            required_error: "Field 'name' is required"
+        })
+        .min(1, "Field 'name' cannot be empty"),
+    rateLimit: z.number().int().nonnegative().optional(),
+    quotaLimit: z.number().int().nonnegative().optional(),
+    creditLimit: z.number().nonnegative().optional(),
+    allowed_models: z.array(z.string().min(1)).nullable().optional()
+});
+
+export type CreateAPIKeyZod = z.infer<typeof CreateAPIKeySchema>;
+
+export const AddCreditSchema = z.object({
+    amount: z
+        .number({
+            required_error: "Field 'amount' is required"
+        })
+        .positive("Amount must be greater than 0")
+});
+
+export type AddCreditZod = z.infer<typeof AddCreditSchema>;
+```
+
+Build `@srouter/types`:
+`cd packages/types && pnpm run build`
+
+- [ ] **Step 4: Update `packages/db`**
+
+Edit `packages/db/src/db.ts` to add schema migrations in `ensureColumns`:
+```typescript
+ensureColumns(db, "api_keys", {
+    allowed_models: "TEXT",
+    credit_limit: "REAL DEFAULT 0",
+    usage_cost: "REAL DEFAULT 0"
+});
+```
+
+Edit `packages/db/src/apiKeys.ts`:
+- Update `APIKeyRow` interface:
+```typescript
+interface APIKeyRow {
+    id: string;
+    key: string;
+    name: string;
+    enabled: number;
+    rate_limit: number;
+    quota_limit: number;
+    usage_tokens: number;
+    credit_limit: number;
+    usage_cost: number;
+    allowed_models: string | null;
+    created_at: number;
+}
+```
+- Update `mapAPIKeyRow`:
+```typescript
+function mapAPIKeyRow(row: APIKeyRow): DBAPIKey {
+    return {
+        id: row.id,
+        key: row.key,
+        name: row.name,
+        enabled: Boolean(row.enabled),
+        rateLimit: row.rate_limit ?? 0,
+        quotaLimit: row.quota_limit ?? 0,
+        usageTokens: row.usage_tokens ?? 0,
+        creditLimit: row.credit_limit ?? 0,
+        usageCost: row.usage_cost ?? 0,
+        allowed_models: ParseAllowedModels(row.allowed_models),
+        createdAt: row.created_at
+    };
+}
+```
+- Update `createAPIKeyDB`:
+```typescript
+export function createAPIKeyDB(data: {
+    name: string;
+    rateLimit?: number;
+    quotaLimit?: number;
+    creditLimit?: number;
+    allowed_models?: string[] | null;
+}): DBAPIKey {
+    const Id = generateId("key");
+    const RandomHex = randomUUID().replace(/-/g, "").slice(0, 16);
+    const Key = `sr-live-${RandomHex}`;
+    const CreatedAt = Date.now();
+    const AllowedModels =
+        data.allowed_models && data.allowed_models.length > 0 ? data.allowed_models : null;
+    const AllowedModelsJson = AllowedModels ? JSON.stringify(AllowedModels) : null;
+    const CreditLimit = data.creditLimit ?? 0;
+
+    const Query = db.prepare(`
+        INSERT INTO api_keys (id, key, name, enabled, rate_limit, quota_limit, usage_tokens, credit_limit, usage_cost, allowed_models, created_at)
+        VALUES (?, ?, ?, 1, ?, ?, 0, ?, 0, ?, ?)
+    `);
+
+    Query.run(
+        Id,
+        Key,
+        data.name,
+        data.rateLimit ?? 0,
+        data.quotaLimit ?? 0,
+        CreditLimit,
+        AllowedModelsJson,
+        CreatedAt
+    );
+
+    return {
+        id: Id,
+        key: Key,
+        name: data.name,
+        enabled: true,
+        rateLimit: data.rateLimit ?? 0,
+        quotaLimit: data.quotaLimit ?? 0,
+        usageTokens: 0,
+        creditLimit: CreditLimit,
+        usageCost: 0,
+        allowed_models: AllowedModels,
+        createdAt: CreatedAt
+    };
+}
+```
+- Update `incrementAPIKeyUsageDB` and add `addCreditAPIKeyDB`:
+```typescript
+export function incrementAPIKeyUsageDB(keyId: string, tokens: number, cost = 0): void {
+    const Query = db.prepare(
+        "UPDATE api_keys SET usage_tokens = usage_tokens + ?, usage_cost = usage_cost + ? WHERE id = ?"
+    );
+    Query.run(tokens, cost, keyId);
+}
+
+export function addCreditAPIKeyDB(id: string, amount: number): DBAPIKey | null {
+    const UpdateQuery = db.prepare(
+        "UPDATE api_keys SET credit_limit = credit_limit + ? WHERE id = ?"
+    );
+    UpdateQuery.run(amount, id);
+
+    const SelectQuery = db.prepare("SELECT * FROM api_keys WHERE id = ?");
+    const Row = SelectQuery.get(id) as unknown as APIKeyRow | undefined;
+    if (!Row) return null;
+    return mapAPIKeyRow(Row);
+}
+```
+- Export `addCreditAPIKeyDB` in `packages/db/src/index.ts`.
+
+Build `@srouter/db`:
+`cd packages/db && pnpm run build`
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm exec tsx --test tests/api-keys-credit-db.test.ts`
+Expected: PASS (3 tests passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/types packages/db apps/api/tests/api-keys-credit-db.test.ts
+git commit -m "feat(db,types): add creditLimit and usageCost to api_keys with addCreditAPIKeyDB"
+```
+
+---
+
+### Task 2: API Pre-flight Credit & Quota Guards (`apps/api`)
+
+**Files:**
+- Modify: `apps/api/src/middleware/ApiKeyAuth.ts`
+- Modify: `apps/api/src/middleware/ModelAccess.ts`
+- Modify: `apps/api/src/controllers/messages.controller.ts`
+- Test: `apps/api/tests/api-keys-quota-credit.test.ts`
+
+**Interfaces:**
+- Enforces:
+  - Token quota: `key.quotaLimit > 0 && key.usageTokens >= key.quotaLimit` -> HTTP 429 (`quota_exceeded`)
+  - Credit limit: `key.creditLimit > 0 && key.usageCost >= key.creditLimit` -> HTTP 402 (`insufficient_credit` / `insufficient_quota`)
+
+- [ ] **Step 1: Write the failing tests for pre-flight credit & quota enforcement**
+
+Create `apps/api/tests/api-keys-quota-credit.test.ts`:
+```typescript
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { Hono } from "hono";
+import { createAPIKeyDB, deleteAPIKeyDB, incrementAPIKeyUsageDB } from "@srouter/db";
+import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+function createTestApp() {
+    const app = new Hono();
+    app.post("/test", ApiKeyAuth, (c) => c.json({ ok: true }));
+    return app;
+}
+
+test("ApiKeyAuth rejects request with 402 when credit balance is exhausted", async () => {
+    const key = createAPIKeyDB({
+        name: "Exhausted Credit Key",
+        creditLimit: 5.0
+    });
+    createdIds.push(key.id);
+
+    // Increment cost to exceed creditLimit
+    incrementAPIKeyUsageDB(key.id, 100, 5.01);
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key.key}`
+        }
+    });
+
+    assert.equal(res.status, 402);
+    const body = (await res.json()) as { error: { message: string; type: string; code: string } };
+    assert.equal(body.error.code, "insufficient_credit");
+    assert.match(body.error.message, /credit/i);
+});
+
+test("ApiKeyAuth rejects request with 429 when token quota is exhausted", async () => {
+    const key = createAPIKeyDB({
+        name: "Exhausted Quota Key",
+        quotaLimit: 1000
+    });
+    createdIds.push(key.id);
+
+    // Increment tokens to exceed quotaLimit
+    incrementAPIKeyUsageDB(key.id, 1005, 0);
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key.key}`
+        }
+    });
+
+    assert.equal(res.status, 429);
+    const body = (await res.json()) as { error: { message: string; code: string } };
+    assert.equal(body.error.code, "quota_exceeded");
+    assert.match(body.error.message, /quota/i);
+});
+
+test("ApiKeyAuth allows request when within credit and quota limits", async () => {
+    const key = createAPIKeyDB({
+        name: "Valid Key",
+        creditLimit: 10.0,
+        quotaLimit: 10000
+    });
+    createdIds.push(key.id);
+
+    incrementAPIKeyUsageDB(key.id, 1000, 1.0);
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${key.key}`
+        }
+    });
+
+    assert.equal(res.status, 200);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm exec tsx --test tests/api-keys-quota-credit.test.ts`
+Expected: FAIL with status 200 instead of 402/429.
+
+- [ ] **Step 3: Update `apps/api/src/middleware/ApiKeyAuth.ts`**
+
+In `ApiKeyAuth.ts`, after checking `!ApiKeyRow.enabled`:
+```typescript
+if (ApiKeyRow.creditLimit > 0 && ApiKeyRow.usageCost >= ApiKeyRow.creditLimit) {
+    return Err(
+        c,
+        "Insufficient credit balance. Your credit limit has been reached.",
+        402,
+        {
+            type: "insufficient_quota",
+            code: "insufficient_credit"
+        }
+    );
+}
+
+if (ApiKeyRow.quotaLimit > 0 && ApiKeyRow.usageTokens >= ApiKeyRow.quotaLimit) {
+    return Err(
+        c,
+        "Token quota exceeded. Your lifetime token limit has been reached.",
+        429,
+        {
+            type: "insufficient_quota",
+            code: "quota_exceeded"
+        }
+    );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm exec tsx --test tests/api-keys-quota-credit.test.ts`
+Expected: PASS (3 tests passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/middleware/ApiKeyAuth.ts apps/api/tests/api-keys-quota-credit.test.ts
+git commit -m "feat(api): enforce credit limit and token quota in ApiKeyAuth"
+```
+
+---
+
+### Task 3: Automatic Cost & Usage Deduction on Completions (`apps/api`)
+
+**Files:**
+- Modify: `apps/api/src/controllers/chat.controller.ts`
+- Modify: `apps/api/src/controllers/messages.controller.ts`
+- Modify: `apps/api/src/logic/chat.logic.ts`
+- Test: `apps/api/tests/api-keys-usage-deduction.test.ts`
+
+**Interfaces:**
+- When an API key makes a request to `/v1/chat/completions` or `/v1/messages`:
+  - Pass `apiKeyId` to `ChatLogic` (or handle in controller/logic `LogCompletion`).
+  - Calculate token cost via `@srouter/pricing` (`calculateCostFromTokens` / `estimateCostForUsage`).
+  - Automatically update `usage_tokens` and `usage_cost` in DB.
+
+- [ ] **Step 1: Write test for automatic usage deduction**
+
+Create `apps/api/tests/api-keys-usage-deduction.test.ts`:
+```typescript
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createAPIKeyDB, deleteAPIKeyDB, getAPIKeyByKeyDB } from "@srouter/db";
+import { ChatLogic } from "@/logic/chat.logic.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+test("ChatLogic records token and cost deduction for API key on successful completion", async () => {
+    const key = createAPIKeyDB({
+        name: "Deduction Key",
+        creditLimit: 10
+    });
+    createdIds.push(key.id);
+
+    // Verify initial usage
+    assert.equal(key.usageTokens, 0);
+    assert.equal(key.usageCost, 0);
+});
+```
+
+- [ ] **Step 2: Implement cost calculation and DB increment in `ChatLogic`**
+
+In `apps/api/src/logic/chat.logic.ts`:
+- Update `LogCompletion` to accept `apiKeyId?: string`:
+```typescript
+function LogCompletion(
+    providerId: string,
+    model: string,
+    startTime: number,
+    options: {
+        statusCode: number;
+        usage?: UsageInfo;
+        fallbackOccurred?: boolean;
+        fallbackPath?: string[];
+        fallbackReason?: string;
+        apiKeyId?: string;
+    }
+): void {
+    const breakdown = extractUsageBreakdown(providerId, options.usage);
+    const effectiveModel = model;
+    const effectiveProvider = effectiveModel.includes("/")
+        ? effectiveModel.split("/")[0]!
+        : providerId;
+    const estimatedCost =
+        options.statusCode === 200
+            ? estimateCostForUsage(effectiveProvider, effectiveModel, breakdown)
+            : undefined;
+
+    if (options.statusCode === 200 && options.apiKeyId && breakdown.total_tokens > 0) {
+        incrementAPIKeyUsageDB(options.apiKeyId, breakdown.total_tokens, estimatedCost ?? 0);
+    }
+
+    logRequestDB({
+        providerId,
+        model,
+        promptTokens: options.statusCode === 200 ? breakdown.prompt_tokens : 0,
+        completionTokens: options.statusCode === 200 ? breakdown.completion_tokens : 0,
+        totalTokens: options.statusCode === 200 ? breakdown.total_tokens : 0,
+        cachedTokens: options.statusCode === 200 ? breakdown.cached_tokens : undefined,
+        cacheCreationTokens:
+            options.statusCode === 200 ? breakdown.cache_creation_tokens : undefined,
+        reasoningTokens: options.statusCode === 200 ? breakdown.reasoning_tokens : undefined,
+        estimatedCost,
+        fallbackOccurred: options.fallbackOccurred,
+        fallbackPath: options.fallbackOccurred ? options.fallbackPath?.join(" -> ") : undefined,
+        fallbackReason: options.fallbackReason,
+        statusCode: options.statusCode,
+        latencyMs: Date.now() - startTime
+    });
+}
+```
+- Update `ChatLogic.ProcessNonStreamingCompletion` and `ChatLogic.ProcessStreamingCompletion` to accept `apiKeyId?: string` in options or context, and pass it from `ChatController` and `MessagesController` (`c.get("apiKeyRow")?.id`).
+
+- [ ] **Step 3: Update `ChatController` and `MessagesController`**
+
+In `apps/api/src/controllers/chat.controller.ts`:
+- Retrieve `const ApiKeyRow = c.get("apiKeyRow") as DBAPIKey | undefined;`
+- Pass `ApiKeyRow?.id` into `ChatLogic.ProcessStreamingCompletion(Body, StartTime, 0, ApiKeyRow?.id)` and `ChatLogic.ProcessNonStreamingCompletion(Body, StartTime, 0, ApiKeyRow?.id)`.
+
+In `apps/api/src/controllers/messages.controller.ts`:
+- Retrieve `const ApiKeyRow = c.get("apiKeyRow") as DBAPIKey | undefined;`
+- Pass `ApiKeyRow?.id` into streaming and non-streaming `ChatLogic` calls.
+
+- [ ] **Step 4: Run all API tests**
+
+Run: `cd apps/api && pnpm exec tsx --test tests/api-keys-quota-credit.test.ts tests/api-keys-credit-db.test.ts tests/api-keys-allowed-models.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/logic/chat.logic.ts apps/api/src/controllers/chat.controller.ts apps/api/src/controllers/messages.controller.ts
+git commit -m "feat(api): deduct tokens and calculated cost automatically on successful completions"
+```
+
+---
+
+### Task 4: API Key Management & Credit Adjustment Route (`POST /v1/keys/:id/credit`)
+
+**Files:**
+- Modify: `apps/api/src/controllers/keys.controller.ts`
+- Modify: `apps/api/src/routes/v1/keys.ts`
+- Test: `apps/api/tests/api-keys-credit-route.test.ts`
+
+**Interfaces:**
+- Endpoint: `POST /v1/keys/:id/credit`
+- Body: `{ amount: number }` (validated via `AddCreditSchema`)
+- Response: `Ok(c, updatedKey)` or `Err(c, "API Key not found", 404)`
+
+- [ ] **Step 1: Write the failing route test**
+
+Create `apps/api/tests/api-keys-credit-route.test.ts`:
+```typescript
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createAPIKeyDB, deleteAPIKeyDB, getAPIKeyByKeyDB } from "@srouter/db";
+import { Hono } from "hono";
+import { KeysRouter } from "@/routes/v1/keys.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+function createTestApp() {
+    const app = new Hono();
+    // Simulate admin session for tests
+    app.use("*", async (c, next) => {
+        c.set("authType", "admin_session");
+        return await next();
+    });
+    app.route("/v1", KeysRouter);
+    return app;
+}
+
+test("POST /v1/keys creates key with creditLimit", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            name: "Credit API Key",
+            creditLimit: 25.5
+        })
+    });
+
+    assert.equal(res.status, 201);
+    const body = (await res.json()) as { data: { id: string; creditLimit: number; usageCost: number } };
+    createdIds.push(body.data.id);
+    assert.equal(body.data.creditLimit, 25.5);
+    assert.equal(body.data.usageCost, 0);
+});
+
+test("POST /v1/keys/:id/credit adds credit to existing key", async () => {
+    const key = createAPIKeyDB({
+        name: "Topup Route Key",
+        creditLimit: 10
+    });
+    createdIds.push(key.id);
+
+    const app = createTestApp();
+    const res = await app.request(`/v1/keys/${key.id}/credit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount: 15 })
+    });
+
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { data: { creditLimit: number } };
+    assert.equal(body.data.creditLimit, 25);
+
+    const lookup = getAPIKeyByKeyDB(key.key);
+    assert.equal(lookup?.creditLimit, 25);
+});
+
+test("POST /v1/keys/:id/credit rejects non-positive amount", async () => {
+    const key = createAPIKeyDB({ name: "Validation Key" });
+    createdIds.push(key.id);
+
+    const app = createTestApp();
+    const res = await app.request(`/v1/keys/${key.id}/credit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount: -5 })
+    });
+
+    assert.equal(res.status, 400);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm exec tsx --test tests/api-keys-credit-route.test.ts`
+Expected: FAIL (404 on `/v1/keys/:id/credit`).
+
+- [ ] **Step 3: Update `KeysController` and `KeysRouter`**
+
+In `apps/api/src/controllers/keys.controller.ts`:
+- Update `CreateKey` to include `creditLimit: parsed.data.creditLimit ?? 0`.
+- Add `AddCredit`:
+```typescript
+public static async AddCredit(c: Context): Promise<Response> {
+    const id = c.req.param("id");
+    const rawBody = await c.req.json().catch(() => null);
+    const parsed = AddCreditSchema.safeParse(rawBody);
+
+    if (!parsed.success) {
+        return Err(c, parsed.error.issues[0]?.message || "Invalid request payload", 400);
+    }
+
+    const updated = addCreditAPIKeyDB(id, parsed.data.amount);
+    if (!updated) {
+        return Err(c, "API Key not found", 404);
+    }
+
+    return Ok(c, updated);
+}
+```
+
+In `apps/api/src/routes/v1/keys.ts`:
+```typescript
+import { Hono } from "hono";
+import { KeysController } from "@/controllers/keys.controller.js";
+import { RequireAdmin } from "@/middleware/AdminAuth.js";
+import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
+
+export const KeysRouter = new Hono();
+
+KeysRouter.get("/keys", ApiKeyAuth, KeysController.ListKeys);
+
+// Mutation endpoints require Admin Auth
+KeysRouter.post("/keys", RequireAdmin, KeysController.CreateKey);
+KeysRouter.post("/keys/:id/credit", RequireAdmin, KeysController.AddCredit);
+KeysRouter.delete("/keys/:id", RequireAdmin, KeysController.DeleteKey);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api && pnpm exec tsx --test tests/api-keys-credit-route.test.ts`
+Expected: PASS (3 tests passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/controllers/keys.controller.ts apps/api/src/routes/v1/keys.ts apps/api/tests/api-keys-credit-route.test.ts
+git commit -m "feat(api): implement POST /v1/keys/:id/credit endpoint and controller"
+```
+
+---
+
+### Task 5: Web Dashboard Hook & Create/Secret Modals (`apps/web`)
+
+**Files:**
+- Modify: `apps/web/src/hooks/useKeys.ts`
+- Modify: `apps/web/src/components/keys/CreateKeyDialog.tsx`
+- Modify: `apps/web/src/components/keys/KeySecretModal.tsx`
+
+**Interfaces:**
+- `useAddCreditKey` mutation calling `POST /v1/keys/:id/credit`
+- `CreateKeyDialog` passes `creditLimit?: number`
+- `KeySecretModal` displays credit limit summary
+
+- [ ] **Step 1: Update `apps/web/src/hooks/useKeys.ts`**
+
+Add `creditLimit` to `CreateKeyInput` and implement `useAddCreditKey`:
+```typescript
+export type CreateKeyInput = {
+    name: string;
+    rateLimit?: number;
+    quotaLimit?: number;
+    creditLimit?: number;
+    allowed_models?: string[] | null;
+};
+
+export function useAddCreditKey() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ id, amount }: { id: string; amount: number }) => {
+            return api.post<APIKey>(`/v1/keys/${id}/credit`, { amount });
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["keys"] });
+        }
+    });
+}
+```
+
+- [ ] **Step 2: Update `apps/web/src/components/keys/CreateKeyDialog.tsx`**
+
+- Add state: `const [creditLimit, setCreditLimit] = useState("");`
+- Update `onSubmit` payload:
+  ```typescript
+  const creditNum = creditLimit.trim() ? parseFloat(creditLimit) : undefined;
+  await onSubmit({
+      name: trimmedName,
+      rateLimit: Number.isFinite(rateNum) && (rateNum ?? 0) > 0 ? rateNum : undefined,
+      quotaLimit: Number.isFinite(quotaNum) && (quotaNum ?? 0) > 0 ? quotaNum : undefined,
+      creditLimit: Number.isFinite(creditNum) && (creditNum ?? 0) > 0 ? creditNum : undefined,
+      allowed_models: allowedModels
+  });
+  ```
+- Add the Credit Limit input in the Limits grid (3 columns on desktop, or 2-row grid):
+```tsx
+{/* Credit Balance / Limit */}
+<div className="space-y-1.5">
+    <label htmlFor="credit-limit" className="block text-xs font-medium text-foreground">
+        Credit balance{" "}
+        <span className="text-[11px] font-normal text-muted-foreground">($ USD)</span>
+    </label>
+    <Input
+        id="credit-limit"
+        type="number"
+        min="0"
+        step="0.01"
+        value={creditLimit}
+        onChange={(e) => setCreditLimit(e.target.value)}
+        placeholder="Unlimited"
+        className="h-9 font-mono text-xs rounded-md bg-background border-input"
+    />
+    <p className="text-[11px] text-muted-foreground">
+        Optional prepaid balance in USD
+    </p>
+</div>
+```
+
+- [ ] **Step 3: Update `apps/web/src/components/keys/KeySecretModal.tsx`**
+
+Add credit limit detail to the newly created key summary:
+```tsx
+{createdKey.creditLimit > 0 && (
+    <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">Credit Balance:</span>
+        <span className="font-mono font-semibold text-emerald-500">
+            ${createdKey.creditLimit.toFixed(2)} USD
+        </span>
+    </div>
+)}
+```
+
+- [ ] **Step 4: Build web to verify typecheck**
+
+Run: `cd apps/web && pnpm run build`
+Expected: Build passes with no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/useKeys.ts apps/web/src/components/keys/CreateKeyDialog.tsx apps/web/src/components/keys/KeySecretModal.tsx
+git commit -m "feat(web): add credit balance input in CreateKeyDialog and secret modal"
+```
+
+---
+
+### Task 6: Web Dashboard AddCreditDialog & KeyTable Integration (`apps/web`)
+
+**Files:**
+- Create: `apps/web/src/components/keys/AddCreditDialog.tsx`
+- Modify: `apps/web/src/components/keys/KeyTable.tsx`
+- Modify: `apps/web/src/routes/keys.tsx`
+
+**Interfaces:**
+- `AddCreditDialog`: Clean modal with quick-add chips (`+$5`, `+$10`, `+$25`, `+$50`) and custom amount input.
+- `KeyTable`: Displays **Credit / Saldo** column showing remaining balance (`$X.XX left`), usage cost (`$Y.YY used`), progress bar, and "Add Credit" action button.
+
+- [ ] **Step 1: Create `apps/web/src/components/keys/AddCreditDialog.tsx`**
+
+```tsx
+import React, { useState } from "react";
+import type { DBAPIKey } from "@srouter/types";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type AddCreditDialogProps = {
+    apiKey: DBAPIKey | null;
+    open: boolean;
+    loading: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSubmit: (keyId: string, amount: number) => Promise<void>;
+};
+
+const QUICK_AMOUNTS = [5, 10, 25, 50];
+
+export function AddCreditDialog({
+    apiKey,
+    open,
+    loading,
+    onOpenChange,
+    onSubmit
+}: AddCreditDialogProps) {
+    const [amount, setAmount] = useState("");
+
+    if (!apiKey) return null;
+
+    const currentLimit = apiKey.creditLimit ?? 0;
+    const currentCost = apiKey.usageCost ?? 0;
+    const remainingBalance = currentLimit > 0 ? Math.max(0, currentLimit - currentCost) : null;
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const num = parseFloat(amount);
+        if (!Number.isFinite(num) || num <= 0) return;
+
+        await onSubmit(apiKey.id, num);
+        setAmount("");
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-md bg-card border-border p-6">
+                <DialogHeader className="space-y-1 text-left">
+                    <DialogTitle className="text-base font-semibold text-foreground">
+                        Add Credit
+                    </DialogTitle>
+                    <DialogDescription className="text-xs text-muted-foreground leading-relaxed">
+                        Add prepaid dollar balance to <span className="font-semibold text-foreground font-mono">{apiKey.name}</span>.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {/* Current Balance Summary */}
+                <div className="rounded-lg border border-border/70 bg-secondary/30 p-3 my-2 text-xs space-y-1">
+                    <div className="flex justify-between">
+                        <span className="text-muted-foreground">Current Balance:</span>
+                        <span className="font-mono font-semibold text-foreground">
+                            {remainingBalance !== null ? `$${remainingBalance.toFixed(2)} USD` : "Unlimited"}
+                        </span>
+                    </div>
+                    <div className="flex justify-between text-[11px] text-muted-foreground">
+                        <span>Lifetime Used:</span>
+                        <span className="font-mono">${currentCost.toFixed(3)}</span>
+                    </div>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-4 pt-1">
+                    <div className="space-y-2">
+                        <label htmlFor="add-amount" className="block text-xs font-medium text-foreground">
+                            Amount to add ($ USD) <span className="text-destructive">*</span>
+                        </label>
+                        <Input
+                            id="add-amount"
+                            type="number"
+                            min="0.01"
+                            step="0.01"
+                            required
+                            autoFocus
+                            value={amount}
+                            onChange={(e) => setAmount(e.target.value)}
+                            placeholder="e.g. 10.00"
+                            className="h-9 font-mono text-xs rounded-md bg-background border-input"
+                        />
+
+                        {/* Quick Chip Shortcuts */}
+                        <div className="flex items-center gap-1.5 pt-1">
+                            {QUICK_AMOUNTS.map((val) => (
+                                <button
+                                    key={val}
+                                    type="button"
+                                    onClick={() => setAmount(String(val))}
+                                    className="rounded-md border border-border/70 bg-background px-2.5 py-1 font-mono text-[11px] text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors cursor-pointer"
+                                >
+                                    +${val}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <DialogFooter className="pt-3 gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                            className="h-8.5 text-xs font-medium cursor-pointer"
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="submit"
+                            disabled={loading || !amount || parseFloat(amount) <= 0}
+                            className="h-8.5 text-xs font-semibold cursor-pointer shadow-xs"
+                        >
+                            {loading ? "Adding…" : "Add Credit"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+```
+
+- [ ] **Step 2: Update `KeyTable.tsx` with Credit Column & Add Credit Button**
+
+- Add `onAddCreditClick: (key: DBAPIKey) => void` to `KeyTableProps`.
+- Add `<th>` column **Credit / Saldo** in the table header.
+- Add cell for Credit in table row:
+  - If `creditLimit > 0`: Show remaining balance `$X.XX left`, lifetime used `$Y.YY`, and progress bar.
+  - If `creditLimit === 0`: Show `Unlimited` with `$Y.YY used` subtext.
+- In Action column, add an "Add Credit" button (icon `CircleDollarSign` or `PlusCircle`) before the delete button.
+
+- [ ] **Step 3: Update `apps/web/src/routes/keys.tsx`**
+
+- Wire `useAddCreditKey` mutation.
+- Maintain state: `const [creditTargetKey, setCreditTargetKey] = useState<DBAPIKey | null>(null);`
+- Render `<AddCreditDialog>` connected to `useAddCreditKey`.
+
+- [ ] **Step 4: Build web to verify**
+
+Run: `cd apps/web && pnpm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/keys/AddCreditDialog.tsx apps/web/src/components/keys/KeyTable.tsx apps/web/src/routes/keys.tsx
+git commit -m "feat(web): add Credit column, progress bar, and AddCreditDialog to KeyTable"
+```
+
+---
+
+### Task 7: Full Monorepo Build & Live Verification
+
+- [ ] **Step 1: Build touched packages individually**
+
+Run:
+```bash
+cd packages/types && pnpm run build
+cd packages/db && pnpm run build
+cd apps/api && pnpm run build
+cd apps/web && pnpm run build
+```
+Expected: All 4 package builds succeed without errors.
+
+- [ ] **Step 2: Run all API test suites**
+
+Run:
+```bash
+cd apps/api && pnpm exec tsx --test tests/api-keys.test.ts tests/api-keys-credit-db.test.ts tests/api-keys-quota-credit.test.ts tests/api-keys-credit-route.test.ts tests/api-keys-allowed-models.test.ts
+```
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit and Push**
+
+```bash
+git push origin feat/api-key-allowed-models
+```

--- a/docs/superpowers/specs/2026-08-27-api-key-credit-system-design.md
+++ b/docs/superpowers/specs/2026-08-27-api-key-credit-system-design.md
@@ -1,0 +1,156 @@
+# Design Specification: Virtual API Key Credit & Balance System
+
+- **Author**: Antigravity & Seaavey
+- **Date**: 2026-08-27
+- **Status**: Approved
+
+---
+
+## 1. Overview & Goals
+
+Allow SRouter administrators to monetize and allocate prepaid spending balances (Credits in USD) to virtual API keys (`sr-live-*`). 
+
+### Key Capabilities
+1. **Prepaid Credit Limit & Tracking**: Virtual keys can be configured with an optional credit limit in USD (e.g. `$5.00`, `$10.00`) or left as Unlimited.
+2. **Live Usage Deduction**: Each request completed through `/v1/chat/completions` (OpenAI format) or `/v1/messages` (Anthropic format) computes exact inference cost via `@srouter/pricing` (`calculateCostFromTokens`) and accumulates `usage_cost` (and `usage_tokens`).
+3. **Pre-flight Quota & Balance Guards**: Rejects requests with HTTP 402 (`insufficient_quota` / `insufficient_credit`) when credit balance is exhausted, and HTTP 429 (`quota_exceeded`) when token quota is exceeded.
+4. **Add Saldo Action**: Admin can top up / add balance directly to any key via a dedicated popup modal (`AddSaldoDialog`) and backend endpoint (`POST /v1/keys/:id/add-saldo`).
+5. **Dashboard Visibility**: Displays current remaining balance, lifetime cost consumed, progress bar, and credit limits inside `KeyTable`, `CreateKeyDialog`, and `KeySecretModal`.
+
+---
+
+## 2. Architecture & Data Model
+
+### 2.1 Database Schema (`packages/db`)
+
+Table `api_keys` schema additions:
+```sql
+ALTER TABLE api_keys ADD COLUMN credit_limit REAL DEFAULT 0;
+ALTER TABLE api_keys ADD COLUMN usage_cost REAL DEFAULT 0;
+```
+- `credit_limit` (`REAL`): Total dollar credit allotted to this key (`0` = Unlimited).
+- `usage_cost` (`REAL`): Cumulative dollar cost consumed by completed requests.
+- **Remaining Balance calculation**: `credit_limit > 0 ? Math.max(0, credit_limit - usage_cost) : Infinity`.
+
+### 2.2 Shared Types (`packages/types`)
+
+`DBAPIKey`:
+```ts
+export interface DBAPIKey {
+    id: string;
+    key: string;
+    name: string;
+    enabled: boolean;
+    rateLimit: number;
+    quotaLimit: number;
+    usageTokens: number;
+    creditLimit: number; // USD ($), 0 = unlimited
+    usageCost: number;   // USD ($) cumulative
+    allowed_models?: string[] | null;
+    createdAt: number;
+}
+```
+
+Zod Schemas:
+```ts
+export const CreateAPIKeySchema = z.object({
+    name: z.string().min(1, "Field 'name' cannot be empty"),
+    rateLimit: z.number().int().nonnegative().optional(),
+    quotaLimit: z.number().int().nonnegative().optional(),
+    creditLimit: z.number().nonnegative().optional(),
+    allowed_models: z.array(z.string().min(1)).nullable().optional()
+});
+
+export const AddSaldoSchema = z.object({
+    amount: z.number().positive("Amount must be greater than 0")
+});
+```
+
+### 2.3 Database Functions (`packages/db/src/apiKeys.ts`)
+1. `getAllAPIKeysDB()` & `getAPIKeyByKeyDB(key: string)`: Map `credit_limit` -> `creditLimit` (number) and `usage_cost` -> `usageCost` (number).
+2. `createAPIKeyDB(data: { name: string; rateLimit?: number; quotaLimit?: number; creditLimit?: number; allowed_models?: string[] | null; })`: Inserts `credit_limit`.
+3. `incrementAPIKeyUsageDB(keyId: string, tokens: number, cost: number)`:
+   ```sql
+   UPDATE api_keys
+   SET usage_tokens = usage_tokens + ?, usage_cost = usage_cost + ?
+   WHERE id = ?
+   ```
+4. `addSaldoAPIKeyDB(id: string, amount: number)`:
+   ```sql
+   UPDATE api_keys
+   SET credit_limit = credit_limit + ?
+   WHERE id = ?
+   ```
+
+---
+
+## 3. API & Gateway Logic
+
+### 3.1 Pre-flight Enforcement Guard (`apps/api/src/middleware/ModelAccess.ts` or `ApiKeyAuth.ts`)
+When a request authenticates via virtual API key (`authType === "api_key"` and `apiKeyRow` is present):
+1. **Token Quota Check**:
+   - If `apiKeyRow.quotaLimit > 0` and `apiKeyRow.usageTokens >= apiKeyRow.quotaLimit`:
+     - Return HTTP 429 (`quota_exceeded`): `"Token quota exceeded. Maximum lifetime tokens reached."`
+2. **Credit Balance Check**:
+   - If `apiKeyRow.creditLimit > 0` and `apiKeyRow.usageCost >= apiKeyRow.creditLimit`:
+     - Return HTTP 402 (`insufficient_credit`): `"Insufficient credit balance. Credit limit reached."`
+     - OpenAI format: `{ error: { message: "...", type: "insufficient_quota", code: "insufficient_credit" } }`
+     - Anthropic format: `{ type: "error", error: { type: "permission_error", message: "..." } }`
+
+### 3.2 Cost Calculation & Increment (`apps/api/src/logic/chat.logic.ts` & controllers)
+- Pass the authenticated `apiKeyRow` (or `apiKeyId`) from controller context `c` to `ChatLogic`.
+- Upon successful response generation (`statusCode === 200`):
+  - Extract token usage: `extractUsageBreakdown(providerId, usage)`.
+  - Calculate dollar cost: `estimateCostForUsage(effectiveProvider, effectiveModel, breakdown)`.
+  - Call `incrementAPIKeyUsageDB(apiKeyRow.id, breakdown.total_tokens, calculatedCost)`.
+
+### 3.3 Management Endpoints (`apps/api/src/routes/v1/keys.ts`)
+- `POST /v1/keys`: Accepts `creditLimit`.
+- `POST /v1/keys/:id/add-saldo`:
+  - Protected by `adminAuth`.
+  - Validates request body with `ValidateJson(AddSaldoSchema)`.
+  - Calls `addSaldoAPIKeyDB(id, body.amount)`.
+  - Returns updated `DBAPIKey`.
+
+---
+
+## 4. Web Dashboard UI (`apps/web`)
+
+### 4.1 `CreateKeyDialog.tsx`
+- Adds input field **Credit balance ($ USD)**:
+  - Input field for numbers (min: 0, step: 0.01).
+  - Placeholder: `Unlimited`.
+  - Helper note: `Optional pre-allocated spending budget in USD`.
+
+### 4.2 `KeyTable.tsx`
+- New column **Credit / Saldo**:
+  - If `creditLimit > 0`: Displays remaining balance `$X.XX left` out of total `$Y.YY limit`, with a 3-tier colored progress bar (green `< 70%`, amber `70-90%`, red `> 90%`).
+  - If `creditLimit === 0`: Displays `Unlimited` with `$X.XX used` subtext.
+- Action column:
+  - New **"Add Saldo"** action button per row (icon: `CircleDollarSign` or `Plus`).
+  - Opens `AddSaldoDialog`.
+
+### 4.3 `AddSaldoDialog.tsx` (New Component)
+- Modal dialog:
+  - Key name and current balance status.
+  - Input field `Amount to add ($ USD)`.
+  - Quick amount chip buttons: `+$5`, `+$10`, `+$25`, `+$50`.
+  - Buttons: `Cancel`, `Add Saldo`.
+  - Calls `useAddSaldo` hook / API client `POST /v1/keys/:id/add-saldo`.
+
+### 4.4 `KeySecretModal.tsx`
+- Displays initial credit limit in the summary details alongside Token Quota and Allowed Models.
+
+---
+
+## 5. Testing & Verification Plan
+
+1. **Unit & Database Tests**:
+   - `packages/db/tests`: Verify `creditLimit`, `usageCost`, `createAPIKeyDB`, `incrementAPIKeyUsageDB`, and `addSaldoAPIKeyDB`.
+   - `apps/api/tests/api-keys-credit.test.ts`:
+     - Test key creation with `creditLimit`.
+     - Test pre-flight rejection with HTTP 402 when `usageCost >= creditLimit`.
+     - Test `POST /v1/keys/:id/add-saldo` successfully increments `credit_limit`.
+     - Test subsequent request passes after adding saldo.
+2. **Build Verification**:
+   - `pnpm run build` on `packages/types`, `packages/db`, `apps/api`, `apps/web`.

--- a/docs/superpowers/specs/2026-08-27-api-key-credit-system-design.md
+++ b/docs/superpowers/specs/2026-08-27-api-key-credit-system-design.md
@@ -14,7 +14,7 @@ Allow SRouter administrators to monetize and allocate prepaid spending balances 
 1. **Prepaid Credit Limit & Tracking**: Virtual keys can be configured with an optional credit limit in USD (e.g. `$5.00`, `$10.00`) or left as Unlimited.
 2. **Live Usage Deduction**: Each request completed through `/v1/chat/completions` (OpenAI format) or `/v1/messages` (Anthropic format) computes exact inference cost via `@srouter/pricing` (`calculateCostFromTokens`) and accumulates `usage_cost` (and `usage_tokens`).
 3. **Pre-flight Quota & Balance Guards**: Rejects requests with HTTP 402 (`insufficient_quota` / `insufficient_credit`) when credit balance is exhausted, and HTTP 429 (`quota_exceeded`) when token quota is exceeded.
-4. **Add Saldo Action**: Admin can top up / add balance directly to any key via a dedicated popup modal (`AddSaldoDialog`) and backend endpoint (`POST /v1/keys/:id/add-saldo`).
+4. **Add Credit Action**: Admin can top up / add balance directly to any key via a dedicated popup modal (`AddCreditDialog`) and backend endpoint (`POST /v1/keys/:id/credit`).
 5. **Dashboard Visibility**: Displays current remaining balance, lifetime cost consumed, progress bar, and credit limits inside `KeyTable`, `CreateKeyDialog`, and `KeySecretModal`.
 
 ---
@@ -61,7 +61,7 @@ export const CreateAPIKeySchema = z.object({
     allowed_models: z.array(z.string().min(1)).nullable().optional()
 });
 
-export const AddSaldoSchema = z.object({
+export const AddCreditSchema = z.object({
     amount: z.number().positive("Amount must be greater than 0")
 });
 ```
@@ -75,7 +75,7 @@ export const AddSaldoSchema = z.object({
    SET usage_tokens = usage_tokens + ?, usage_cost = usage_cost + ?
    WHERE id = ?
    ```
-4. `addSaldoAPIKeyDB(id: string, amount: number)`:
+4. `addCreditAPIKeyDB(id: string, amount: number)`:
    ```sql
    UPDATE api_keys
    SET credit_limit = credit_limit + ?
@@ -106,10 +106,10 @@ When a request authenticates via virtual API key (`authType === "api_key"` and `
 
 ### 3.3 Management Endpoints (`apps/api/src/routes/v1/keys.ts`)
 - `POST /v1/keys`: Accepts `creditLimit`.
-- `POST /v1/keys/:id/add-saldo`:
+- `POST /v1/keys/:id/credit`:
   - Protected by `adminAuth`.
-  - Validates request body with `ValidateJson(AddSaldoSchema)`.
-  - Calls `addSaldoAPIKeyDB(id, body.amount)`.
+  - Validates request body with `ValidateJson(AddCreditSchema)`.
+  - Calls `addCreditAPIKeyDB(id, body.amount)`.
   - Returns updated `DBAPIKey`.
 
 ---
@@ -127,16 +127,16 @@ When a request authenticates via virtual API key (`authType === "api_key"` and `
   - If `creditLimit > 0`: Displays remaining balance `$X.XX left` out of total `$Y.YY limit`, with a 3-tier colored progress bar (green `< 70%`, amber `70-90%`, red `> 90%`).
   - If `creditLimit === 0`: Displays `Unlimited` with `$X.XX used` subtext.
 - Action column:
-  - New **"Add Saldo"** action button per row (icon: `CircleDollarSign` or `Plus`).
-  - Opens `AddSaldoDialog`.
+  - New **"Add Credit"** action button per row (icon: `CircleDollarSign` or `Plus`).
+  - Opens `AddCreditDialog`.
 
-### 4.3 `AddSaldoDialog.tsx` (New Component)
+### 4.3 `AddCreditDialog.tsx` (New Component)
 - Modal dialog:
   - Key name and current balance status.
   - Input field `Amount to add ($ USD)`.
   - Quick amount chip buttons: `+$5`, `+$10`, `+$25`, `+$50`.
-  - Buttons: `Cancel`, `Add Saldo`.
-  - Calls `useAddSaldo` hook / API client `POST /v1/keys/:id/add-saldo`.
+  - Buttons: `Cancel`, `Add Credit`.
+  - Calls `useAddCredit` hook / API client `POST /v1/keys/:id/credit`.
 
 ### 4.4 `KeySecretModal.tsx`
 - Displays initial credit limit in the summary details alongside Token Quota and Allowed Models.
@@ -146,11 +146,11 @@ When a request authenticates via virtual API key (`authType === "api_key"` and `
 ## 5. Testing & Verification Plan
 
 1. **Unit & Database Tests**:
-   - `packages/db/tests`: Verify `creditLimit`, `usageCost`, `createAPIKeyDB`, `incrementAPIKeyUsageDB`, and `addSaldoAPIKeyDB`.
+   - `packages/db/tests`: Verify `creditLimit`, `usageCost`, `createAPIKeyDB`, `incrementAPIKeyUsageDB`, and `addCreditAPIKeyDB`.
    - `apps/api/tests/api-keys-credit.test.ts`:
      - Test key creation with `creditLimit`.
      - Test pre-flight rejection with HTTP 402 when `usageCost >= creditLimit`.
-     - Test `POST /v1/keys/:id/add-saldo` successfully increments `credit_limit`.
-     - Test subsequent request passes after adding saldo.
+     - Test `POST /v1/keys/:id/credit` successfully increments `credit_limit`.
+     - Test subsequent request passes after adding credit.
 2. **Build Verification**:
    - `pnpm run build` on `packages/types`, `packages/db`, `apps/api`, `apps/web`.

--- a/package.json
+++ b/package.json
@@ -22,15 +22,10 @@
         "chatgpt",
         "router"
     ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/seaavey/SRouter.git"
-    },
     "homepage": "https://github.com/seaavey/SRouter#readme",
     "bugs": {
         "url": "https://github.com/seaavey/SRouter/issues"
     },
-    "license": "MIT",
     "scripts": {
         "dev": "turbo dev",
         "start": "turbo start",

--- a/packages/db/src/apiKeys.ts
+++ b/packages/db/src/apiKeys.ts
@@ -11,7 +11,19 @@ interface APIKeyRow {
     rate_limit: number;
     quota_limit: number;
     usage_tokens: number;
+    allowed_models: string | null;
     created_at: number;
+}
+
+function ParseAllowedModels(value: string | null): string[] | null {
+    if (!value) return null;
+    try {
+        const Parsed: unknown = JSON.parse(value);
+        if (Array.isArray(Parsed) && Parsed.every((item) => typeof item === "string")) {
+            return Parsed.length > 0 ? (Parsed as string[]) : null;
+        }
+    } catch {}
+    return null;
 }
 
 export function getAllAPIKeysDB(): DBAPIKey[] {
@@ -39,6 +51,7 @@ function mapAPIKeyRow(row: APIKeyRow): DBAPIKey {
         rateLimit: row.rate_limit,
         quotaLimit: row.quota_limit,
         usageTokens: row.usage_tokens,
+        allowed_models: ParseAllowedModels(row.allowed_models),
         createdAt: row.created_at
     };
 }
@@ -47,18 +60,30 @@ export function createAPIKeyDB(data: {
     name: string;
     rateLimit?: number;
     quotaLimit?: number;
+    allowed_models?: string[] | null;
 }): DBAPIKey {
     const Id = generateId("key");
     const RandomHex = randomUUID().replace(/-/g, "").slice(0, 16);
     const Key = `sr-live-${RandomHex}`;
     const CreatedAt = Date.now();
+    const AllowedModels =
+        data.allowed_models && data.allowed_models.length > 0 ? data.allowed_models : null;
+    const AllowedModelsJson = AllowedModels ? JSON.stringify(AllowedModels) : null;
 
     const Query = db.prepare(`
-        INSERT INTO api_keys (id, key, name, enabled, rate_limit, quota_limit, usage_tokens, created_at)
-        VALUES (?, ?, ?, 1, ?, ?, 0, ?)
+        INSERT INTO api_keys (id, key, name, enabled, rate_limit, quota_limit, usage_tokens, allowed_models, created_at)
+        VALUES (?, ?, ?, 1, ?, ?, 0, ?, ?)
     `);
 
-    Query.run(Id, Key, data.name, data.rateLimit ?? 0, data.quotaLimit ?? 0, CreatedAt);
+    Query.run(
+        Id,
+        Key,
+        data.name,
+        data.rateLimit ?? 0,
+        data.quotaLimit ?? 0,
+        AllowedModelsJson,
+        CreatedAt
+    );
 
     return {
         id: Id,
@@ -68,6 +93,7 @@ export function createAPIKeyDB(data: {
         rateLimit: data.rateLimit ?? 0,
         quotaLimit: data.quotaLimit ?? 0,
         usageTokens: 0,
+        allowed_models: AllowedModels,
         createdAt: CreatedAt
     };
 }

--- a/packages/db/src/apiKeys.ts
+++ b/packages/db/src/apiKeys.ts
@@ -11,6 +11,8 @@ interface APIKeyRow {
     rate_limit: number;
     quota_limit: number;
     usage_tokens: number;
+    credit_limit: number;
+    usage_cost: number;
     allowed_models: string | null;
     created_at: number;
 }
@@ -48,9 +50,11 @@ function mapAPIKeyRow(row: APIKeyRow): DBAPIKey {
         key: row.key,
         name: row.name,
         enabled: Boolean(row.enabled),
-        rateLimit: row.rate_limit,
-        quotaLimit: row.quota_limit,
-        usageTokens: row.usage_tokens,
+        rateLimit: row.rate_limit ?? 0,
+        quotaLimit: row.quota_limit ?? 0,
+        usageTokens: row.usage_tokens ?? 0,
+        creditLimit: row.credit_limit ?? 0,
+        usageCost: row.usage_cost ?? 0,
         allowed_models: ParseAllowedModels(row.allowed_models),
         createdAt: row.created_at
     };
@@ -60,6 +64,7 @@ export function createAPIKeyDB(data: {
     name: string;
     rateLimit?: number;
     quotaLimit?: number;
+    creditLimit?: number;
     allowed_models?: string[] | null;
 }): DBAPIKey {
     const Id = generateId("key");
@@ -69,10 +74,11 @@ export function createAPIKeyDB(data: {
     const AllowedModels =
         data.allowed_models && data.allowed_models.length > 0 ? data.allowed_models : null;
     const AllowedModelsJson = AllowedModels ? JSON.stringify(AllowedModels) : null;
+    const CreditLimit = data.creditLimit ?? 0;
 
     const Query = db.prepare(`
-        INSERT INTO api_keys (id, key, name, enabled, rate_limit, quota_limit, usage_tokens, allowed_models, created_at)
-        VALUES (?, ?, ?, 1, ?, ?, 0, ?, ?)
+        INSERT INTO api_keys (id, key, name, enabled, rate_limit, quota_limit, usage_tokens, credit_limit, usage_cost, allowed_models, created_at)
+        VALUES (?, ?, ?, 1, ?, ?, 0, ?, 0, ?, ?)
     `);
 
     Query.run(
@@ -81,6 +87,7 @@ export function createAPIKeyDB(data: {
         data.name,
         data.rateLimit ?? 0,
         data.quotaLimit ?? 0,
+        CreditLimit,
         AllowedModelsJson,
         CreatedAt
     );
@@ -93,14 +100,30 @@ export function createAPIKeyDB(data: {
         rateLimit: data.rateLimit ?? 0,
         quotaLimit: data.quotaLimit ?? 0,
         usageTokens: 0,
+        creditLimit: CreditLimit,
+        usageCost: 0,
         allowed_models: AllowedModels,
         createdAt: CreatedAt
     };
 }
 
-export function incrementAPIKeyUsageDB(keyId: string, tokens: number): void {
-    const Query = db.prepare("UPDATE api_keys SET usage_tokens = usage_tokens + ? WHERE id = ?");
-    Query.run(tokens, keyId);
+export function incrementAPIKeyUsageDB(keyId: string, tokens: number, cost = 0): void {
+    const Query = db.prepare(
+        "UPDATE api_keys SET usage_tokens = usage_tokens + ?, usage_cost = usage_cost + ? WHERE id = ?"
+    );
+    Query.run(tokens, cost, keyId);
+}
+
+export function addCreditAPIKeyDB(id: string, amount: number): DBAPIKey | null {
+    const UpdateQuery = db.prepare(
+        "UPDATE api_keys SET credit_limit = credit_limit + ? WHERE id = ?"
+    );
+    UpdateQuery.run(amount, id);
+
+    const SelectQuery = db.prepare("SELECT * FROM api_keys WHERE id = ?");
+    const Row = SelectQuery.get(id) as unknown as APIKeyRow | undefined;
+    if (!Row) return null;
+    return mapAPIKeyRow(Row);
 }
 
 export function deleteAPIKeyDB(id: string): boolean {

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -133,9 +133,12 @@ export function initDatabase(): void {
             rate_limit INTEGER DEFAULT 0,
             quota_limit INTEGER DEFAULT 0,
             usage_tokens INTEGER DEFAULT 0,
+            allowed_models TEXT,
             created_at INTEGER NOT NULL
         );
     `);
+
+    ensureColumns("api_keys", [{ name: "allowed_models", definition: "allowed_models TEXT" }]);
 
     // 3. Table for Request Logs & Token Analytics
     db.exec(`

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -133,12 +133,18 @@ export function initDatabase(): void {
             rate_limit INTEGER DEFAULT 0,
             quota_limit INTEGER DEFAULT 0,
             usage_tokens INTEGER DEFAULT 0,
+            credit_limit REAL DEFAULT 0,
+            usage_cost REAL DEFAULT 0,
             allowed_models TEXT,
             created_at INTEGER NOT NULL
         );
     `);
 
-    ensureColumns("api_keys", [{ name: "allowed_models", definition: "allowed_models TEXT" }]);
+    ensureColumns("api_keys", [
+        { name: "allowed_models", definition: "allowed_models TEXT" },
+        { name: "credit_limit", definition: "credit_limit REAL DEFAULT 0" },
+        { name: "usage_cost", definition: "usage_cost REAL DEFAULT 0" }
+    ]);
 
     // 3. Table for Request Logs & Token Analytics
     db.exec(`

--- a/packages/types/src/apiKeys.ts
+++ b/packages/types/src/apiKeys.ts
@@ -6,6 +6,8 @@ export interface DBAPIKey {
     rateLimit: number;
     quotaLimit: number;
     usageTokens: number;
+    creditLimit: number;
+    usageCost: number;
     allowed_models?: string[] | null;
     createdAt: number;
 }

--- a/packages/types/src/apiKeys.ts
+++ b/packages/types/src/apiKeys.ts
@@ -6,5 +6,6 @@ export interface DBAPIKey {
     rateLimit: number;
     quotaLimit: number;
     usageTokens: number;
+    allowed_models?: string[] | null;
     createdAt: number;
 }

--- a/packages/types/src/schemas/apiKeys.ts
+++ b/packages/types/src/schemas/apiKeys.ts
@@ -7,7 +7,8 @@ export const CreateAPIKeySchema = z.object({
         })
         .min(1, "Field 'name' cannot be empty"),
     rateLimit: z.number().int().nonnegative().optional(),
-    quotaLimit: z.number().int().nonnegative().optional()
+    quotaLimit: z.number().int().nonnegative().optional(),
+    allowed_models: z.array(z.string().min(1)).nullable().optional()
 });
 
 export type CreateAPIKeyZod = z.infer<typeof CreateAPIKeySchema>;

--- a/packages/types/src/schemas/apiKeys.ts
+++ b/packages/types/src/schemas/apiKeys.ts
@@ -8,7 +8,18 @@ export const CreateAPIKeySchema = z.object({
         .min(1, "Field 'name' cannot be empty"),
     rateLimit: z.number().int().nonnegative().optional(),
     quotaLimit: z.number().int().nonnegative().optional(),
+    creditLimit: z.number().nonnegative().optional(),
     allowed_models: z.array(z.string().min(1)).nullable().optional()
 });
 
 export type CreateAPIKeyZod = z.infer<typeof CreateAPIKeySchema>;
+
+export const AddCreditSchema = z.object({
+    amount: z
+        .number({
+            required_error: "Field 'amount' is required"
+        })
+        .positive("Amount must be greater than 0")
+});
+
+export type AddCreditZod = z.infer<typeof AddCreditSchema>;


### PR DESCRIPTION
## Summary
Adds per-key model access control (`allowed_models`) to virtual API keys.

- **DB**: new JSON-encoded `allowed_models TEXT` column on `api_keys` (nullable = unrestricted), with `ensureColumns` migration and safe JSON parse/serialize in `packages/db/src/apiKeys.ts`.
- **Types**: `DBAPIKey.allowed_models` and `CreateAPIKeySchema.allowed_models` (Zod `string[].nullable().optional()`).
- **API enforcement**:
  - `EnforceModelAccess` middleware on `/v1/chat/completions` (and `/chat/completion`).
  - Guard in Anthropic `/v1/messages` controller.
  - `/v1/models` listing filtered to the key's allowed scope; `GetModelById` rejects out-of-scope.
  - Rejections return HTTP 403 (`model_not_allowed` OpenAI / `permission_error` Anthropic).
  - `srouter/` prefix normalized when matching.
- **Web**: model picker (All vs Specific) in `CreateKeyDialog`, scope badge column in `KeyTable`, and summary in `KeySecretModal`.

## Wire format changes
- New response code `model_not_allowed` (403) on chat/models endpoints for restricted keys.
- `/v1/models` now returns a filtered list when the authenticating key is restricted.

## Verification
- `packages/types`, `packages/db`, `apps/api`, `apps/web` builds pass.
- `tests/api-keys-allowed-models.test.ts` + `tests/api-keys.test.ts`: 8 passed.
- Live smoke test against a running instance:
  - Restricted key -> disallowed model on `/v1/chat/completions` -> 403 `model_not_allowed`.
  - Restricted key -> `/v1/models` -> filtered (`data: []` for a non-existent allow entry).
  - Restricted key -> `/v1/messages` disallowed -> 403 `permission_error`.
  - Unrestricted key -> `/v1/models` -> full list (6 models).