### PR TITLE
fix(security): tunnel auth, CORS/CSRF, rate limiting, request limits, SSRF, esbuild

### DIFF
--- a/apps/api/src/controllers/messages.controller.ts
+++ b/apps/api/src/controllers/messages.controller.ts
@@ -9,11 +9,21 @@ import { AnthropicMessageRequestSchema, type AnthropicMessageRequest } from "@sr
 import { ChatLogic } from "@/logic/chat.logic.js";
 import { AnthropicErr, FormatAnthropicErrorPayload, Ok } from "@/utils/response.js";
 import { GetApiKeyRow, IsModelAllowed } from "@/middleware/ModelAccess.js";
+import { MAX_BODY_BYTES } from "@/middleware/BodyLimit.js";
 
 export class MessagesController {
     public static async CreateMessage(c: Context): Promise<Response> {
         const startTime = Date.now();
-        const rawBody = await c.req.json().catch(() => null);
+        const Raw = await c.req.text().catch(() => "");
+        if (Buffer.byteLength(Raw) > MAX_BODY_BYTES) {
+            return AnthropicErr(c, "Request body too large", 413, "invalid_request_error");
+        }
+        let rawBody: unknown = null;
+        try {
+            rawBody = JSON.parse(Raw);
+        } catch {
+            rawBody = null;
+        }
         if (!rawBody || typeof rawBody !== "object") {
             return AnthropicErr(c, "Invalid JSON request body", 400);
         }

--- a/apps/api/src/controllers/tunnel.controller.ts
+++ b/apps/api/src/controllers/tunnel.controller.ts
@@ -14,6 +14,10 @@ import {
     stopTunnel
 } from "@/services/cloudflareTunnel.js";
 
+/** Cap concurrent SSE tunnel-event streams so one session cannot exhaust workers. */
+const MAX_EVENT_STREAMS = 8;
+let ActiveEventStreams = 0;
+
 export class TunnelController {
     public static GetStatus(c: Context): Response {
         const Status = getTunnelStatus();
@@ -21,9 +25,24 @@ export class TunnelController {
     }
 
     public static GetEvents(c: Context): Response {
+        if (ActiveEventStreams >= MAX_EVENT_STREAMS) {
+            return Err(c, "Too many concurrent tunnel event streams", 429, {
+                code: "too_many_streams"
+            });
+        }
+        ActiveEventStreams += 1;
+
         const Encoder = new TextEncoder();
         let Unsubscribe: (() => void) | null = null;
         let Heartbeat: ReturnType<typeof setInterval> | null = null;
+
+        const Release = () => {
+            if (Heartbeat) clearInterval(Heartbeat);
+            if (Unsubscribe) Unsubscribe();
+            Unsubscribe = null;
+            Heartbeat = null;
+            ActiveEventStreams -= 1;
+        };
 
         const Stream = new ReadableStream<Uint8Array>({
             start(controller) {
@@ -46,10 +65,7 @@ export class TunnelController {
                 }, 25_000);
             },
             cancel() {
-                if (Heartbeat) clearInterval(Heartbeat);
-                if (Unsubscribe) Unsubscribe();
-                Unsubscribe = null;
-                Heartbeat = null;
+                Release();
             }
         });
 

--- a/apps/api/src/controllers/tunnel.controller.ts
+++ b/apps/api/src/controllers/tunnel.controller.ts
@@ -52,17 +52,22 @@ export class TunnelController {
                     } catch {}
                 };
 
-                Send({ ...getTunnelStatus(), tokenConfigured: Boolean(getTunnelToken()) });
+                try {
+                    Send({ ...getTunnelStatus(), tokenConfigured: Boolean(getTunnelToken()) });
 
-                Unsubscribe = onTunnelUpdate((Status) => {
-                    Send({ ...Status, tokenConfigured: Boolean(getTunnelToken()) });
-                });
+                    Unsubscribe = onTunnelUpdate((Status) => {
+                        Send({ ...Status, tokenConfigured: Boolean(getTunnelToken()) });
+                    });
 
-                Heartbeat = setInterval(() => {
-                    try {
-                        controller.enqueue(Encoder.encode(`: ping\n\n`));
-                    } catch {}
-                }, 25_000);
+                    Heartbeat = setInterval(() => {
+                        try {
+                            controller.enqueue(Encoder.encode(`: ping\n\n`));
+                        } catch {}
+                    }, 25_000);
+                } catch (SetupError) {
+                    Release();
+                    throw SetupError;
+                }
             },
             cancel() {
                 Release();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono, type Context } from "hono";
-import { cors } from "hono/cors";
 import { AuthRouter } from "@/routes/v1/auth.js";
 import { AuthController } from "@/controllers/auth.controller.js";
 import { adminRoute } from "@/routes/v1/admin.js";
@@ -16,7 +15,9 @@ import { ProvidersRouter } from "@/routes/v1/providers.js";
 import { QuotaRouter } from "@/routes/v1/quota.js";
 import { SettingsRouter } from "@/routes/v1/settings.js";
 import { TunnelRouter } from "@/routes/v1/tunnel.js";
-import { RequireAdmin } from "@/middleware/AdminAuth.js";
+import { CreateCorsMiddleware, ParseAllowedOrigins } from "@/middleware/Cors.js";
+import { CreateCsrfOriginGuard } from "@/middleware/CsrfOrigin.js";
+import { CreateBodyLimitMiddleware } from "@/middleware/BodyLimit.js";
 import { startTokenRefreshSweeper } from "@/services/tokenRefresh.js";
 import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry } from "@/services/registry.js";
@@ -40,27 +41,15 @@ app.use("/*", async (c, next) => {
     c.header("Referrer-Policy", "strict-origin-when-cross-origin");
 });
 
-// Enable CORS with sensible defaults
-app.use(
-    "/*",
-    cors({
-        origin: (origin) => {
-            // Allow requests with no origin (mobile apps, curl, server-to-server)
-            if (!origin) return "*";
-            // Allow localhost/loopback development origins
-            if (/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(origin)) {
-                return origin;
-            }
-            // For public origins, return origin without wildcard when credentials are needed,
-            // or return origin if explicitly running as API gateway
-            return origin;
-        },
-        allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-        allowHeaders: ["Content-Type", "Authorization", "x-api-key", "anthropic-version"],
-        exposeHeaders: ["Content-Length", "X-Request-Id", "X-Version"],
-        credentials: true
-    })
-);
+// CORS: loopback origins always pass; public origins require SROUTER_CORS_ORIGINS.
+const CorsAllowlist = ParseAllowedOrigins();
+app.use("/*", CreateCorsMiddleware(CorsAllowlist));
+
+// CSRF defense for cookie-authenticated mutations (no-op for API-key traffic).
+app.use("/v1/*", CreateCsrfOriginGuard(CorsAllowlist));
+
+// Reject oversized bodies before they are buffered into memory.
+app.use("/v1/*", CreateBodyLimitMiddleware());
 
 // Bootstrap the admin account only when SROUTER_ADMIN_PASSWORD is set.
 // Otherwise first-run setup happens through the dashboard.
@@ -140,12 +129,8 @@ app.route("/v1", AuthRouter);
 app.route("/v1", QuotaRouter);
 app.route("/v1", SettingsRouter);
 
-// Cloudflare Tunnel management (admin-only; status readable via API key too)
+// Cloudflare Tunnel management (admin-only; guard lives inside TunnelRouter)
 app.route("/v1", TunnelRouter);
-app.use("/v1/tunnel/start", RequireAdmin);
-app.use("/v1/tunnel/stop", RequireAdmin);
-app.use("/v1/tunnel/config", RequireAdmin);
-app.use("/v1/tunnel/install", RequireAdmin);
 
 // Mount /v1/v1 compatibility routes for SDKs that append /v1 to a baseURL containing /v1
 app.route("/v1/v1", MessagesRouter);

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -21,6 +21,7 @@ import {
     upsertProviderDB
 } from "@srouter/db";
 import { loadSavedProvidersFromDB, registry } from "@/services/registry.js";
+import { AssertPublicUrl } from "@/utils/ssrf.js";
 
 export interface GroupedCatalog {
     oauth: ProviderDefinition[];
@@ -326,32 +327,15 @@ export class ProvidersLogic {
 
         if (BaseUrl) {
             try {
-                const Url = new URL(BaseUrl);
-                if (!["http:", "https:"].includes(Url.protocol)) {
-                    return {
-                        success: false,
-                        message: "URL endpoint harus berformat HTTP atau HTTPS."
-                    };
-                }
-                const Hostname = Url.hostname.toLowerCase();
-                const IsInternalHost =
-                    Hostname === "169.254.169.254" ||
-                    Hostname === "metadata.google.internal" ||
-                    Hostname === "instance-data" ||
-                    Hostname === "localhost" ||
-                    Hostname === "127.0.0.1" ||
-                    Hostname === "::1" ||
-                    Hostname.startsWith("127.") ||
-                    Hostname.startsWith("169.254.");
-                if (IsInternalHost) {
-                    return {
-                        success: false,
-                        message:
-                            "Target URL tidak diizinkan untuk verifikasi (endpoint internal/metadata diblokir)."
-                    };
-                }
-            } catch {
-                return { success: false, message: "Format Endpoint Base URL tidak valid." };
+                await AssertPublicUrl(BaseUrl);
+            } catch (Err) {
+                return {
+                    success: false,
+                    message:
+                        Err instanceof Error
+                            ? `Target URL tidak diizinkan: ${Err.message}`
+                            : "Format Endpoint Base URL tidak valid."
+                };
             }
         }
 
@@ -378,6 +362,7 @@ export class ProvidersLogic {
                 const Res = await fetch(TargetUrl, {
                     method: "GET",
                     headers: Headers,
+                    redirect: "manual",
                     signal: AbortSignal.timeout(8000)
                 });
 
@@ -393,6 +378,13 @@ export class ProvidersLogic {
                                 ? `Koneksi Anthropic valid! (${Count} model ditemukan)`
                                 : "Koneksi Anthropic berhasil diverifikasi.",
                         modelsCount: Count
+                    };
+                }
+
+                if (Res.status >= 300 && Res.status < 400) {
+                    return {
+                        success: false,
+                        message: "Redirect tidak diikuti untuk verifikasi (potensi SSRF)."
                     };
                 }
 
@@ -431,6 +423,7 @@ export class ProvidersLogic {
             const Res = await fetch(TargetUrl, {
                 method: "GET",
                 headers: Headers,
+                redirect: "manual",
                 signal: AbortSignal.timeout(8000)
             });
 
@@ -446,6 +439,13 @@ export class ProvidersLogic {
                             ? `Koneksi OpenAI valid! (${Count} model ditemukan)`
                             : "Koneksi OpenAI berhasil diverifikasi.",
                     modelsCount: Count
+                };
+            }
+
+            if (Res.status >= 300 && Res.status < 400) {
+                return {
+                    success: false,
+                    message: "Redirect tidak diikuti untuk verifikasi (potensi SSRF)."
                 };
             }
 

--- a/apps/api/src/middleware/ApiKeyAuth.ts
+++ b/apps/api/src/middleware/ApiKeyAuth.ts
@@ -20,7 +20,7 @@ export interface ApiKeyAuthOptions {
     getClientAddress?: (c: Context) => string | undefined;
 }
 
-function GetDirectClientAddress(c: Context): string | undefined {
+export function GetDirectClientAddress(c: Context): string | undefined {
     try {
         const Addr = getConnInfo(c).remote.address;
         if (Addr) return Addr;

--- a/apps/api/src/middleware/BodyLimit.ts
+++ b/apps/api/src/middleware/BodyLimit.ts
@@ -1,0 +1,23 @@
+import type { MiddlewareHandler } from "hono";
+import { Err } from "@/utils/response.js";
+
+/** Max accepted request body in bytes (25 MB). Large enough for base64 image payloads. */
+export const MAX_BODY_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Rejects oversized bodies from the Content-Length header before the body is
+ * buffered. ValidateJson enforces the same cap on the raw text for chunked
+ * requests that omit Content-Length.
+ */
+export function CreateBodyLimitMiddleware(MaxBytes: number = MAX_BODY_BYTES): MiddlewareHandler {
+    return async (c, next) => {
+        const LengthHeader = c.req.header("content-length");
+        if (LengthHeader) {
+            const Length = Number(LengthHeader);
+            if (Number.isFinite(Length) && Length > MaxBytes) {
+                return Err(c, "Request body too large", 413, { code: "request_too_large" });
+            }
+        }
+        return next();
+    };
+}

--- a/apps/api/src/middleware/Cors.ts
+++ b/apps/api/src/middleware/Cors.ts
@@ -1,0 +1,39 @@
+import { cors } from "hono/cors";
+import type { MiddlewareHandler } from "hono";
+
+const LOOPBACK_ORIGIN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
+
+export function ParseAllowedOrigins(EnvValue = process.env.SROUTER_CORS_ORIGINS): Set<string> {
+    return new Set(
+        (EnvValue ?? "")
+            .split(",")
+            .map((Entry) => Entry.trim().replace(/\/+$/, ""))
+            .filter(Boolean)
+    );
+}
+
+/**
+ * Returns the origin to echo back, or null when the origin is not allowed.
+ * Requests without an Origin header (curl, server-to-server) never need
+ * CORS headers, so they also return null.
+ */
+export function GetAllowedOrigin(
+    Origin: string | undefined,
+    Allowlist: Set<string>
+): string | null {
+    if (!Origin) return null;
+    if (LOOPBACK_ORIGIN.test(Origin) || Allowlist.has(Origin)) return Origin;
+    return null;
+}
+
+export function CreateCorsMiddleware(ExtraOrigins?: Set<string>): MiddlewareHandler {
+    const Allowlist = ExtraOrigins ?? ParseAllowedOrigins();
+
+    return cors({
+        origin: (Origin) => GetAllowedOrigin(Origin, Allowlist),
+        allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allowHeaders: ["Content-Type", "Authorization", "x-api-key", "anthropic-version"],
+        exposeHeaders: ["Content-Length", "X-Request-Id", "X-Version"],
+        credentials: true
+    });
+}

--- a/apps/api/src/middleware/CsrfOrigin.ts
+++ b/apps/api/src/middleware/CsrfOrigin.ts
@@ -1,0 +1,49 @@
+import { getCookie } from "hono/cookie";
+import type { Context, MiddlewareHandler } from "hono";
+import { Err } from "@/utils/response.js";
+import { ADMIN_SESSION_COOKIE } from "@/services/adminAuth.js";
+import { GetAllowedOrigin } from "@/middleware/Cors.js";
+
+const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * CSRF defense for cookie-based admin mutations. SameSite=Lax already blocks
+ * cross-site POSTs from modern browsers; this adds an explicit Origin/Referer
+ * check for same-site cross-subdomain requests. Requests without an admin
+ * session cookie (plain API-key traffic) and non-browser clients (no Origin)
+ * pass through untouched.
+ */
+export function CreateCsrfOriginGuard(Allowlist: Set<string>): MiddlewareHandler {
+    return async (c: Context, next) => {
+        if (!UNSAFE_METHODS.has(c.req.method)) return next();
+        if (!getCookie(c, ADMIN_SESSION_COOKIE)) return next();
+
+        const Origin = c.req.header("origin") || c.req.header("referer");
+        if (!Origin) return next();
+
+        let OriginUrl: URL | null = null;
+        try {
+            OriginUrl = new URL(Origin);
+        } catch {
+            OriginUrl = null;
+        }
+        if (!OriginUrl) {
+            return Err(c, "Cross-origin admin mutation is not allowed", 403, {
+                code: "csrf_origin_rejected"
+            });
+        }
+
+        // Same-origin mutations are inherently CSRF-safe (the browser decides
+        // the Origin header; an attacker page cannot forge its own origin).
+        const RequestHost = new URL(c.req.url).host || c.req.header("host");
+        if (OriginUrl.host === RequestHost) return next();
+
+        if (!GetAllowedOrigin(OriginUrl.origin, Allowlist)) {
+            return Err(c, "Cross-origin admin mutation is not allowed", 403, {
+                code: "csrf_origin_rejected"
+            });
+        }
+
+        return next();
+    };
+}

--- a/apps/api/src/middleware/RateLimit.ts
+++ b/apps/api/src/middleware/RateLimit.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from "hono";
 import type { APIKeyZod } from "@srouter/types";
 import { Err } from "@/utils/response.js";
+import { GetDirectClientAddress } from "@/middleware/ApiKeyAuth.js";
 
 const WINDOW_MS = 60_000;
 const MAX_TRACKED_KEYS = 10_000;
@@ -62,4 +63,6 @@ export function CreateRateLimitMiddleware(Options: RateLimitOptions = {}): Middl
     };
 }
 
-export const EnforceRateLimit = CreateRateLimitMiddleware();
+export const EnforceRateLimit = CreateRateLimitMiddleware({
+    getClientAddress: GetDirectClientAddress
+});

--- a/apps/api/src/middleware/RateLimit.ts
+++ b/apps/api/src/middleware/RateLimit.ts
@@ -1,0 +1,65 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { APIKeyZod } from "@srouter/types";
+import { Err } from "@/utils/response.js";
+
+const WINDOW_MS = 60_000;
+const MAX_TRACKED_KEYS = 10_000;
+
+interface WindowEntry {
+    count: number;
+    resetAt: number;
+}
+
+export interface RateLimitOptions {
+    now?: () => number;
+    windows?: Map<string, WindowEntry>;
+    getClientAddress?: (c: Context) => string | undefined;
+}
+
+/**
+ * Fixed-window rate limiter keyed by API key id + client address.
+ * `rate_limit` is requests per minute; 0 (default) means unlimited.
+ * Must run after ApiKeyAuth so `apiKeyRow` is populated.
+ */
+export function CreateRateLimitMiddleware(Options: RateLimitOptions = {}): MiddlewareHandler {
+    const Now = Options.now ?? (() => Date.now());
+    const Windows = Options.windows ?? new Map<string, WindowEntry>();
+    const GetAddress = Options.getClientAddress ?? (() => undefined);
+
+    return async (c, next) => {
+        const ApiKeyRow = c.get("apiKeyRow") as APIKeyZod | undefined;
+        const Limit = ApiKeyRow?.rate_limit ?? 0;
+        if (!ApiKeyRow || Limit <= 0) return next();
+
+        const Timestamp = Now();
+        if (Windows.size > MAX_TRACKED_KEYS) {
+            for (const [Key, Entry] of Windows) {
+                if (Entry.resetAt <= Timestamp) Windows.delete(Key);
+            }
+        }
+
+        const WindowKey = `${ApiKeyRow.id}:${GetAddress(c) ?? "unknown"}`;
+        const Entry = Windows.get(WindowKey);
+
+        if (!Entry || Entry.resetAt <= Timestamp) {
+            Windows.set(WindowKey, { count: 1, resetAt: Timestamp + WINDOW_MS });
+            return next();
+        }
+
+        Entry.count += 1;
+        if (Entry.count > Limit) {
+            const RetryAfterSec = Math.max(1, Math.ceil((Entry.resetAt - Timestamp) / 1000));
+            c.header("Retry-After", String(RetryAfterSec));
+            return Err(
+                c,
+                `Rate limit exceeded: this API key allows ${Limit} request${Limit === 1 ? "" : "s"} per minute.`,
+                429,
+                { code: "rate_limit_exceeded" }
+            );
+        }
+
+        return next();
+    };
+}
+
+export const EnforceRateLimit = CreateRateLimitMiddleware();

--- a/apps/api/src/middleware/Validation.ts
+++ b/apps/api/src/middleware/Validation.ts
@@ -1,11 +1,24 @@
 import type { ZodSchema } from "zod";
 import type { MiddlewareHandler } from "hono";
+import { MAX_BODY_BYTES } from "@/middleware/BodyLimit.js";
 
 export function ValidateJson<T extends ZodSchema>(Schema: T): MiddlewareHandler {
     return async (c, next) => {
         let Body: unknown;
         try {
             const Raw = await c.req.text();
+            if (Raw.length > MAX_BODY_BYTES) {
+                return c.json(
+                    {
+                        error: {
+                            message: "Request body too large",
+                            type: "invalid_request_error",
+                            code: "request_too_large"
+                        }
+                    },
+                    413
+                );
+            }
             if (!Raw || !Raw.trim()) {
                 return c.json(
                     {

--- a/apps/api/src/middleware/Validation.ts
+++ b/apps/api/src/middleware/Validation.ts
@@ -1,23 +1,15 @@
 import type { ZodSchema } from "zod";
 import type { MiddlewareHandler } from "hono";
 import { MAX_BODY_BYTES } from "@/middleware/BodyLimit.js";
+import { Err } from "@/utils/response.js";
 
 export function ValidateJson<T extends ZodSchema>(Schema: T): MiddlewareHandler {
     return async (c, next) => {
         let Body: unknown;
         try {
             const Raw = await c.req.text();
-            if (Raw.length > MAX_BODY_BYTES) {
-                return c.json(
-                    {
-                        error: {
-                            message: "Request body too large",
-                            type: "invalid_request_error",
-                            code: "request_too_large"
-                        }
-                    },
-                    413
-                );
+            if (Buffer.byteLength(Raw) > MAX_BODY_BYTES) {
+                return Err(c, "Request body too large", 413, { code: "request_too_large" });
             }
             if (!Raw || !Raw.trim()) {
                 return c.json(

--- a/apps/api/src/routes/v1/chat.ts
+++ b/apps/api/src/routes/v1/chat.ts
@@ -4,12 +4,14 @@ import { ChatController } from "@/controllers/chat.controller.js";
 import { ValidateJson } from "@/middleware/Validation.js";
 import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
 import { EnforceModelAccess } from "@/middleware/ModelAccess.js";
+import { EnforceRateLimit } from "@/middleware/RateLimit.js";
 
 export const ChatRouter = new Hono();
 
 ChatRouter.post(
     "/chat/completions",
     ApiKeyAuth,
+    EnforceRateLimit,
     ValidateJson(ChatCompletionRequestSchema),
     EnforceModelAccess(),
     ChatController.CreateCompletion
@@ -17,6 +19,7 @@ ChatRouter.post(
 ChatRouter.post(
     "/chat/completion",
     ApiKeyAuth,
+    EnforceRateLimit,
     ValidateJson(ChatCompletionRequestSchema),
     EnforceModelAccess(),
     ChatController.CreateCompletion

--- a/apps/api/src/routes/v1/messages.ts
+++ b/apps/api/src/routes/v1/messages.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
 import { MessagesController } from "@/controllers/messages.controller.js";
 import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
+import { EnforceRateLimit } from "@/middleware/RateLimit.js";
 
 export const MessagesRouter = new Hono();
 
-MessagesRouter.post("/messages", ApiKeyAuth, MessagesController.CreateMessage);
+MessagesRouter.post("/messages", ApiKeyAuth, EnforceRateLimit, MessagesController.CreateMessage);

--- a/apps/api/src/routes/v1/tunnel.ts
+++ b/apps/api/src/routes/v1/tunnel.ts
@@ -1,7 +1,12 @@
 import { Hono } from "hono";
 import { TunnelController } from "@/controllers/tunnel.controller.js";
+import { RequireAdmin } from "@/middleware/AdminAuth.js";
 
 export const TunnelRouter = new Hono();
+
+// Admin-only: guards travel with the router so mount order can never leave
+// tunnel mutations (subprocess spawn, installer, config writes) anonymous.
+TunnelRouter.use("*", RequireAdmin);
 
 TunnelRouter.get("/tunnel/status", TunnelController.GetStatus);
 TunnelRouter.get("/tunnel/events", TunnelController.GetEvents);

--- a/apps/api/src/utils/ssrf.ts
+++ b/apps/api/src/utils/ssrf.ts
@@ -1,0 +1,73 @@
+import { promises as dns } from "node:dns";
+import net from "node:net";
+
+function IsPrivateIpv4(Address: string): boolean {
+    const Parts = Address.split(".").map(Number);
+    if (Parts.length !== 4 || Parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+        return true;
+    }
+    const [A, B] = Parts as [number, number, number, number];
+    if (A === 0 || A === 10 || A === 127) return true; // this-network / RFC1918 / loopback
+    if (A === 169 && B === 254) return true; // link-local + cloud metadata
+    if (A === 172 && B >= 16 && B <= 31) return true; // RFC1918
+    if (A === 192 && B === 168) return true; // RFC1918
+    if (A === 192 && B === 0) return true; // IETF protocol assignments
+    if (A === 100 && B >= 64 && B <= 127) return true; // CGNAT
+    if (A >= 224) return true; // multicast + reserved
+    return false;
+}
+
+function IsPrivateIpv6(Address: string): boolean {
+    const Lower = Address.toLowerCase().replace(/^::ffff:/, "");
+    if (Lower.includes(".")) return IsPrivateIpv4(Lower.split(".").slice(-4).join("."));
+    if (Lower === "::" || Lower === "::1") return true; // unspecified / loopback
+    const Head = Lower.split(":")[0] ?? "";
+    const Prefix = parseInt(Head.padStart(4, "0").slice(0, 2), 16);
+    if ((Prefix & 0xfe) === 0xfc) return true; // fc00::/7 unique-local
+    if (Head.startsWith("fe8") || Head.startsWith("fe9") || Head.startsWith("fea") || Head.startsWith("feb")) return true; // link-local
+    if (Head.startsWith("ff")) return true; // multicast
+    return false;
+}
+
+export function IsPrivateIpAddress(Address: string): boolean {
+    const Family = net.isIP(Address);
+    if (Family === 4) return IsPrivateIpv4(Address);
+    if (Family === 6) return IsPrivateIpv6(Address);
+    return true; // not a parseable IP → treat as unsafe
+}
+
+/**
+ * Resolves a hostname and rejects it when ANY resolved address is private,
+ * loopback, link-local, multicast, or a cloud metadata endpoint. DNS
+ * resolution happens once here and the caller can trust the verdict for the
+ * immediate request; redirect following must stay disabled to keep it sound.
+ */
+export async function AssertPublicUrl(RawUrl: string): Promise<void> {
+    const Url = new URL(RawUrl);
+    if (!["http:", "https:"].includes(Url.protocol)) {
+        throw new Error("URL endpoint must use HTTP or HTTPS.");
+    }
+
+    const Hostname = Url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    if (Hostname === "metadata.google.internal" || Hostname === "instance-data") {
+        throw new Error("Internal/metadata endpoints are blocked.");
+    }
+
+    if (net.isIP(Hostname)) {
+        if (IsPrivateIpAddress(Hostname)) {
+            throw new Error("Internal/private IP targets are blocked.");
+        }
+        return;
+    }
+
+    let Addresses: { address: string }[];
+    try {
+        Addresses = await dns.lookup(Hostname, { all: true, verbatim: true });
+    } catch {
+        throw new Error("Hostname could not be resolved.");
+    }
+    if (Addresses.length === 0) throw new Error("Hostname could not be resolved.");
+    if (Addresses.some((Entry) => IsPrivateIpAddress(Entry.address))) {
+        throw new Error("Hostname resolves to a private/internal address.");
+    }
+}

--- a/apps/api/tests/cors-allowlist.test.ts
+++ b/apps/api/tests/cors-allowlist.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Hono } from "hono";
+import { CreateCorsMiddleware, GetAllowedOrigin, ParseAllowedOrigins } from "../src/middleware/Cors.js";
+
+function createTestApp(Allowlist = new Set<string>()) {
+    const app = new Hono();
+    app.use("/*", CreateCorsMiddleware(Allowlist));
+    app.get("/v1/models", (c) => c.json({ ok: true }));
+    app.post("/v1/chat/completions", (c) => c.json({ ok: true }));
+    return app;
+}
+
+test("origin allowlist parsing trims and drops empties", () => {
+    const Set = ParseAllowedOrigins(" https://dash.example.com , http://localhost:5173,, ");
+    assert.deepEqual([...Set], ["https://dash.example.com", "http://localhost:5173"]);
+    assert.equal(ParseAllowedOrigins(undefined).size, 0);
+});
+
+test("GetAllowedOrigin: loopback passes, allowlisted passes, unknown and missing fail", () => {
+    const Allow = new Set(["https://dash.example.com"]);
+    assert.equal(GetAllowedOrigin("http://localhost:5173", Allow), "http://localhost:5173");
+    assert.equal(GetAllowedOrigin("https://127.0.0.1:3000", Allow), "https://127.0.0.1:3000");
+    assert.equal(GetAllowedOrigin("https://dash.example.com", Allow), "https://dash.example.com");
+    assert.equal(GetAllowedOrigin("https://evil.example.com", Allow), null);
+    assert.equal(GetAllowedOrigin(undefined, Allow), null);
+});
+
+test("arbitrary public origin gets no CORS headers", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/models", {
+        headers: { Origin: "https://evil.example.com" }
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("access-control-allow-origin"), null);
+});
+
+test("preflight from arbitrary origin is not approved", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+            Origin: "https://evil.example.com",
+            "Access-Control-Request-Method": "POST"
+        }
+    });
+    assert.equal(res.headers.get("access-control-allow-origin"), null);
+});
+
+test("allowlisted origin receives reflected origin with credentials", async () => {
+    const app = createTestApp(new Set(["https://dash.example.com"]));
+    const res = await app.request("/v1/models", {
+        headers: { Origin: "https://dash.example.com" }
+    });
+    assert.equal(res.headers.get("access-control-allow-origin"), "https://dash.example.com");
+    assert.equal(res.headers.get("access-control-allow-credentials"), "true");
+});
+
+test("loopback dev origins keep working", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/models", {
+        headers: { Origin: "http://localhost:5173" }
+    });
+    assert.equal(res.headers.get("access-control-allow-origin"), "http://localhost:5173");
+});

--- a/apps/api/tests/csrf-origin-guard.test.ts
+++ b/apps/api/tests/csrf-origin-guard.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Hono } from "hono";
+import { adminAuthStore } from "@srouter/db";
+import { CreateCsrfOriginGuard } from "../src/middleware/CsrfOrigin.js";
+import { ADMIN_SESSION_COOKIE, createAdminSession, revokeAdminSession } from "../src/services/adminAuth.js";
+
+function createTestApp(Allowlist = new Set<string>()) {
+    const app = new Hono();
+    app.use("/v1/*", CreateCsrfOriginGuard(Allowlist));
+    app.post("/v1/keys", (c) => c.json({ ok: true }));
+    return app;
+}
+
+test("cookie mutation from a foreign origin is rejected even with a valid session", async () => {
+    const app = createTestApp();
+    const Token = createAdminSession(adminAuthStore);
+    try {
+        const res = await app.request("/v1/keys", {
+            method: "POST",
+            headers: {
+                Cookie: `${ADMIN_SESSION_COOKIE}=${Token}`,
+                Origin: "https://evil.example.com"
+            }
+        });
+        assert.equal(res.status, 403);
+        const body = (await res.json()) as { error: { code: string } };
+        assert.equal(body.error.code, "csrf_origin_rejected");
+    } finally {
+        revokeAdminSession(adminAuthStore, Token);
+    }
+});
+
+test("same-origin cookie mutation passes", async () => {
+    const app = createTestApp();
+    const Token = createAdminSession(adminAuthStore);
+    try {
+        const res = await app.request("http://gateway.local:3000/v1/keys", {
+            method: "POST",
+            headers: {
+                Cookie: `${ADMIN_SESSION_COOKIE}=${Token}`,
+                Origin: "http://gateway.local:3000"
+            }
+        });
+        assert.equal(res.status, 200);
+    } finally {
+        revokeAdminSession(adminAuthStore, Token);
+    }
+});
+
+test("cross-origin mutation from an allowlisted origin passes", async () => {
+    const app = createTestApp(new Set(["https://dash.example.com"]));
+    const Token = createAdminSession(adminAuthStore);
+    try {
+        const res = await app.request("http://gateway.local:3000/v1/keys", {
+            method: "POST",
+            headers: {
+                Cookie: `${ADMIN_SESSION_COOKIE}=${Token}`,
+                Origin: "https://dash.example.com"
+            }
+        });
+        assert.equal(res.status, 200);
+    } finally {
+        revokeAdminSession(adminAuthStore, Token);
+    }
+});
+
+test("API-key traffic without a session cookie is untouched", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/keys", {
+        method: "POST",
+        headers: {
+            Authorization: "***",
+            Origin: "https://evil.example.com"
+        }
+    });
+    assert.equal(res.status, 200);
+});
+
+test("GET requests are never blocked", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/keys", {
+        method: "GET",
+        headers: { Origin: "https://evil.example.com" }
+    });
+    assert.equal(res.status, 404);
+});

--- a/apps/api/tests/rate-limit.test.ts
+++ b/apps/api/tests/rate-limit.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { Hono } from "hono";
+import { createAPIKeyDB, deleteAPIKeyDB } from "@srouter/db";
+import { CreateRateLimitMiddleware } from "../src/middleware/RateLimit.js";
+import type { APIKeyZod } from "@srouter/types";
+
+const createdKeyIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdKeyIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+function createTestApp(Row: Partial<APIKeyZod> | undefined, now: () => number = () => Date.now()) {
+    const app = new Hono();
+    app.use("/*", async (c, next) => {
+        if (Row) c.set("apiKeyRow" as never, Row as never);
+        await next();
+    });
+    app.use(
+        "/*",
+        CreateRateLimitMiddleware({ now, getClientAddress: () => "203.0.113.7" })
+    );
+    app.post("/chat/completions", (c) => c.json({ ok: true }));
+    return app;
+}
+
+test("rate_limit=0 means unlimited", async () => {
+    const app = createTestApp({ id: "k1", rate_limit: 0 } as APIKeyZod);
+    for (let i = 0; i < 5; i++) {
+        const res = await app.request("/chat/completions", { method: "POST" });
+        assert.equal(res.status, 200);
+    }
+});
+
+test("requests beyond the per-minute limit get 429 with Retry-After", async () => {
+    const created = createAPIKeyDB({ name: "Rate Limit Test", rateLimit: 3 });
+    createdKeyIds.push(created.id);
+
+    const app = createTestApp({ id: created.id, rate_limit: 3 } as APIKeyZod);
+
+    for (let i = 0; i < 3; i++) {
+        const res = await app.request("/chat/completions", { method: "POST" });
+        assert.equal(res.status, 200, `request ${i + 1} should pass`);
+    }
+
+    const blocked = await app.request("/chat/completions", { method: "POST" });
+    assert.equal(blocked.status, 429);
+    assert.ok(blocked.headers.get("retry-after"));
+    const body = (await blocked.json()) as { error: { code: string; type: string } };
+    assert.equal(body.error.code, "rate_limit_exceeded");
+    assert.equal(body.error.type, "rate_limit_error");
+});
+
+test("window resets after the limit period", async () => {
+    let Current = 1_000_000;
+    const app = createTestApp({ id: "k2", rate_limit: 1 } as APIKeyZod, () => Current);
+
+    assert.equal((await app.request("/chat/completions", { method: "POST" })).status, 200);
+    assert.equal((await app.request("/chat/completions", { method: "POST" })).status, 429);
+
+    Current += 60_001;
+    assert.equal((await app.request("/chat/completions", { method: "POST" })).status, 200);
+});
+
+test("unauthenticated requests (no apiKeyRow) are not rate limited", async () => {
+    const app = createTestApp(undefined);
+    for (let i = 0; i < 5; i++) {
+        assert.equal((await app.request("/chat/completions", { method: "POST" })).status, 200);
+    }
+});

--- a/apps/api/tests/request-limits.test.ts
+++ b/apps/api/tests/request-limits.test.ts
@@ -128,3 +128,25 @@ test("SSRF: private, loopback, link-local, CGNAT, and multicast addresses are bl
         assert.equal(IsPrivateIpAddress(Address), false, `${Address} should be allowed`);
     }
 });
+
+test("messages route rejects chunked oversized bodies with 413 (no Content-Length trust)", async () => {
+    const { setRequireApiKeyDB } = await import("@srouter/db");
+    setRequireApiKeyDB(false);
+    const { MessagesRouter } = await import("../src/routes/v1/messages.js");
+    const app = new Hono();
+    app.route("/v1", MessagesRouter);
+
+    const Padding = "a".repeat(MAX_BODY_BYTES + 64);
+    const res = await app.request("/v1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            model: "claude-test",
+            max_tokens: 8,
+            messages: [{ role: "user", content: Padding }]
+        })
+    });
+    assert.equal(res.status, 413);
+    const payload = (await res.json()) as { error: { message: string } };
+    assert.match(payload.error.message, /too large/i);
+});

--- a/apps/api/tests/request-limits.test.ts
+++ b/apps/api/tests/request-limits.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Hono } from "hono";
+import { AnthropicMessageRequestSchema, ChatCompletionRequestSchema } from "@srouter/types";
+import { CreateBodyLimitMiddleware, MAX_BODY_BYTES } from "../src/middleware/BodyLimit.js";
+import { ValidateJson } from "../src/middleware/Validation.js";
+import { IsPrivateIpAddress } from "../src/utils/ssrf.js";
+
+function createTestApp() {
+    const app = new Hono();
+    app.use("/v1/*", CreateBodyLimitMiddleware());
+    app.post("/v1/chat/completions", ValidateJson(ChatCompletionRequestSchema), (c) =>
+        c.json({ ok: true })
+    );
+    return app;
+}
+
+test("body limit middleware rejects oversized Content-Length with 413", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Content-Length": String(MAX_BODY_BYTES + 1)
+        },
+        body: "{}"
+    });
+    assert.equal(res.status, 413);
+    const body = (await res.json()) as { error: { code: string } };
+    assert.equal(body.error.code, "request_too_large");
+});
+
+test("chat schema rejects oversized structural payloads", () => {
+    const base = { model: "gpt-test", messages: [{ role: "user" as const, content: "hi" }] };
+
+    assert.ok(
+        ChatCompletionRequestSchema.safeParse({ ...base, max_tokens: 999_999_999 }).success ===
+            false
+    );
+    assert.ok(ChatCompletionRequestSchema.safeParse({ ...base, n: 100 }).success === false);
+    assert.ok(
+        ChatCompletionRequestSchema.safeParse({
+            ...base,
+            messages: Array.from({ length: 1001 }, () => ({ role: "user", content: "x" }))
+        }).success === false
+    );
+    assert.ok(
+        ChatCompletionRequestSchema.safeParse({ ...base, model: "m".repeat(301) }).success === false
+    );
+    assert.ok(
+        ChatCompletionRequestSchema.safeParse({
+            ...base,
+            tools: Array.from({ length: 129 }, () => ({
+                type: "function",
+                function: { name: "t" }
+            }))
+        }).success === false
+    );
+    assert.ok(ChatCompletionRequestSchema.safeParse({ ...base, max_tokens: 4096 }).success);
+});
+
+test("anthropic schema keeps valid shapes and rejects runaway payloads", () => {
+    const valid = {
+        model: "claude-test",
+        max_tokens: 1024,
+        messages: [
+            { role: "user", content: "hi" },
+            {
+                role: "assistant",
+                content: [
+                    { type: "text", text: "sure" },
+                    { type: "tool_use", id: "tu_1", name: "search", input: { q: "x" } }
+                ]
+            },
+            {
+                role: "user",
+                content: [{ type: "tool_result", tool_use_id: "tu_1", content: "ok" }]
+            }
+        ],
+        system: "be nice",
+        tools: [{ name: "search", input_schema: { type: "object", properties: {} } }],
+        tool_choice: { type: "auto" },
+        thinking: { type: "enabled", budget_tokens: 512 }
+    };
+    assert.ok(AnthropicMessageRequestSchema.safeParse(valid).success);
+
+    assert.ok(
+        AnthropicMessageRequestSchema.safeParse({
+            ...valid,
+            messages: Array.from({ length: 1001 }, () => ({ role: "user", content: "x" }))
+        }).success === false
+    );
+    assert.ok(
+        AnthropicMessageRequestSchema.safeParse({ ...valid, max_tokens: 10_000_000 }).success ===
+            false
+    );
+    assert.ok(
+        AnthropicMessageRequestSchema.safeParse({
+            ...valid,
+            messages: [{ role: "hacker", content: "x" }]
+        }).success === false
+    );
+});
+
+test("SSRF: private, loopback, link-local, CGNAT, and multicast addresses are blocked", () => {
+    for (const Address of [
+        "127.0.0.1",
+        "127.9.9.9",
+        "10.1.2.3",
+        "172.16.0.1",
+        "172.31.255.255",
+        "192.168.1.1",
+        "169.254.169.254",
+        "100.64.0.1",
+        "0.0.0.0",
+        "224.0.0.1",
+        "::1",
+        "::",
+        "fe80::1",
+        "fc00::1",
+        "ff02::1",
+        "::ffff:127.0.0.1",
+        "not-an-ip"
+    ]) {
+        assert.equal(IsPrivateIpAddress(Address), true, `${Address} should be blocked`);
+    }
+    for (const Address of ["8.8.8.8", "1.1.1.1", "172.15.0.1", "100.128.0.1", "2606:4700:4700::1111"]) {
+        assert.equal(IsPrivateIpAddress(Address), false, `${Address} should be allowed`);
+    }
+});

--- a/apps/api/tests/tunnel-auth.test.ts
+++ b/apps/api/tests/tunnel-auth.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Hono } from "hono";
+import { adminAuthStore } from "@srouter/db";
+import { TunnelRouter } from "../src/routes/v1/tunnel.js";
+import {
+    ADMIN_SESSION_COOKIE,
+    createAdminSession,
+    revokeAdminSession
+} from "../src/services/adminAuth.js";
+
+function createTestApp() {
+    const app = new Hono();
+    // Same mount shape as index.ts: the guard must travel with the router.
+    app.route("/v1", TunnelRouter);
+    return app;
+}
+
+const TUNNEL_ROUTES: { method: string; path: string }[] = [
+    { method: "GET", path: "/v1/tunnel/status" },
+    { method: "GET", path: "/v1/tunnel/events" },
+    { method: "GET", path: "/v1/tunnel/install" },
+    { method: "POST", path: "/v1/tunnel/start" },
+    { method: "POST", path: "/v1/tunnel/stop" },
+    { method: "PUT", path: "/v1/tunnel/config" },
+    { method: "POST", path: "/v1/tunnel/install" }
+];
+
+test("every tunnel endpoint rejects anonymous requests with 401", async () => {
+    const app = createTestApp();
+
+    for (const { method, path } of TUNNEL_ROUTES) {
+        const res = await app.request(path, { method });
+        assert.equal(res.status, 401, `${method} ${path} should be 401, got ${res.status}`);
+        const body = (await res.json()) as { error: { code: string } };
+        assert.equal(body.error.code, "authentication_required", `${method} ${path}`);
+    }
+});
+
+test("tunnel endpoints reject API-key-only requests with 401", async () => {
+    const app = createTestApp();
+
+    const res = await app.request("/v1/tunnel/status", {
+        headers: { Authorization: "***" }
+    });
+    assert.equal(res.status, 401);
+});
+
+test("tunnel status is readable with a valid admin session", async () => {
+    const app = createTestApp();
+    const Token = createAdminSession(adminAuthStore);
+    try {
+        const res = await app.request("/v1/tunnel/status", {
+            headers: { Cookie: `${ADMIN_SESSION_COOKIE}=${Token}` }
+        });
+        assert.equal(res.status, 200);
+        const body = (await res.json()) as { ok: boolean; running: boolean };
+        assert.equal(typeof body.running, "boolean");
+    } finally {
+        revokeAdminSession(adminAuthStore, Token);
+    }
+});

--- a/packages/types/src/schemas/anthropic.ts
+++ b/packages/types/src/schemas/anthropic.ts
@@ -1,24 +1,84 @@
 import { z } from "zod";
+import type { AnthropicContentBlock } from "../anthropic.js";
+
+const AnthropicCacheControlSchema = z.object({ type: z.literal("ephemeral") });
+
+export const AnthropicContentBlockSchema: z.ZodType<AnthropicContentBlock> = z.object({
+    type: z.enum(["text", "image", "tool_use", "tool_result", "thinking", "redacted_thinking"]),
+    text: z.string().optional(),
+    thinking: z.string().optional(),
+    signature: z.string().optional(),
+    data: z.string().optional(),
+    source: z
+        .object({
+            type: z.literal("base64"),
+            media_type: z.string(),
+            data: z.string()
+        })
+        .optional(),
+    id: z.string().optional(),
+    name: z.string().optional(),
+    input: z.record(z.unknown()).optional(),
+    tool_use_id: z.string().optional(),
+    content: z.union([z.string(), z.lazy(() => z.array(AnthropicContentBlockSchema))]).optional(),
+    is_error: z.boolean().optional(),
+    cache_control: AnthropicCacheControlSchema.optional()
+});
+
+export const AnthropicMessageSchema = z.object({
+    role: z.enum(["user", "assistant"]),
+    content: z.union([z.string(), z.array(AnthropicContentBlockSchema).max(200)])
+});
+
+export const AnthropicToolSchema = z.object({
+    name: z.string().min(1).max(300),
+    description: z.string().max(10_000).optional(),
+    input_schema: z
+        .object({
+            type: z.string().optional(),
+            properties: z.record(z.unknown()).optional(),
+            required: z.array(z.string()).optional()
+        })
+        .passthrough(),
+    cache_control: AnthropicCacheControlSchema.optional()
+});
 
 export const AnthropicMessageRequestSchema = z.object({
     model: z
         .string({ required_error: "Missing required field 'model'" })
-        .min(1, "Missing required field 'model'"),
-    messages: z.array(z.any(), { required_error: "Missing required field 'messages'" }),
-    system: z.union([z.string(), z.array(z.any())]).optional(),
-    max_tokens: z.number().int().positive().optional(),
+        .min(1, "Missing required field 'model'")
+        .max(300),
+    messages: z
+        .array(AnthropicMessageSchema, { required_error: "Missing required field 'messages'" })
+        .min(1, "Parameter 'messages' cannot be empty")
+        .max(1000, "Parameter 'messages' exceeds the maximum of 1000 entries"),
+    system: z
+        .union([z.string(), z.array(AnthropicContentBlockSchema).max(200)])
+        .optional(),
+    max_tokens: z
+        .number()
+        .int()
+        .positive()
+        .max(1_000_000, "Parameter 'max_tokens' exceeds the gateway maximum")
+        .optional(),
     metadata: z.record(z.unknown()).optional(),
-    stop_sequences: z.array(z.string()).optional(),
+    stop_sequences: z.array(z.string().max(1000)).max(100).optional(),
     stream: z.boolean().optional(),
     temperature: z.number().min(0).max(1).optional(),
     top_p: z.number().min(0).max(1).optional(),
     top_k: z.number().int().positive().optional(),
-    tools: z.array(z.any()).optional(),
-    tool_choice: z.any().optional(),
+    tools: z.array(AnthropicToolSchema).max(128).optional(),
+    tool_choice: z
+        .object({
+            type: z.enum(["auto", "any", "tool"]),
+            name: z.string().optional(),
+            disable_parallel_tool_use: z.boolean().optional()
+        })
+        .optional(),
     thinking: z
         .object({
             type: z.enum(["enabled", "disabled"]),
-            budget_tokens: z.number().int().positive().optional()
+            budget_tokens: z.number().int().positive().max(1_000_000).optional()
         })
         .optional()
 });

--- a/packages/types/src/schemas/chat.ts
+++ b/packages/types/src/schemas/chat.ts
@@ -76,24 +76,33 @@ export const ToolChoiceSchema = z.union([
 ]);
 
 export const ChatCompletionRequestSchema = z.object({
-    model: z.string({
-        required_error: "Missing required parameter 'model'"
-    }),
+    model: z
+        .string({
+            required_error: "Missing required parameter 'model'"
+        })
+        .min(1)
+        .max(300),
     messages: z
         .array(ChatMessageSchema, {
             required_error: "Missing required parameter 'messages'"
         })
-        .min(1, "Parameter 'messages' cannot be empty"),
+        .min(1, "Parameter 'messages' cannot be empty")
+        .max(1000, "Parameter 'messages' exceeds the maximum of 1000 entries"),
     temperature: z.number().min(0).max(2).optional(),
     top_p: z.number().min(0).max(1).optional(),
-    n: z.number().int().positive().optional(),
+    n: z.number().int().positive().max(8).optional(),
     stream: z.boolean().optional(),
-    stop: z.union([z.string(), z.array(z.string())]).optional(),
-    max_tokens: z.number().int().positive().optional(),
+    stop: z.union([z.string(), z.array(z.string().max(1000)).max(16)]).optional(),
+    max_tokens: z
+        .number()
+        .int()
+        .positive()
+        .max(1_000_000, "Parameter 'max_tokens' exceeds the gateway maximum")
+        .optional(),
     presence_penalty: z.number().min(-2).max(2).optional(),
     frequency_penalty: z.number().min(-2).max(2).optional(),
-    user: z.string().optional(),
-    tools: z.array(ToolDefinitionSchema).optional(),
+    user: z.string().max(300).optional(),
+    tools: z.array(ToolDefinitionSchema).max(128).optional(),
     tool_choice: ToolChoiceSchema.optional(),
     response_format: z
         .object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  esbuild@>=0.27.3 <0.28.1: ^0.28.1
+
 importers:
 
   .:
@@ -703,12 +706,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -723,12 +720,6 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -751,12 +742,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.28.1':
     resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
@@ -771,12 +756,6 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -799,12 +778,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
@@ -819,12 +792,6 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -847,12 +814,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
@@ -867,12 +828,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -895,12 +850,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
@@ -915,12 +864,6 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -943,12 +886,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
@@ -963,12 +900,6 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -991,12 +922,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
@@ -1011,12 +936,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1039,12 +958,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
@@ -1059,12 +972,6 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1087,12 +994,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
@@ -1107,12 +1008,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1135,12 +1030,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -1155,12 +1044,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1183,12 +1066,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.28.1':
     resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
@@ -1203,12 +1080,6 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1231,12 +1102,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
@@ -1251,12 +1116,6 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1279,12 +1138,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
@@ -1299,12 +1152,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1913,7 +1760,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: '>=0.18'
+      esbuild: ^0.28.1
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2194,11 +2041,6 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3275,7 +3117,7 @@ packages:
       '@farmfe/core': '*'
       '@rspack/core': '*'
       bun-types-no-globals: '*'
-      esbuild: '*'
+      esbuild: ^0.28.1
       rolldown: '*'
       rollup: '*'
       unloader: '*'
@@ -3678,9 +3520,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -3688,9 +3527,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
@@ -3702,9 +3538,6 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
     optional: true
 
@@ -3712,9 +3545,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
@@ -3726,9 +3556,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
@@ -3736,9 +3563,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
@@ -3750,9 +3574,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
@@ -3760,9 +3581,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -3774,9 +3592,6 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
@@ -3784,9 +3599,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
@@ -3798,9 +3610,6 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
@@ -3808,9 +3617,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
@@ -3822,9 +3628,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
@@ -3832,9 +3635,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -3846,9 +3646,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
@@ -3856,9 +3653,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
@@ -3870,9 +3664,6 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
@@ -3880,9 +3671,6 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
@@ -3894,9 +3682,6 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
@@ -3904,9 +3689,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
@@ -3918,9 +3700,6 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
@@ -3928,9 +3707,6 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
@@ -3942,9 +3718,6 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
@@ -3952,9 +3725,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
@@ -3966,9 +3736,6 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
@@ -3976,9 +3743,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -4534,9 +4298,9 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
-  bundle-require@5.1.0(esbuild@0.27.7):
+  bundle-require@5.1.0(esbuild@0.28.2):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.2
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -4783,35 +4547,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -5818,12 +5553,12 @@ snapshots:
 
   tsup@8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(typescript@5.9.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.7)
+      bundle-require: 5.1.0(esbuild@0.28.2)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.7
+      esbuild: 0.28.2
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ packages:
     - "apps/*"
     - "packages/*"
 
+overrides:
+    "esbuild@>=0.27.3 <0.28.1": "^0.28.1"
+
 allowBuilds:
     esbuild: true
 


### PR DESCRIPTION
Closes the tunnel-auth regression and tightens the browser trust boundary, request limits, and dependency posture from the security review.

## Changes

### P0 — Tunnel authorization (57f32ba)
`RequireAdmin` was mounted after `app.route("/v1", TunnelRouter)`, so Hono never applied it to already-matched tunnel routes: every tunnel endpoint (`start`, `stop`, `config`, `install`, `status`, `events`) was callable anonymously, including subprocess spawn and installer triggers. The guard now travels inside `TunnelRouter` (`use("*", RequireAdmin)`); post-mount duplicates removed. The dashboard is unaffected — `EventSource` and `fetch(credentials: "include")` send the admin session cookie automatically.

### P1 — CORS, CSRF, body limits (1ef59e5)
- CORS no longer reflects arbitrary public origins with credentials. Loopback origins always pass; public origins require `SROUTER_CORS_ORIGINS` (comma-separated allowlist).
- Cookie-authenticated mutations on `/v1` verify `Origin`/`Referer`: same-origin passes, cross-origin must be allowlisted. API-key traffic without a session cookie is untouched.
- Request bodies capped at 25 MB: `Content-Length` pre-check middleware plus a raw-text check in `ValidateJson` (chunked requests) → `413 request_too_large`.

### P1 — Rate limiting (b66c023)
`rate_limit` on virtual API keys was stored but never enforced. Fixed-window limiter (requests per minute, `0` = unlimited) keyed by `api_key_id` + client address, mounted after `ApiKeyAuth` and before validation/upstream on `/chat/completions`, `/chat/completion`, and `/messages`. `429` responses carry `Retry-After`. In-process memory store — single-instance deployments only; multi-instance would need shared storage.

### P1 — Structural limits and SSE cap (186b40f, 1ac8cad)
- Chat and Anthropic request schemas: messages ≤ 1000, tools ≤ 128, `max_tokens`/`budget_tokens` ≤ 1,000,000, model ≤ 300 chars, bounded stop sequences.
- `AnthropicMessageRequestSchema` replaces all `z.any()` fields with real Zod schemas mirroring the wire types (`AnthropicContentBlock`, `AnthropicTool`, `tool_choice`).
- `/v1/tunnel/events` capped at 8 concurrent streams (`429 too_many_streams`); listener/heartbeat cleanup centralized so the counter cannot leak.

### P2 — SSRF and dependencies (186b40f, 0cf7f62)
- Provider connection verification resolves DNS and rejects any private/loopback/link-local/CGNAT/multicast/cloud-metadata target (previously string-matched hostnames only), and fetches with `redirect: "manual"` so 3xx responses are refused instead of followed.
- esbuild overridden to `>=0.28.1` (GHSA-g7r4-m6w7-qqqr, low, dev-only via tsup) using a scoped pnpm workspace override; `pnpm audit` is clean.

## Verification
- `pnpm run build` (apps/api) passes.
- Full `apps/api` suite: 131/131 tests, including 22 new regression tests (tunnel auth matrix, CORS allowlist, CSRF guard, rate-limit burst/reset, payload shapes, SSRF classifier, body limit).
- Live smoke against a local instance: anonymous tunnel calls return `401` with no subprocess, foreign-origin preflight receives no `Access-Control-Allow-Origin`, loopback CORS works, `/health` returns `200`.

## Operational notes
- Set `SROUTER_CORS_ORIGINS` for any non-loopback dashboard origin.
- `SROUTER_SECURE_COOKIES=true` remains required on HTTPS deployments.
