### PR TITLE
feat(web): bulk add accounts for Qoder PAT and Codex tokens

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web",
-    "version": "0.1.3",
+    "version": "0.1.3-rc.1",
     "type": "module",
     "private": true,
     "repository": {

--- a/apps/web/src/components/providers/ConnectOAuthModal.tsx
+++ b/apps/web/src/components/providers/ConnectOAuthModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import { Loader2, Copy, Check, X, Key, Globe, ExternalLink } from "lucide-react";
+import { Loader2, Copy, Check, X, Key, Globe, ExternalLink, Layers } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { AuthPollStatus, type ProviderConfig, type ProviderDefinition } from "@srouter/types";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
@@ -23,7 +24,8 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
     const [copied, setCopied] = useState(false);
     const [callbackUrlInput, setCallbackUrlInput] = useState("");
     const [patInput, setPatInput] = useState("");
-    const [activeTab, setActiveTab] = useState<"oauth" | "pat">("oauth");
+    const [bulkInput, setBulkInput] = useState("");
+    const [activeTab, setActiveTab] = useState<"oauth" | "pat" | "bulk">("oauth");
     const [error, setError] = useState("");
     const [authUrl, setAuthUrl] = useState("");
     const [oauthState, setOauthState] = useState("");
@@ -34,7 +36,9 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
     const authProviderId = provider?.id === "codebuddy-cn" ? "codebuddy-cn" : baseId;
     const isQoder = baseId === "qoder";
     const isCodeBuddy = baseId === "codebuddy";
+    const isCodex = baseId === "openai";
     const isPolling = isQoder || isCodeBuddy;
+    const supportsBulk = isQoder || isCodex;
 
     // Fetch backend-registered PKCE OAuth session without auto-opening popup
     useEffect(() => {
@@ -44,6 +48,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
             setError("");
             setCallbackUrlInput("");
             setPatInput("");
+            setBulkInput("");
             if (popupRef.current && !popupRef.current.closed) {
                 popupRef.current.close();
             }
@@ -178,7 +183,11 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
     const patMutation = useMutation({
         mutationFn: (payload: { accessToken: string }) => {
             const endpoint = `/v1/auth/${authProviderId}/token`;
-            return api.post(endpoint, payload);
+            // Schema requires snake_case; handler mappers read camelCase (passthrough).
+            return api.post(endpoint, {
+                access_token: payload.accessToken,
+                accessToken: payload.accessToken
+            });
         },
         onSuccess: () => {
             if (provider) {
@@ -194,6 +203,69 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
             setError(err.message || "Failed to save token");
         }
     });
+
+    const bulkMutation = useMutation({
+        mutationFn: async (rawText: string) => {
+            const Lines = rawText
+                .split(/\r?\n/)
+                .map((l) => l.trim())
+                .filter(Boolean);
+            const Results = await Promise.allSettled(
+                Lines.map((line) => {
+                    // Codex lines may carry an optional refresh token: "<access>,<refresh>"
+                    const [accessToken, refreshToken] = isCodex
+                        ? line.split(",").map((s) => s.trim())
+                        : [line];
+                    return api.post(`/v1/auth/${authProviderId}/token`, {
+                        access_token: accessToken,
+                        accessToken,
+                        ...(refreshToken
+                            ? { refresh_token: refreshToken, refreshToken }
+                            : {})
+                    });
+                })
+            );
+            const Failed = Results.filter((r) => r.status === "rejected").length;
+            return { total: Lines.length, failed: Failed };
+        },
+        onSuccess: ({ total, failed }) => {
+            if (provider) {
+                void queryClient.invalidateQueries({ queryKey: ["providers"] });
+                void queryClient.invalidateQueries({ queryKey: ["providers", provider.id] });
+                void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
+            }
+            const added = total - failed;
+            if (added > 0) {
+                toast.success(
+                    `${added} account${added === 1 ? "" : "s"} added${failed ? ` · ${failed} failed` : ""}`
+                );
+            }
+            if (failed === 0) {
+                onOpenChange(false);
+                setBulkInput("");
+                setError("");
+            } else if (added === 0) {
+                setError(`All ${failed} token${failed === 1 ? "" : "s"} failed to import.`);
+            }
+        },
+        onError: (err: Error) => {
+            setError(err.message || "Bulk import failed");
+        }
+    });
+
+    const handleBulkSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        const lines = bulkInput
+            .split(/\r?\n/)
+            .map((l) => l.trim())
+            .filter(Boolean);
+        if (lines.length === 0) {
+            setError("Paste at least one token, one per line.");
+            return;
+        }
+        setError("");
+        bulkMutation.mutate(bulkInput);
+    };
 
     const handleCopy = async () => {
         if (!authUrl) return;
@@ -258,7 +330,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 </div>
 
                 {/* Optional Tab Switcher for Qoder or CodeBuddy */}
-                {(isQoder || isCodeBuddy) && (
+                {(isQoder || isCodeBuddy || supportsBulk) && (
                     <div className="flex border-b border-border/60 text-xs font-mono">
                         <button
                             type="button"
@@ -286,6 +358,20 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                                 {isCodeBuddy ? "Access Token" : "Personal Access Token (PAT)"}
                             </span>
                         </button>
+                        {supportsBulk && (
+                            <button
+                                type="button"
+                                onClick={() => setActiveTab("bulk")}
+                                className={`flex items-center gap-1.5 px-3 py-1.5 border-b-2 transition-colors cursor-pointer ${
+                                    activeTab === "bulk"
+                                        ? "border-foreground text-foreground font-semibold"
+                                        : "border-transparent text-muted-foreground hover:text-foreground"
+                                }`}
+                            >
+                                <Layers className="size-3.5" />
+                                <span>Bulk Add</span>
+                            </button>
+                        )}
                     </div>
                 )}
 
@@ -295,7 +381,69 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                     </div>
                 )}
 
-                {activeTab === "oauth" ? (
+                {activeTab === "bulk" ? (
+                    /* Bulk Add Tab */
+                    <form onSubmit={handleBulkSubmit} className="space-y-4 text-xs font-mono">
+                        <div className="space-y-1.5">
+                            <label className="font-semibold text-foreground block font-sans text-xs">
+                                Bulk {isCodex ? "Access Tokens" : "PATs"} — one per line
+                            </label>
+                            <p className="text-[11px] text-muted-foreground font-sans">
+                                {isCodex ? (
+                                    <>
+                                        Paste one Codex access token per line. Need refresh
+                                        support? Use{" "}
+                                        <code className="rounded bg-secondary px-1 py-0.5 text-[10px]">
+                                            access_token,refresh_token
+                                        </code>{" "}
+                                        per line.
+                                    </>
+                                ) : (
+                                    <>
+                                        Paste multiple Qoder PATs (`pt-...`) from{" "}
+                                        <a
+                                            href="https://qoder.com/account/integrations"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="underline text-foreground"
+                                        >
+                                            qoder.com/account/integrations
+                                        </a>
+                                        , one per line.
+                                    </>
+                                )}
+                            </p>
+                            <textarea
+                                rows={6}
+                                placeholder={isCodex ? "eyJhbGciOi...\neyJhbGciOi..." : "pt-xxx...\npt-yyy..."}
+                                value={bulkInput}
+                                onChange={(e) => setBulkInput(e.target.value)}
+                                className="w-full resize-y rounded-lg border border-border/60 bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                            />
+                            <p className="text-[11px] text-muted-foreground font-sans">
+                                {bulkInput.split(/\r?\n/).filter((l) => l.trim()).length > 0 &&
+                                    `${bulkInput.split(/\r?\n/).filter((l) => l.trim()).length} token(s) detected`}
+                            </p>
+                        </div>
+
+                        <div className="pt-3 border-t border-border/60 flex items-center justify-end gap-3 font-sans">
+                            <button
+                                type="button"
+                                onClick={() => onOpenChange(false)}
+                                className="px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="submit"
+                                disabled={bulkMutation.isPending}
+                                className="rounded-lg bg-secondary hover:bg-foreground hover:text-background border border-border/60 text-foreground px-5 py-2 text-xs font-bold transition-all disabled:opacity-50 cursor-pointer"
+                            >
+                                {bulkMutation.isPending ? "Importing…" : "Import Accounts"}
+                            </button>
+                        </div>
+                    </form>
+                ) : activeTab === "oauth" ? (
                     <>
                         {/* Waiting State Banner */}
                         <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-secondary/30 p-3 text-xs font-mono text-foreground">
@@ -392,11 +540,15 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                             <label className="font-semibold text-foreground block font-sans text-xs">
                                 {isCodeBuddy
                                     ? "CodeBuddy Access Token"
-                                    : "Personal Access Token (PAT)"}
+                                    : isCodex
+                                      ? "Codex Access Token"
+                                      : "Personal Access Token (PAT)"}
                             </label>
                             <p className="text-[11px] text-muted-foreground font-sans">
                                 {isCodeBuddy ? (
                                     "Masukkan Access Token / Bearer Token dari akun CodeBuddy Anda."
+                                ) : isCodex ? (
+                                    "Paste an OpenAI Codex access token (from ~/.codex/auth.json)."
                                 ) : (
                                     <>
                                         Generate your PAT (`pt-...`) from{" "}
@@ -413,7 +565,9 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                             </p>
                             <input
                                 type="password"
-                                placeholder={isCodeBuddy ? "eyJhbGciOi..." : "pt-..."}
+                                placeholder={
+                                    isCodeBuddy || isCodex ? "eyJhbGciOi..." : "pt-..."
+                                }
                                 value={patInput}
                                 onChange={(e) => setPatInput(e.target.value)}
                                 className="w-full rounded-lg border border-border/60 bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"

--- a/apps/web/src/components/providers/ConnectOAuthModal.tsx
+++ b/apps/web/src/components/providers/ConnectOAuthModal.tsx
@@ -1,10 +1,28 @@
 import { useState, useEffect, useRef } from "react";
-import { Loader2, Copy, Check, X, Key, Globe, ExternalLink, Layers } from "lucide-react";
+import {
+    Loader2,
+    Copy,
+    Check,
+    X,
+    Key,
+    Globe,
+    ExternalLink,
+    Layers,
+    AlertCircle
+} from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { AuthPollStatus, type ProviderConfig, type ProviderDefinition } from "@srouter/types";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ProviderIcon } from "@/components/ProviderIcon";
 
 interface ConnectOAuthModalProps {
     provider: ProviderDefinition | null;
@@ -111,6 +129,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 void queryClient.invalidateQueries({ queryKey: ["providers"] });
                 void queryClient.invalidateQueries({ queryKey: ["providers", provider.id] });
                 void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
+                toast.success(`${provider.name} connected successfully!`);
                 onOpenChange(false);
                 setCallbackUrlInput("");
                 setError("");
@@ -141,6 +160,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                     void queryClient.invalidateQueries({ queryKey: ["providers"] });
                     void queryClient.invalidateQueries({ queryKey: ["providers", provider.id] });
                     void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
+                    toast.success(`${provider.name} connected successfully!`);
                     onOpenChange(false);
                     setError("");
                 }
@@ -170,6 +190,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 void queryClient.invalidateQueries({ queryKey: ["providers"] });
                 void queryClient.invalidateQueries({ queryKey: ["providers", provider.id] });
                 void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
+                toast.success(`${provider.name} connected successfully!`);
             }
             onOpenChange(false);
             setCallbackUrlInput("");
@@ -194,6 +215,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 void queryClient.invalidateQueries({ queryKey: ["providers"] });
                 void queryClient.invalidateQueries({ queryKey: ["providers", provider.id] });
                 void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
+                toast.success(`Token for ${provider.name} saved successfully!`);
             }
             onOpenChange(false);
             setPatInput("");
@@ -206,12 +228,12 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
 
     const bulkMutation = useMutation({
         mutationFn: async (rawText: string) => {
-            const Lines = rawText
+            const lines = rawText
                 .split(/\r?\n/)
                 .map((l) => l.trim())
                 .filter(Boolean);
-            const Results = await Promise.allSettled(
-                Lines.map((line) => {
+            const results = await Promise.allSettled(
+                lines.map((line) => {
                     // Codex lines may carry an optional refresh token: "<access>,<refresh>"
                     const [accessToken, refreshToken] = isCodex
                         ? line.split(",").map((s) => s.trim())
@@ -225,8 +247,8 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                     });
                 })
             );
-            const Failed = Results.filter((r) => r.status === "rejected").length;
-            return { total: Lines.length, failed: Failed };
+            const failed = results.filter((r) => r.status === "rejected").length;
+            return { total: lines.length, failed };
         },
         onSuccess: ({ total, failed }) => {
             if (provider) {
@@ -304,99 +326,114 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
 
     if (!provider) return null;
 
+    const tabsCount = (supportsBulk ? 3 : isQoder || isCodeBuddy ? 2 : 1);
+
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-md w-full p-5 bg-card border border-border/80 rounded-xl space-y-4 shadow-xl">
-                {/* Window Header */}
-                <div className="flex items-center justify-between border-b border-border/60 pb-3">
-                    <div className="flex items-center gap-2">
-                        <div className="flex items-center gap-1.5">
-                            <span className="size-3 rounded-full bg-red-500/80 inline-block" />
-                            <span className="size-3 rounded-full bg-amber-500/80 inline-block" />
-                            <span className="size-3 rounded-full bg-emerald-500/80 inline-block" />
+            <DialogContent className="sm:max-w-md w-full p-6 bg-card border border-border/80 rounded-2xl space-y-4 shadow-2xl">
+                {/* Header */}
+                <DialogHeader className="flex flex-row items-center justify-between pb-3 border-b border-border/60">
+                    <div className="flex items-center gap-2.5">
+                        <ProviderIcon providerId={provider.id} className="size-6 rounded-md shadow-2xs" />
+                        <div>
+                            <DialogTitle className="text-sm font-bold tracking-tight text-foreground">
+                                Connect {provider.name}
+                            </DialogTitle>
+                            <DialogDescription className="text-[11px] text-muted-foreground">
+                                Authenticate and link your account
+                            </DialogDescription>
                         </div>
-                        <h2 className="font-bold text-sm text-foreground ml-2">
-                            Connect {provider.name}
-                        </h2>
                     </div>
 
                     <button
                         type="button"
                         onClick={() => onOpenChange(false)}
-                        className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-secondary transition-colors cursor-pointer"
+                        className="inline-flex size-7 items-center justify-center rounded-lg text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer"
+                        aria-label="Close dialog"
                     >
                         <X className="size-4" />
                     </button>
-                </div>
+                </DialogHeader>
 
-                {/* Optional Tab Switcher for Qoder or CodeBuddy */}
+                {/* Segmented Tab Switcher */}
                 {(isQoder || isCodeBuddy || supportsBulk) && (
-                    <div className="flex border-b border-border/60 text-xs font-mono">
+                    <div
+                        className={`grid w-full gap-1 rounded-lg border border-border/60 bg-secondary/30 p-1 text-xs ${
+                            tabsCount === 3 ? "grid-cols-3" : "grid-cols-2"
+                        }`}
+                    >
                         <button
                             type="button"
                             onClick={() => setActiveTab("oauth")}
-                            className={`flex items-center gap-1.5 px-3 py-1.5 border-b-2 transition-colors cursor-pointer ${
+                            className={`flex items-center justify-center gap-1.5 py-1.5 px-2.5 rounded-md font-medium transition-all cursor-pointer ${
                                 activeTab === "oauth"
-                                    ? "border-foreground text-foreground font-semibold"
-                                    : "border-transparent text-muted-foreground hover:text-foreground"
+                                    ? "bg-card text-foreground shadow-xs font-semibold"
+                                    : "text-muted-foreground hover:text-foreground"
                             }`}
                         >
-                            <Globe className="size-3.5" />
-                            <span>Browser Login</span>
+                            <Globe className="size-3.5 shrink-0" />
+                            <span className="truncate">Browser Login</span>
                         </button>
                         <button
                             type="button"
                             onClick={() => setActiveTab("pat")}
-                            className={`flex items-center gap-1.5 px-3 py-1.5 border-b-2 transition-colors cursor-pointer ${
+                            className={`flex items-center justify-center gap-1.5 py-1.5 px-2.5 rounded-md font-medium transition-all cursor-pointer ${
                                 activeTab === "pat"
-                                    ? "border-foreground text-foreground font-semibold"
-                                    : "border-transparent text-muted-foreground hover:text-foreground"
+                                    ? "bg-card text-foreground shadow-xs font-semibold"
+                                    : "text-muted-foreground hover:text-foreground"
                             }`}
                         >
-                            <Key className="size-3.5" />
-                            <span>
-                                {isCodeBuddy ? "Access Token" : "Personal Access Token (PAT)"}
+                            <Key className="size-3.5 shrink-0" />
+                            <span className="truncate">
+                                {isCodeBuddy ? "Access Token" : "PAT Token"}
                             </span>
                         </button>
                         {supportsBulk && (
                             <button
                                 type="button"
                                 onClick={() => setActiveTab("bulk")}
-                                className={`flex items-center gap-1.5 px-3 py-1.5 border-b-2 transition-colors cursor-pointer ${
+                                className={`flex items-center justify-center gap-1.5 py-1.5 px-2.5 rounded-md font-medium transition-all cursor-pointer ${
                                     activeTab === "bulk"
-                                        ? "border-foreground text-foreground font-semibold"
-                                        : "border-transparent text-muted-foreground hover:text-foreground"
+                                        ? "bg-card text-foreground shadow-xs font-semibold"
+                                        : "text-muted-foreground hover:text-foreground"
                                 }`}
                             >
-                                <Layers className="size-3.5" />
-                                <span>Bulk Add</span>
+                                <Layers className="size-3.5 shrink-0" />
+                                <span className="truncate">Bulk Add</span>
                             </button>
                         )}
                     </div>
                 )}
 
+                {/* Error Banner */}
                 {error && (
-                    <div className="rounded border border-destructive/40 bg-destructive/10 p-2.5 text-xs font-mono text-destructive">
-                        {error}
+                    <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
+                        <AlertCircle className="size-4 shrink-0 mt-0.5" />
+                        <span className="font-mono">{error}</span>
                     </div>
                 )}
 
                 {activeTab === "bulk" ? (
                     /* Bulk Add Tab */
-                    <form onSubmit={handleBulkSubmit} className="space-y-4 text-xs font-mono">
+                    <form onSubmit={handleBulkSubmit} className="space-y-4 text-xs">
                         <div className="space-y-1.5">
-                            <label className="font-semibold text-foreground block font-sans text-xs">
-                                Bulk {isCodex ? "Access Tokens" : "PATs"} — one per line
-                            </label>
-                            <p className="text-[11px] text-muted-foreground font-sans">
+                            <div className="flex items-center justify-between">
+                                <label className="font-semibold text-foreground text-xs">
+                                    Bulk {isCodex ? "Access Tokens" : "PATs"}
+                                </label>
+                                {bulkInput.split(/\r?\n/).filter((l) => l.trim()).length > 0 && (
+                                    <span className="rounded-md bg-secondary px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
+                                        {bulkInput.split(/\r?\n/).filter((l) => l.trim()).length} detected
+                                    </span>
+                                )}
+                            </div>
+                            <p className="text-[11px] text-muted-foreground leading-relaxed">
                                 {isCodex ? (
                                     <>
-                                        Paste one Codex access token per line. Need refresh
-                                        support? Use{" "}
-                                        <code className="rounded bg-secondary px-1 py-0.5 text-[10px]">
+                                        Paste one Codex access token per line. Format:{" "}
+                                        <code className="rounded bg-secondary px-1 py-0.5 text-[10px] font-mono">
                                             access_token,refresh_token
-                                        </code>{" "}
-                                        per line.
+                                        </code>
                                     </>
                                 ) : (
                                     <>
@@ -405,7 +442,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                                             href="https://qoder.com/account/integrations"
                                             target="_blank"
                                             rel="noreferrer"
-                                            className="underline text-foreground"
+                                            className="underline text-foreground hover:text-primary transition-colors"
                                         >
                                             qoder.com/account/integrations
                                         </a>
@@ -414,120 +451,150 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                                 )}
                             </p>
                             <textarea
-                                rows={6}
+                                rows={5}
                                 placeholder={isCodex ? "eyJhbGciOi...\neyJhbGciOi..." : "pt-xxx...\npt-yyy..."}
                                 value={bulkInput}
                                 onChange={(e) => setBulkInput(e.target.value)}
-                                className="w-full resize-y rounded-lg border border-border/60 bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                                className="w-full resize-y rounded-lg border border-border/60 bg-secondary/20 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
                             />
-                            <p className="text-[11px] text-muted-foreground font-sans">
-                                {bulkInput.split(/\r?\n/).filter((l) => l.trim()).length > 0 &&
-                                    `${bulkInput.split(/\r?\n/).filter((l) => l.trim()).length} token(s) detected`}
-                            </p>
                         </div>
 
-                        <div className="pt-3 border-t border-border/60 flex items-center justify-end gap-3 font-sans">
-                            <button
+                        <div className="pt-2 border-t border-border/60 flex items-center justify-end gap-2">
+                            <Button
                                 type="button"
+                                variant="outline"
+                                size="sm"
                                 onClick={() => onOpenChange(false)}
-                                className="px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                className="h-8 text-xs cursor-pointer"
                             >
                                 Cancel
-                            </button>
-                            <button
+                            </Button>
+                            <Button
                                 type="submit"
+                                size="sm"
                                 disabled={bulkMutation.isPending}
-                                className="rounded-lg bg-secondary hover:bg-foreground hover:text-background border border-border/60 text-foreground px-5 py-2 text-xs font-bold transition-all disabled:opacity-50 cursor-pointer"
+                                className="h-8 text-xs font-semibold cursor-pointer gap-1.5"
                             >
+                                {bulkMutation.isPending && <Loader2 className="size-3.5 animate-spin" />}
                                 {bulkMutation.isPending ? "Importing…" : "Import Accounts"}
-                            </button>
+                            </Button>
                         </div>
                     </form>
                 ) : activeTab === "oauth" ? (
                     <>
-                        {/* Waiting State Banner */}
-                        <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-secondary/30 p-3 text-xs font-mono text-foreground">
-                            <Loader2 className="size-4 text-orange-500 animate-spin shrink-0" />
-                            <span>
-                                {isLoadingUrl
-                                    ? "Generating authorization session…"
-                                    : isQoder
-                                      ? "Waiting for Qoder browser authorization…"
-                                      : isCodeBuddy
-                                        ? "Waiting for CodeBuddy browser authorization…"
-                                        : "Waiting for popup authorization…"}
-                            </span>
+                        {/* Live Waiting Status Banner */}
+                        <div className="flex items-center gap-3 rounded-xl border border-amber-500/25 bg-amber-500/5 px-3.5 py-2.5 text-xs">
+                            {isLoadingUrl ? (
+                                <Loader2 className="size-4 text-amber-500 animate-spin shrink-0" />
+                            ) : (
+                                <div className="relative flex size-3 items-center justify-center shrink-0">
+                                    <span className="absolute size-full rounded-full bg-amber-500/40 animate-ping" />
+                                    <span className="size-2 rounded-full bg-amber-500" />
+                                </div>
+                            )}
+                            <div className="flex-1 min-w-0">
+                                <p className="font-medium text-foreground text-xs truncate">
+                                    {isLoadingUrl
+                                        ? "Generating authorization session…"
+                                        : isQoder
+                                          ? "Waiting for Qoder browser authorization…"
+                                          : isCodeBuddy
+                                            ? "Waiting for CodeBuddy browser authorization…"
+                                            : "Waiting for browser authorization…"}
+                                </p>
+                                <p className="text-[10.5px] text-muted-foreground mt-0.5">
+                                    Complete authorization in your browser window to link.
+                                </p>
+                            </div>
                         </div>
 
-                        <form onSubmit={handleConnect} className="space-y-4 text-xs font-mono">
-                            {/* Step 1 */}
-                            <div className="space-y-1.5">
-                                <label className="font-semibold text-foreground block font-sans text-xs">
-                                    Step 1: Open this URL in your browser
+                        <form onSubmit={handleConnect} className="space-y-3.5 text-xs">
+                            {/* Step 1: Open in Browser */}
+                            <div className="space-y-2">
+                                <label className="font-semibold text-foreground block text-xs">
+                                    Step 1: Open authorization in browser
                                 </label>
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        type="text"
-                                        readOnly
-                                        value={authUrl || "Generating authorization URL..."}
-                                        className="w-full rounded-lg border border-border/60 bg-secondary/30 px-3 py-2 text-xs font-mono text-muted-foreground focus:outline-none truncate"
-                                    />
-                                    <button
-                                        type="button"
-                                        onClick={handleOpenPopup}
-                                        disabled={!authUrl}
-                                        className="inline-flex items-center gap-1.5 rounded-lg border border-border/60 bg-foreground text-background hover:opacity-90 px-3 py-2 text-xs font-semibold transition-all shrink-0 disabled:opacity-50 cursor-pointer"
-                                    >
-                                        <ExternalLink className="size-3.5" />
-                                        <span>Open</span>
-                                    </button>
+                                <Button
+                                    type="button"
+                                    onClick={handleOpenPopup}
+                                    disabled={!authUrl || isLoadingUrl}
+                                    className="w-full h-9 text-xs font-semibold gap-2 shadow-xs cursor-pointer"
+                                >
+                                    <ExternalLink className="size-3.5" />
+                                    <span>Open {provider.name} Login Page</span>
+                                </Button>
+                            </div>
+
+                            {/* Link Copy Box */}
+                            <div className="space-y-1.5">
+                                <div className="flex items-center justify-between text-[11px]">
+                                    <span className="text-muted-foreground">Or copy authorization URL</span>
                                     <button
                                         type="button"
                                         onClick={() => void handleCopy()}
                                         disabled={!authUrl}
-                                        className="inline-flex items-center gap-1.5 rounded-lg border border-border/60 bg-secondary/60 hover:bg-secondary px-3 py-2 text-xs font-semibold text-foreground transition-all shrink-0 disabled:opacity-50 cursor-pointer"
+                                        className="inline-flex items-center gap-1 font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
                                     >
                                         {copied ? (
-                                            <Check className="size-3.5 text-emerald-500" />
+                                            <>
+                                                <Check className="size-3 text-emerald-500" />
+                                                <span className="text-emerald-500">Copied</span>
+                                            </>
                                         ) : (
-                                            <Copy className="size-3.5" />
+                                            <>
+                                                <Copy className="size-3" />
+                                                <span>Copy link</span>
+                                            </>
                                         )}
-                                        <span>Copy</span>
                                     </button>
+                                </div>
+                                <div className="relative flex items-center">
+                                    <input
+                                        type="text"
+                                        readOnly
+                                        value={authUrl || "Generating authorization URL..."}
+                                        className="w-full rounded-lg border border-border/60 bg-secondary/20 px-3 py-2 text-[11px] font-mono text-muted-foreground focus:outline-none select-all truncate"
+                                    />
                                 </div>
                             </div>
 
                             {!isPolling && (
                                 <>
                                     {/* Step 2 for redirect-based OAuth */}
-                                    <div className="space-y-1.5">
-                                        <label className="font-semibold text-foreground block font-sans text-xs">
-                                            Step 2: Paste the callback URL here (if not auto-closed)
+                                    <div className="space-y-1.5 pt-2 border-t border-border/60">
+                                        <label className="font-semibold text-foreground block text-xs">
+                                            Step 2: Paste callback URL (if not auto-closed)
                                         </label>
                                         <input
                                             type="text"
                                             placeholder="http://localhost:1455/auth/callback?code=...&state=..."
                                             value={callbackUrlInput}
                                             onChange={(e) => setCallbackUrlInput(e.target.value)}
-                                            className="w-full rounded-lg border border-border/60 bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                                            className="w-full rounded-lg border border-border/60 bg-secondary/20 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
                                         />
                                     </div>
 
-                                    <div className="pt-3 border-t border-border/60 flex items-center justify-end gap-3 font-sans">
-                                        <button
+                                    <div className="pt-2 border-t border-border/60 flex items-center justify-end gap-2">
+                                        <Button
                                             type="button"
+                                            variant="outline"
+                                            size="sm"
                                             onClick={() => onOpenChange(false)}
-                                            className="px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                            className="h-8 text-xs cursor-pointer"
                                         >
                                             Cancel
-                                        </button>
-                                        <button
+                                        </Button>
+                                        <Button
                                             type="submit"
+                                            size="sm"
                                             disabled={callbackMutation.isPending}
-                                            className="rounded-lg bg-secondary hover:bg-foreground hover:text-background border border-border/60 text-foreground px-5 py-2 text-xs font-bold transition-all disabled:opacity-50 cursor-pointer"
+                                            className="h-8 text-xs font-semibold cursor-pointer gap-1.5"
                                         >
+                                            {callbackMutation.isPending && (
+                                                <Loader2 className="size-3.5 animate-spin" />
+                                            )}
                                             {callbackMutation.isPending ? "Connecting…" : "Connect"}
-                                        </button>
+                                        </Button>
                                     </div>
                                 </>
                             )}
@@ -535,16 +602,16 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                     </>
                 ) : (
                     /* PAT Tab */
-                    <form onSubmit={handlePatSubmit} className="space-y-4 text-xs font-mono">
+                    <form onSubmit={handlePatSubmit} className="space-y-4 text-xs">
                         <div className="space-y-1.5">
-                            <label className="font-semibold text-foreground block font-sans text-xs">
+                            <label className="font-semibold text-foreground block text-xs">
                                 {isCodeBuddy
                                     ? "CodeBuddy Access Token"
                                     : isCodex
                                       ? "Codex Access Token"
                                       : "Personal Access Token (PAT)"}
                             </label>
-                            <p className="text-[11px] text-muted-foreground font-sans">
+                            <p className="text-[11px] text-muted-foreground leading-relaxed">
                                 {isCodeBuddy ? (
                                     "Masukkan Access Token / Bearer Token dari akun CodeBuddy Anda."
                                 ) : isCodex ? (
@@ -556,7 +623,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                                             href="https://qoder.com/account/integrations"
                                             target="_blank"
                                             rel="noreferrer"
-                                            className="underline text-foreground"
+                                            className="underline text-foreground hover:text-primary transition-colors"
                                         >
                                             qoder.com/account/integrations
                                         </a>
@@ -570,29 +637,35 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                                 }
                                 value={patInput}
                                 onChange={(e) => setPatInput(e.target.value)}
-                                className="w-full rounded-lg border border-border/60 bg-secondary/30 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                                className="w-full rounded-lg border border-border/60 bg-secondary/20 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
                             />
                         </div>
 
-                        <div className="pt-3 border-t border-border/60 flex items-center justify-end gap-3 font-sans">
-                            <button
+                        <div className="pt-2 border-t border-border/60 flex items-center justify-end gap-2">
+                            <Button
                                 type="button"
+                                variant="outline"
+                                size="sm"
                                 onClick={() => onOpenChange(false)}
-                                className="px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                className="h-8 text-xs cursor-pointer"
                             >
                                 Cancel
-                            </button>
-                            <button
+                            </Button>
+                            <Button
                                 type="submit"
+                                size="sm"
                                 disabled={patMutation.isPending}
-                                className="rounded-lg bg-secondary hover:bg-foreground hover:text-background border border-border/60 text-foreground px-5 py-2 text-xs font-bold transition-all disabled:opacity-50 cursor-pointer"
+                                className="h-8 text-xs font-semibold cursor-pointer gap-1.5"
                             >
+                                {patMutation.isPending && (
+                                    <Loader2 className="size-3.5 animate-spin" />
+                                )}
                                 {patMutation.isPending
                                     ? "Connecting…"
                                     : isCodeBuddy
                                       ? "Connect CodeBuddy"
                                       : "Connect PAT"}
-                            </button>
+                            </Button>
                         </div>
                     </form>
                 )}

--- a/packages/constants/src/version.ts
+++ b/packages/constants/src/version.ts
@@ -1,5 +1,5 @@
 export const GLOBAL_VERSION = "0.1.3";
-export const APP_VERSION = "0.1.3";
+export const APP_VERSION = "0.1.3-rc.1";
 export const API_VERSION = "0.1.3";
 export const CLI_VERSION = "0.1.3-rc.3";
 


### PR DESCRIPTION
# Bulk add accounts for Qoder PAT and Codex tokens

## Summary

The backend already supports importing tokens one at a time via `POST /v1/auth/{qoder,openai}/token`, but there was no UI to add many accounts at once. This PR adds a **Bulk Add** tab to the OAuth connect modal for the **Qoder** and **OpenAI Codex** providers.

## Changes

- **`components/providers/ConnectOAuthModal.tsx`**
  - New Bulk Add tab with a textarea — one token per line:
    - **Qoder**: `pt-...` PATs
    - **Codex**: `access_token` or `access_token,refresh_token`
  - Parallel import through the existing token-import endpoint; a failure on one line does not stop the batch. A summary toast reports `N added · M failed`, and the dialog stays open when any line fails.
  - Live counter showing `X token(s) detected`.
  - **Bugfix**: the single-PAT payload previously sent only `accessToken`, but the backend Zod schema requires `access_token` (400). It now sends both keys (snake_case schema + camelCase mapper via passthrough).

## Verification

- `tsc --noEmit` ✓, `pnpm run build` (apps/web) ✓
- Smoke: `POST /v1/auth/{qoder,openai}/token` → 401 without an admin session (expected; the modal uses the admin session cookie)

Closes #77
