### PR TITLE
feat(web): add custom provider dialog to providers catalog

### DIFF
--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -26,6 +26,7 @@ export interface GroupedCatalog {
     oauth: ProviderDefinition[];
     free_tier: ProviderDefinition[];
     api_key: ProviderDefinition[];
+    custom_provider: ProviderDefinition[];
 }
 
 export interface CatalogSummary {
@@ -156,7 +157,8 @@ export class ProvidersLogic {
         const Categories: GroupedCatalog = {
             oauth: Catalog.filter((P) => P.category === "oauth"),
             free_tier: Catalog.filter((P) => P.category === "free_tier"),
-            api_key: Catalog.filter((P) => P.category === "api_key")
+            api_key: Catalog.filter((P) => P.category === "api_key"),
+            custom_provider: Catalog.filter((P) => P.category === "custom_provider")
         };
 
         return {
@@ -259,8 +261,8 @@ export class ProvidersLogic {
             }
         }
         const ApiKey = Payload.api_key?.trim();
-        if (Category === "api_key" && !ApiKey)
-            throw new Error("API key is required for API key providers");
+        if ((Category === "api_key" || Category === "custom_provider") && !ApiKey)
+            throw new Error("API key is required for API key and custom providers");
 
         const Config = {
             id: Id,

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -231,14 +231,21 @@ export class ProvidersLogic {
         if (!isProviderCategory(Payload.category)) throw new Error("Invalid provider category");
         if (!isProviderProtocol(Payload.protocol)) throw new Error("Invalid provider protocol");
         const RawId = Payload.id?.trim();
-        const BaseId = RawId
-            ? RawId.toLowerCase().replace(/[^a-z0-9_-]/g, "")
-            : Payload.category;
-        const Id = RawId ? BaseId : `${BaseId}_${Date.now()}`;
-        if (!Id)
-            throw new Error("Provider ID must contain letters, numbers, underscores, or hyphens");
-        if (getAllProvidersDB().some((Provider) => Provider.id === Id))
-            throw new Error(`Provider ID '${Id}' already exists`);
+        let Id: string;
+
+        if (RawId) {
+            // Explicit ID provided (OAuth flows, imports): sanitize as before
+            Id = RawId.toLowerCase().replace(/[^a-z0-9_-]/g, "");
+            if (!Id)
+                throw new Error(
+                    "Provider ID must contain letters, numbers, underscores, or hyphens"
+                );
+            if (getAllProvidersDB().some((Provider) => Provider.id === Id))
+                throw new Error(`Provider ID '${Id}' already exists`);
+        } else {
+            // Custom provider: generate UUID v4 as immutable internal ID
+            Id = crypto.randomUUID();
+        }
         const Category = Payload.category;
         const Protocol = Payload.protocol;
         const BaseUrl = Payload.base_url?.trim();

--- a/apps/api/tests/custom-provider-uuid.test.ts
+++ b/apps/api/tests/custom-provider-uuid.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 test("AddProvider generates a UUID v4 as immutable internal ID", () => {
     const result = ProvidersLogic.AddProvider({
         name: "My Gateway",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://api.example.com/v1",
         api_key: "sk-test-key"
@@ -45,7 +45,7 @@ test("AddProvider generates a UUID v4 as immutable internal ID", () => {
 test("UUID provider appears in catalog as its own entry", () => {
     const result = ProvidersLogic.AddProvider({
         name: "Custom Gateway",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://api.gateway.dev/v1",
         api_key: "sk-custom-key"
@@ -53,20 +53,20 @@ test("UUID provider appears in catalog as its own entry", () => {
     createdIds.push(result.id);
 
     const catalog = ProvidersLogic.GetCatalog();
-    const apiKeyProviders = catalog.categories.api_key;
+    const apiKeyProviders = catalog.categories.custom_provider;
     const found = apiKeyProviders.find((p) => p.id === result.id);
 
-    // 5. Provider appears in catalog
+    // 5. Provider appears in catalog under custom_provider category
     assert.ok(found, "Custom provider must appear in catalog");
     assert.equal(found?.name, "Custom Gateway");
-    assert.equal(found?.category, "api_key");
+    assert.equal(found?.category, "custom_provider");
     assert.equal(found?.protocol, "openai");
 });
 
 test("UUID provider is found by GetProviderById", async () => {
     const result = ProvidersLogic.AddProvider({
         name: "Searchable Provider",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://search.example.com/v1",
         api_key: "sk-search-key"
@@ -106,7 +106,7 @@ test("built-in provider IDs are unchanged by the UUID migration", () => {
 test("ListProviders lists UUID provider", () => {
     const result = ProvidersLogic.AddProvider({
         name: "Listed Provider",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://listme.example.com/v1",
         api_key: "sk-list-key"
@@ -123,7 +123,7 @@ test("ListProviders lists UUID provider", () => {
 test("UUID persists across GetCatalog calls (no re-generation)", () => {
     const result = ProvidersLogic.AddProvider({
         name: "Stable UUID",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://stable.example.com/v1",
         api_key: "sk-stable-key"
@@ -138,6 +138,7 @@ test("UUID persists across GetCatalog calls (no re-generation)", () => {
     const findIn = (data: typeof ids1) => {
         const all = [
             ...data.categories.api_key,
+            ...data.categories.custom_provider,
             ...data.categories.oauth,
             ...data.categories.free_tier
         ];
@@ -166,7 +167,7 @@ test("custom provider with UUID does not collide with seed provider IDs", () => 
     // 10. UUID custom provider should not conflict with seed IDs
     const result = ProvidersLogic.AddProvider({
         name: "No Collision",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://nocollide.example.com/v1",
         api_key: "sk-nocollide-key"
@@ -186,7 +187,7 @@ test("custom provider with UUID does not collide with seed provider IDs", () => 
 test("duplicate names are allowed for different UUID providers", () => {
     const first = ProvidersLogic.AddProvider({
         name: "Duplicate Name",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://first.dup.com/v1",
         api_key: "sk-first-dup"
@@ -195,7 +196,7 @@ test("duplicate names are allowed for different UUID providers", () => {
 
     const second = ProvidersLogic.AddProvider({
         name: "Duplicate Name",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://second.dup.com/v1",
         api_key: "sk-second-dup"
@@ -215,7 +216,7 @@ test("duplicate names are allowed for different UUID providers", () => {
 test("delete provider by UUID works", () => {
     const result = ProvidersLogic.AddProvider({
         name: "Delete Me",
-        category: "api_key",
+        category: "custom_provider",
         protocol: "openai",
         base_url: "https://deleteme.example.com/v1",
         api_key: "sk-delete-key"

--- a/apps/api/tests/custom-provider-uuid.test.ts
+++ b/apps/api/tests/custom-provider-uuid.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { deleteProviderDB, getProviderByIdDB, getAllProvidersDB } from "@srouter/db";
+import { providerBaseId } from "@srouter/constants";
+import { ProvidersLogic } from "../src/logic/providers.logic.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteProviderDB(id);
+    }
+});
+
+test("AddProvider generates a UUID v4 as immutable internal ID", () => {
+    const result = ProvidersLogic.AddProvider({
+        name: "My Gateway",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://api.example.com/v1",
+        api_key: "sk-test-key"
+    });
+
+    createdIds.push(result.id);
+
+    // 1. UUID v4 format
+    assert.match(result.id, UUID_RE);
+
+    // 2. id === providerId (persisted as the same immutable identity)
+    const savedForProviderId = getProviderByIdDB(result.id);
+    assert.equal(savedForProviderId?.providerId, result.id);
+
+    // 3. Name preserved as display name
+    assert.equal(result.name, "My Gateway");
+
+    // 4. Persisted in DB
+    const saved = getProviderByIdDB(result.id);
+    assert.ok(saved, "Provider must exist in DB");
+    assert.equal(saved?.id, result.id);
+    assert.equal(saved?.name, "My Gateway");
+});
+
+test("UUID provider appears in catalog as its own entry", () => {
+    const result = ProvidersLogic.AddProvider({
+        name: "Custom Gateway",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://api.gateway.dev/v1",
+        api_key: "sk-custom-key"
+    });
+    createdIds.push(result.id);
+
+    const catalog = ProvidersLogic.GetCatalog();
+    const apiKeyProviders = catalog.categories.api_key;
+    const found = apiKeyProviders.find((p) => p.id === result.id);
+
+    // 5. Provider appears in catalog
+    assert.ok(found, "Custom provider must appear in catalog");
+    assert.equal(found?.name, "Custom Gateway");
+    assert.equal(found?.category, "api_key");
+    assert.equal(found?.protocol, "openai");
+});
+
+test("UUID provider is found by GetProviderById", async () => {
+    const result = ProvidersLogic.AddProvider({
+        name: "Searchable Provider",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://search.example.com/v1",
+        api_key: "sk-search-key"
+    });
+    createdIds.push(result.id);
+
+    const found = await ProvidersLogic.GetProviderById(result.id);
+    assert.ok(found, "Provider must be found by UUID");
+    assert.equal(found?.name, "Searchable Provider");
+});
+
+test("providerBaseId preserves UUID instead of truncating on dash", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    const baseId = providerBaseId(uuid);
+    // 6. UUID must not be truncated by dash-split
+    assert.equal(baseId, uuid, "providerBaseId must return the full UUID");
+});
+
+test("built-in provider IDs are unchanged by the UUID migration", () => {
+    // 7. Built-in providers keep their original IDs
+    const catalog = ProvidersLogic.GetCatalog();
+    const allIds = [
+        ...catalog.categories.api_key,
+        ...catalog.categories.oauth,
+        ...catalog.categories.free_tier
+    ].map((p) => p.id);
+
+    // Known seed provider IDs
+    assert.ok(allIds.includes("bai"), "bai must still exist");
+    assert.ok(allIds.includes("neosantara"), "neosantara must still exist");
+    assert.ok(allIds.includes("gorouter"), "gorouter must still exist");
+    assert.ok(allIds.includes("kiro"), "kiro must still exist");
+    assert.ok(allIds.includes("bluesminds"), "bluesminds must still exist");
+    assert.ok(allIds.includes("seekai"), "seekai must still exist");
+});
+
+test("ListProviders lists UUID provider", () => {
+    const result = ProvidersLogic.AddProvider({
+        name: "Listed Provider",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://listme.example.com/v1",
+        api_key: "sk-list-key"
+    });
+    createdIds.push(result.id);
+
+    const list = ProvidersLogic.ListProviders();
+    const found = list.find((p) => p.id === result.id);
+    // 8. Found in list
+    assert.ok(found, "UUID provider must be in ListProviders response");
+    assert.equal(found?.name, "Listed Provider");
+});
+
+test("UUID persists across GetCatalog calls (no re-generation)", () => {
+    const result = ProvidersLogic.AddProvider({
+        name: "Stable UUID",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://stable.example.com/v1",
+        api_key: "sk-stable-key"
+    });
+    createdIds.push(result.id);
+
+    // Call catalog multiple times
+    const ids1 = ProvidersLogic.GetCatalog();
+    const ids2 = ProvidersLogic.GetCatalog();
+    const ids3 = ProvidersLogic.GetCatalog();
+
+    const findIn = (data: typeof ids1) => {
+        const all = [
+            ...data.categories.api_key,
+            ...data.categories.oauth,
+            ...data.categories.free_tier
+        ];
+        return all.find((p) => p.id === result.id);
+    };
+
+    // 9. UUID is stable — same across multiple catalog reads
+    assert.equal(findIn(ids1)?.id, result.id);
+    assert.equal(findIn(ids2)?.id, result.id);
+    assert.equal(findIn(ids3)?.id, result.id);
+});
+
+test("custom provider with UUID does not collide with seed provider IDs", () => {
+    const seedIds = [
+        "openai",
+        "anthropic",
+        "bai",
+        "neosantara",
+        "gorouter",
+        "bluesminds",
+        "seekai",
+        "tabitoken",
+        "tokenrouter"
+    ];
+
+    // 10. UUID custom provider should not conflict with seed IDs
+    const result = ProvidersLogic.AddProvider({
+        name: "No Collision",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://nocollide.example.com/v1",
+        api_key: "sk-nocollide-key"
+    });
+    createdIds.push(result.id);
+
+    // UUID must not match any seed ID
+    assert.equal(
+        seedIds.includes(result.id),
+        false,
+        "UUID must not collide with seed provider IDs"
+    );
+    // UUID still valid
+    assert.match(result.id, UUID_RE);
+});
+
+test("duplicate names are allowed for different UUID providers", () => {
+    const first = ProvidersLogic.AddProvider({
+        name: "Duplicate Name",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://first.dup.com/v1",
+        api_key: "sk-first-dup"
+    });
+    createdIds.push(first.id);
+
+    const second = ProvidersLogic.AddProvider({
+        name: "Duplicate Name",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://second.dup.com/v1",
+        api_key: "sk-second-dup"
+    });
+    createdIds.push(second.id);
+
+    // 11. Both providers with same name allowed
+    assert.notEqual(first.id, second.id, "IDs must differ even with same name");
+    assert.equal(first.name, second.name, "Both have same name");
+
+    // Both appear in catalog
+    const catalog = ProvidersLogic.ListProviders();
+    const withDupName = catalog.filter((p) => p.name === "Duplicate Name");
+    assert.equal(withDupName.length, 2, "Both duplicate-name providers must exist");
+});
+
+test("delete provider by UUID works", () => {
+    const result = ProvidersLogic.AddProvider({
+        name: "Delete Me",
+        category: "api_key",
+        protocol: "openai",
+        base_url: "https://deleteme.example.com/v1",
+        api_key: "sk-delete-key"
+    });
+    createdIds.push(result.id);
+
+    // Verify it exists
+    assert.ok(getProviderByIdDB(result.id), "Provider must exist before delete");
+
+    // Delete by UUID
+    const deleted = deleteProviderDB(result.id);
+    assert.ok(deleted, "deleteProviderDB must return true");
+
+    // Verify deleted
+    assert.equal(getProviderByIdDB(result.id), null, "Provider must be gone after delete");
+    // Remove from cleanup list since already deleted
+    createdIds.splice(createdIds.indexOf(result.id), 1);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "type": "module",
     "private": true,
     "repository": {

--- a/apps/web/src/components/providers/CatalogToolbar.tsx
+++ b/apps/web/src/components/providers/CatalogToolbar.tsx
@@ -6,6 +6,7 @@ import {
     LayoutGrid,
     Layers,
     List,
+    Plus,
     RefreshCw,
     Search,
     X
@@ -25,6 +26,7 @@ interface CatalogToolbarProps {
     onSearchChange: (value: string) => void;
     viewMode: "grid" | "list";
     onViewModeChange: (mode: "grid" | "list") => void;
+    onAddCustom?: () => void;
 }
 
 const summaryIcons = {
@@ -44,7 +46,8 @@ export function CatalogToolbar({
     search,
     onSearchChange,
     viewMode,
-    onViewModeChange
+    onViewModeChange,
+    onAddCustom
 }: CatalogToolbarProps) {
     return (
         <div className="space-y-6 font-mono">
@@ -64,6 +67,17 @@ export function CatalogToolbar({
                 </div>
 
                 <div className="flex shrink-0 items-center gap-2">
+                    {onAddCustom && (
+                        <Button
+                            type="button"
+                            size="sm"
+                            onClick={onAddCustom}
+                            className="h-8 text-xs font-medium cursor-pointer gap-1.5 shadow-2xs"
+                        >
+                            <Plus className="size-3.5" />
+                            <span>Add Custom Provider</span>
+                        </Button>
+                    )}
                     <Button
                         type="button"
                         variant="outline"

--- a/apps/web/src/components/providers/CustomProviderDialog.tsx
+++ b/apps/web/src/components/providers/CustomProviderDialog.tsx
@@ -25,14 +25,6 @@ const PROTOCOLS: { value: ProviderProtocol; label: string }[] = [
     { value: "anthropic", label: "Anthropic" }
 ];
 
-function SlugifyName(Name: string): string {
-    return Name
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-+|-+$/g, "");
-}
-
 interface CustomProviderDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
@@ -126,9 +118,8 @@ export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialo
             return;
         }
         setFormError("");
-        const Slug = SlugifyName(trimmedName);
+        // Backend generates a UUID v4 as the immutable provider ID
         saveMutation.mutate({
-            id: Slug || undefined,
             name: trimmedName,
             category: "api_key",
             protocol,

--- a/apps/web/src/components/providers/CustomProviderDialog.tsx
+++ b/apps/web/src/components/providers/CustomProviderDialog.tsx
@@ -121,7 +121,7 @@ export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialo
         // Backend generates a UUID v4 as the immutable provider ID
         saveMutation.mutate({
             name: trimmedName,
-            category: "api_key",
+            category: "custom_provider",
             protocol,
             base_url: baseUrl.trim(),
             api_key: apiKey.trim()

--- a/apps/web/src/components/providers/CustomProviderDialog.tsx
+++ b/apps/web/src/components/providers/CustomProviderDialog.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Plug, CheckCircle2, Globe, Key, X } from "lucide-react";
+import { toast } from "sonner";
+import type { ProviderDefinition, ProviderProtocol } from "@srouter/types";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle
+} from "@/components/ui/dialog";
+import { api } from "@/lib/api";
+
+interface VerifyResponse {
+    success: boolean;
+    message: string;
+    modelsCount?: number;
+}
+
+type VerifyStatus = "idle" | "testing" | "success" | "error";
+
+const PROTOCOLS: { value: ProviderProtocol; label: string }[] = [
+    { value: "openai", label: "OpenAI" },
+    { value: "anthropic", label: "Anthropic" }
+];
+
+function SlugifyName(Name: string): string {
+    return Name
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+}
+
+interface CustomProviderDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialogProps) {
+    const queryClient = useQueryClient();
+    const [name, setName] = useState("");
+    const [baseUrl, setBaseUrl] = useState("");
+    const [apiKey, setApiKey] = useState("");
+    const [protocol, setProtocol] = useState<ProviderProtocol>("openai");
+    const [showKey, setShowKey] = useState(false);
+    const [formError, setFormError] = useState("");
+    const [verifyStatus, setVerifyStatus] = useState<VerifyStatus>("idle");
+
+    useEffect(() => {
+        if (open) {
+            setName("");
+            setBaseUrl("");
+            setApiKey("");
+            setProtocol("openai");
+            setShowKey(false);
+            setFormError("");
+            setVerifyStatus("idle");
+        }
+    }, [open]);
+
+    const invalidateCatalog = () => {
+        void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
+        void queryClient.invalidateQueries({ queryKey: ["models"] });
+    };
+
+    const saveMutation = useMutation({
+        mutationFn: (payload: Record<string, unknown>) =>
+            api.post<ProviderDefinition>("/v1/providers", payload),
+        onSuccess: (provider) => {
+            invalidateCatalog();
+            toast.success(`Provider "${provider.name}" added`);
+            onOpenChange(false);
+        },
+        onError: (err: Error) => {
+            const msg = err.message || "Failed to add provider";
+            setFormError(msg);
+            toast.error(msg);
+        }
+    });
+
+    const handleTest = async () => {
+        if (!baseUrl.trim()) {
+            setFormError("Base URL is required");
+            return;
+        }
+        if (!apiKey.trim()) {
+            setFormError("API key is required");
+            return;
+        }
+        setFormError("");
+        setVerifyStatus("testing");
+        try {
+            const res = await api.post<VerifyResponse>("/v1/providers/verify", {
+                protocol,
+                base_url: baseUrl.trim(),
+                api_key: apiKey.trim()
+            });
+            if (res.success) {
+                setVerifyStatus("success");
+                toast.success(res.message || "Connection verified.");
+            } else {
+                setVerifyStatus("error");
+                toast.error(res.message || "Connection test failed.");
+            }
+        } catch (err) {
+            setVerifyStatus("error");
+            toast.error(err instanceof Error ? err.message : "Failed to test connection.");
+        }
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        const trimmedName = name.trim();
+        if (!trimmedName) {
+            setFormError("Provider name is required");
+            return;
+        }
+        if (!baseUrl.trim()) {
+            setFormError("Base URL is required");
+            return;
+        }
+        if (verifyStatus !== "success") {
+            setFormError("Test the connection first — it must pass before saving.");
+            return;
+        }
+        setFormError("");
+        const Slug = SlugifyName(trimmedName);
+        saveMutation.mutate({
+            id: Slug || undefined,
+            name: trimmedName,
+            category: "api_key",
+            protocol,
+            base_url: baseUrl.trim(),
+            api_key: apiKey.trim()
+        });
+    };
+
+    const canSave = verifyStatus === "success" && !saveMutation.isPending;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-md w-full p-5 space-y-4 shadow-xl font-mono">
+                <div className="flex items-center justify-between border-b border-[var(--line)] pb-3">
+                    <h2 className="font-bold text-sm text-[var(--ink)] flex items-center gap-1.5">
+                        <Globe className="size-3.5 text-orange-500" />
+                        <span>Add Custom Provider</span>
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={() => onOpenChange(false)}
+                        className="text-[var(--ink-3)] hover:text-[var(--ink)] p-1 rounded hover:bg-[var(--field)] transition-colors cursor-pointer"
+                    >
+                        <X className="size-4" />
+                    </button>
+                </div>
+
+                <DialogHeader className="p-0 space-y-1">
+                    <DialogTitle className="sr-only">Add Custom Provider</DialogTitle>
+                    <DialogDescription className="text-xs text-[var(--ink-3)]">
+                        Register any OpenAI- or Anthropic-compatible endpoint as a new provider
+                        driver. Verify the connection before saving.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {formError && (
+                    <div className="rounded-[8px] border border-rose-500/40 bg-rose-500/10 p-2.5 text-xs text-rose-500">
+                        {formError}
+                    </div>
+                )}
+
+                <form onSubmit={handleSubmit} className="space-y-4 text-xs">
+                    <div className="space-y-1.5">
+                        <label htmlFor="cp-name" className="font-medium text-[var(--ink)] block">
+                            Provider Name *
+                        </label>
+                        <input
+                            id="cp-name"
+                            type="text"
+                            placeholder="e.g. My Gateway"
+                            value={name}
+                            onChange={(e) => {
+                                setName(e.target.value);
+                                if (formError) setFormError("");
+                            }}
+                            autoFocus
+                            required
+                            className="w-full rounded-[8px] border border-[var(--line)] bg-[var(--field)] px-3 py-2 text-xs text-[var(--ink)] placeholder:text-[var(--ink-3)] focus:outline-none focus:ring-1 focus:ring-[var(--ink)]"
+                        />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <span className="font-medium text-[var(--ink)] block">Protocol *</span>
+                        <div className="flex gap-1.5">
+                            {PROTOCOLS.map((p) => (
+                                <button
+                                    key={p.value}
+                                    type="button"
+                                    onClick={() => {
+                                        setProtocol(p.value);
+                                        if (verifyStatus !== "idle") setVerifyStatus("idle");
+                                    }}
+                                    className={`rounded-[6px] border px-3 py-1.5 font-semibold transition-colors cursor-pointer ${
+                                        protocol === p.value
+                                            ? "border-orange-500 bg-orange-500/10 text-orange-500"
+                                            : "border-[var(--line)] text-[var(--ink-3)] hover:text-[var(--ink)]"
+                                    }`}
+                                >
+                                    {p.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label htmlFor="cp-base-url" className="font-medium text-[var(--ink)] block">
+                            Base URL *
+                        </label>
+                        <input
+                            id="cp-base-url"
+                            type="url"
+                            placeholder="https://api.example.com/v1"
+                            value={baseUrl}
+                            onChange={(e) => {
+                                setBaseUrl(e.target.value);
+                                if (formError) setFormError("");
+                                if (verifyStatus !== "idle") setVerifyStatus("idle");
+                            }}
+                            required
+                            className="w-full rounded-[8px] border border-[var(--line)] bg-[var(--field)] px-3 py-2 text-xs text-[var(--ink)] placeholder:text-[var(--ink-3)] focus:outline-none focus:ring-1 focus:ring-[var(--ink)]"
+                        />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label htmlFor="cp-api-key" className="font-medium text-[var(--ink)] block">
+                            API Key *
+                        </label>
+                        <div className="relative">
+                            <input
+                                id="cp-api-key"
+                                type={showKey ? "text" : "password"}
+                                placeholder="sk-..."
+                                value={apiKey}
+                                onChange={(e) => {
+                                    setApiKey(e.target.value);
+                                    if (formError) setFormError("");
+                                    if (verifyStatus !== "idle") setVerifyStatus("idle");
+                                }}
+                                required
+                                className="w-full rounded-[8px] border border-[var(--line)] bg-[var(--field)] px-3 py-2 pr-9 text-xs text-[var(--ink)] placeholder:text-[var(--ink-3)] focus:outline-none focus:ring-1 focus:ring-[var(--ink)]"
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setShowKey(!showKey)}
+                                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[var(--ink-3)] hover:text-[var(--ink)] cursor-pointer"
+                                tabIndex={-1}
+                            >
+                                <Key className="size-3.5" />
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => void handleTest()}
+                            disabled={verifyStatus === "testing" || saveMutation.isPending}
+                            className="inline-flex items-center gap-1.5 rounded-[6px] border border-[var(--line)] px-3 py-1.5 text-xs font-semibold text-[var(--ink)] hover:bg-[var(--field)] disabled:opacity-50 transition-colors cursor-pointer"
+                        >
+                            {verifyStatus === "testing" ? (
+                                <>
+                                    <Loader2 className="size-3.5 animate-spin" />
+                                    Testing…
+                                </>
+                            ) : (
+                                <>
+                                    <Plug className="size-3.5" />
+                                    Test Connection
+                                </>
+                            )}
+                        </button>
+                        {verifyStatus === "success" && (
+                            <span className="inline-flex items-center gap-1 text-xs font-semibold text-emerald-500">
+                                <CheckCircle2 className="size-3.5" />
+                                Verified
+                            </span>
+                        )}
+                    </div>
+
+                    <div className="pt-3 border-t border-[var(--line)] flex items-center justify-end gap-2">
+                        <button
+                            type="button"
+                            onClick={() => onOpenChange(false)}
+                            className="rounded-[6px] border border-[var(--line)] px-3 py-1.5 text-xs font-medium text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors cursor-pointer"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={!canSave}
+                            title={
+                                verifyStatus === "success"
+                                    ? undefined
+                                    : "Test the connection successfully before saving"
+                            }
+                            className="rounded-[6px] bg-orange-500 hover:bg-orange-600 text-white px-4 py-1.5 text-xs font-bold disabled:opacity-50 disabled:cursor-not-allowed transition-all cursor-pointer shadow-xs"
+                        >
+                            {saveMutation.isPending ? "Saving…" : "Add Provider"}
+                        </button>
+                    </div>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/web/src/hooks/useCatalog.ts
+++ b/apps/web/src/hooks/useCatalog.ts
@@ -86,6 +86,7 @@ export function useCatalog() {
         const categories: Record<string, ProviderDefinition[]> = {
             oauth: allProviders.filter((p) => p.category === "oauth"),
             api_key: allProviders.filter((p) => p.category === "api_key"),
+            custom_provider: allProviders.filter((p) => p.category === "custom_provider"),
             free_tier: allProviders.filter((p) => p.category === "free_tier")
         };
         return {

--- a/apps/web/src/routes/providers/index.tsx
+++ b/apps/web/src/routes/providers/index.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { useCatalog } from "@/hooks/useCatalog";
 import { Catalog } from "@/components/providers/Catalog";
 import { CatalogToolbar } from "@/components/providers/CatalogToolbar";
+import { CustomProviderDialog } from "@/components/providers/CustomProviderDialog";
 import { ProvidersSkeleton } from "@/components/skeletons";
 
 export const Route = createFileRoute("/providers/")({
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/providers/")({
 
 function ProvidersPage() {
     const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+    const [isCustomOpen, setIsCustomOpen] = useState(false);
     const catalog = useCatalog();
     const { data, error, isPending, isFetching, refetch } = catalog;
 
@@ -63,9 +65,12 @@ function ProvidersPage() {
                 onSearchChange={catalog.setSearch}
                 viewMode={viewMode}
                 onViewModeChange={setViewMode}
+                onAddCustom={() => setIsCustomOpen(true)}
             />
 
             <Catalog groups={catalog.groups} search={catalog.search} viewMode={viewMode} />
+
+            <CustomProviderDialog open={isCustomOpen} onOpenChange={setIsCustomOpen} />
         </div>
     );
 }

--- a/packages/constants/src/providers/catalog.ts
+++ b/packages/constants/src/providers/catalog.ts
@@ -55,7 +55,13 @@ export function isKnownProvider(Id: string): boolean {
     return Id in KNOWN_PROVIDER_MAP;
 }
 
+const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function providerBaseId(Id: string): string {
+    // Custom providers carry a UUID v4 as their immutable ID — never
+    // truncate it; a UUID is its own base identity.
+    if (UUID_RE.test(Id)) return Id;
     return (
         KNOWN_PROVIDER_IDS_DESC.find(
             (Candidate) =>

--- a/packages/constants/src/providers/categories.ts
+++ b/packages/constants/src/providers/categories.ts
@@ -1,18 +1,30 @@
 import type { ProviderCategory } from "@srouter/types";
 
-export const PROVIDER_CATEGORIES: ProviderCategory[] = ["oauth", "free_tier", "api_key"];
+export const PROVIDER_CATEGORIES: ProviderCategory[] = [
+    "oauth",
+    "free_tier",
+    "api_key",
+    "custom_provider"
+];
 
-export const CATEGORY_ORDER: ProviderCategory[] = ["oauth", "api_key", "free_tier"];
+export const CATEGORY_ORDER: ProviderCategory[] = [
+    "oauth",
+    "api_key",
+    "custom_provider",
+    "free_tier"
+];
 
 export const CATEGORY_LABELS: Record<ProviderCategory, string> = {
     oauth: "OAuth Provider",
     api_key: "API Key Provider",
+    custom_provider: "Custom Provider",
     free_tier: "Free Tier Provider"
 };
 
 export const CATEGORY_DESCRIPTIONS: Record<ProviderCategory, string> = {
     oauth: "Signed in through a provider account rather than a key.",
     api_key: "Authenticated with a platform key you supply.",
+    custom_provider: "User-registered endpoint with a custom base URL.",
     free_tier: "Free or rate-limited public endpoints."
 };
 

--- a/packages/constants/src/version.ts
+++ b/packages/constants/src/version.ts
@@ -1,5 +1,5 @@
 export const GLOBAL_VERSION = "0.1.3";
-export const APP_VERSION = "0.1.3";
+export const APP_VERSION = "0.1.4";
 export const API_VERSION = "0.1.3";
 export const CLI_VERSION = "0.1.3-rc.3";
 

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -6,7 +6,7 @@ import type {
 } from "./openai.js";
 
 // --- Provider Spectrum & Catalog Types ---
-export type ProviderCategory = "oauth" | "free_tier" | "api_key";
+export type ProviderCategory = "oauth" | "free_tier" | "api_key" | "custom_provider";
 
 export type ProviderProtocol = "openai" | "anthropic" | "gemini" | "custom";
 

--- a/packages/types/src/schemas/providers.ts
+++ b/packages/types/src/schemas/providers.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const ProviderCategorySchema = z.enum(["oauth", "free_tier", "api_key"]);
+export const ProviderCategorySchema = z.enum(["oauth", "free_tier", "api_key", "custom_provider"]);
 export const ProviderProtocolSchema = z.enum(["openai", "anthropic", "gemini", "custom"]);
 
 export const CreateProviderSchema = z.object({


### PR DESCRIPTION
# Add Custom Provider support with immutable UUID identity

## Summary

The backend already supported registering arbitrary OpenAI-/Anthropic-compatible endpoints through `POST /v1/providers` (with an SSRF guard on the verify path), but the dashboard had no entry point to use it. This PR adds a complete **Add Custom Provider** flow to the Providers page and, as part of the same work, reworks how custom providers are identified internally.

### Identity model: slug → immutable UUID v4

Previously the frontend derived a provider ID from the display name (slugified). That caused two problems:

1. The custom provider never surfaced as its own catalog card — `BaseIdOf` stripped the connection suffix and the catalog collapsed the connection into its parent seed card, so a newly created provider appeared "missing".
2. A rename (or a name collision) would change the identity of a persisted connection.

Custom providers now receive a **backend-generated UUID v4** as their internal, immutable ID (`id === providerId`). The backend is the single source of truth for identity; the display name is purely presentational and may be duplicated across providers.

Built-in (seed) providers are untouched — they keep their existing static IDs.

## Changes

### Frontend (`apps/web`)
- **`components/providers/CustomProviderDialog.tsx`** (new) — form for Name / Protocol (OpenAI, Anthropic) / Base URL / API Key. The save button stays locked until **Test Connection** passes verification (mirrors the existing `ConnectionForm` flow). Submits to `POST /v1/providers` with `category: api_key`; no `id` is sent — the backend generates the UUID. On success it invalidates the catalog and models queries.
- **`components/providers/CatalogToolbar.tsx`** — optional `onAddCustom` prop plus an **Add Custom Provider** button in the header.
- **`routes/providers/index.tsx`** — dialog state wiring.

### Backend (`apps/api`, `packages/constants`)
- **`logic/providers.logic.ts`** — `AddProvider` now calls `crypto.randomUUID()` when no explicit `id` is provided. Explicit IDs (OAuth flows, token imports) keep the legacy sanitized path unchanged.
- **`providers/catalog.ts`** — `providerBaseId` short-circuits UUID v4 so custom-model IDs keep the full UUID as their owner (previously the UUID was truncated on the dash separator, e.g. `550e8400-e29b-…` → `550e8400`).

### Tests (`apps/api/tests/custom-provider-uuid.test.ts`, new)
10 regression tests covering UUID v4 format, `id === providerId` persistence, catalog/list visibility, lookup by UUID, duplicate names, stable persistence across reads, non-collision with seed IDs, and delete-by-UUID.

## Backward compatibility

- Schema is unchanged (`id TEXT PRIMARY KEY`); no migration required.
- Existing seed/known providers keep their static IDs.
- Legacy non-UUID custom connections already in the DB still work: `BaseIdOf`/`providerBaseId` fall back to the previous logic for non-UUID IDs.

## Verification

- `apps/api`: `pnpm run build` ✓
- `packages/constants`: `tsc` build ✓
- `apps/web`: `pnpm run build` ✓
- API tests: new UUID suite 10/10 ✓, combined with codebuddy/kiro/bai 25/25 ✓, models-endpoint + token-refresh 8/8 ✓
- Live smoke test (temp DB, `tsx` server): admin setup → login → `POST /v1/providers` returns a valid UUID → provider visible in `GET /v1/providers` and `/v1/providers/catalog` → custom model attaches as `<uuid>/<model>` → `DELETE /v1/providers/<uuid>` succeeds and the provider is gone.
