### PR TITLE
feat(web): redesign settings page — modern layout, shared primitives

### DIFF
--- a/apps/web/src/components/settings/AppearanceSettings.tsx
+++ b/apps/web/src/components/settings/AppearanceSettings.tsx
@@ -1,5 +1,6 @@
 import { Check, Moon, Palette, Sun, LayoutGrid, Type } from "lucide-react";
 import type { AppSettings } from "@/hooks/useSettings";
+import { SettingsSection, SettingsRow, SegmentedControl } from "./settings-ui";
 
 interface AppearanceSettingsProps {
     theme: "light" | "dark";
@@ -15,137 +16,113 @@ export function AppearanceSettings({
     updateSetting
 }: AppearanceSettingsProps) {
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Palette className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Appearance & Interface
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Customize your color palette, table density, and dashboard visual presentation.
-                </p>
-            </div>
-
-            {/* Theme Selection */}
-            <div className="space-y-3">
-                <label className="text-xs font-bold text-foreground">Color Theme Mode</label>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-lg">
-                    {/* Dark Mode Option */}
-                    <button
-                        type="button"
-                        onClick={(e) => theme !== "dark" && toggleTheme(e)}
-                        className={`group relative flex flex-col gap-3 rounded-xl border p-4 text-left transition-all cursor-pointer ${
-                            theme === "dark"
-                                ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20 shadow-xs"
-                                : "border-border/80 bg-background text-muted-foreground hover:border-border hover:text-foreground"
-                        }`}
-                    >
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                                <div className="flex size-7 items-center justify-center rounded-lg bg-zinc-900 border border-zinc-800 text-foreground">
-                                    <Moon className="size-3.5" />
-                                </div>
-                                <span className="text-xs font-bold text-foreground">
-                                    Dark Cockpit
-                                </span>
-                            </div>
-                            {theme === "dark" && (
-                                <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-background">
-                                    <Check className="size-3 stroke-[3]" />
-                                </span>
-                            )}
-                        </div>
-
-                        {/* Dark Mode Mini Mockup */}
-                        <div className="rounded-md border border-zinc-800 bg-zinc-950 p-2.5 space-y-1.5 opacity-90">
-                            <div className="flex items-center justify-between">
-                                <div className="h-2 w-16 rounded bg-zinc-800" />
-                                <div className="h-2 w-6 rounded bg-zinc-700" />
-                            </div>
-                            <div className="h-1.5 w-full rounded bg-zinc-900" />
-                            <div className="h-1.5 w-4/5 rounded bg-zinc-900" />
-                        </div>
-                    </button>
-
-                    {/* Light Mode Option */}
-                    <button
-                        type="button"
-                        onClick={(e) => theme !== "light" && toggleTheme(e)}
-                        className={`group relative flex flex-col gap-3 rounded-xl border p-4 text-left transition-all cursor-pointer ${
-                            theme === "light"
-                                ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20 shadow-xs"
-                                : "border-border/80 bg-background text-muted-foreground hover:border-border hover:text-foreground"
-                        }`}
-                    >
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                                <div className="flex size-7 items-center justify-center rounded-lg bg-zinc-100 border border-zinc-200 text-foreground">
-                                    <Sun className="size-3.5" />
-                                </div>
-                                <span className="text-xs font-bold text-foreground">
-                                    Light Paper
-                                </span>
-                            </div>
-                            {theme === "light" && (
-                                <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-background">
-                                    <Check className="size-3 stroke-[3]" />
-                                </span>
-                            )}
-                        </div>
-
-                        {/* Light Mode Mini Mockup */}
-                        <div className="rounded-md border border-zinc-200 bg-white p-2.5 space-y-1.5 opacity-90">
-                            <div className="flex items-center justify-between">
-                                <div className="h-2 w-16 rounded bg-zinc-200" />
-                                <div className="h-2 w-6 rounded bg-zinc-300" />
-                            </div>
-                            <div className="h-1.5 w-full rounded bg-zinc-100" />
-                            <div className="h-1.5 w-4/5 rounded bg-zinc-100" />
-                        </div>
-                    </button>
-                </div>
-            </div>
-
-            {/* UI Density */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="space-y-0.5">
-                    <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                        <LayoutGrid className="size-3.5 text-muted-foreground" />
-                        <span>Interface Table & Row Density</span>
+        <div className="space-y-5">
+            <SettingsSection
+                title="Appearance & Interface"
+                description="Customize your color palette, table density, and dashboard visual presentation."
+                icon={<Palette className="size-4" />}
+            >
+                {/* Theme Selection */}
+                <div className="space-y-3">
+                    <label className="text-xs font-semibold text-foreground">
+                        Color Theme Mode
                     </label>
-                    <p className="text-[11px] text-muted-foreground">
-                        Control table row padding and vertical layout spacing across logs and model
-                        catalogs.
-                    </p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-lg">
+                        <button
+                            type="button"
+                            onClick={(e) => theme !== "dark" && toggleTheme(e)}
+                            className={`group relative flex flex-col gap-3 rounded-xl border p-4 text-left transition-all cursor-pointer ${
+                                theme === "dark"
+                                    ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20"
+                                    : "border-border/70 bg-background text-muted-foreground hover:border-border hover:text-foreground"
+                            }`}
+                        >
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-2">
+                                    <div className="flex size-7 items-center justify-center rounded-lg bg-zinc-900 border border-zinc-800 text-foreground">
+                                        <Moon className="size-3.5" />
+                                    </div>
+                                    <span className="text-xs font-bold text-foreground">
+                                        Dark Cockpit
+                                    </span>
+                                </div>
+                                {theme === "dark" && (
+                                    <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-background">
+                                        <Check className="size-3 stroke-[3]" />
+                                    </span>
+                                )}
+                            </div>
+                            <div className="rounded-md border border-zinc-800 bg-zinc-950 p-2.5 space-y-1.5 opacity-90">
+                                <div className="flex items-center justify-between">
+                                    <div className="h-2 w-16 rounded bg-zinc-800" />
+                                    <div className="h-2 w-6 rounded bg-zinc-700" />
+                                </div>
+                                <div className="h-1.5 w-full rounded bg-zinc-900" />
+                                <div className="h-1.5 w-4/5 rounded bg-zinc-900" />
+                            </div>
+                        </button>
+
+                        <button
+                            type="button"
+                            onClick={(e) => theme !== "light" && toggleTheme(e)}
+                            className={`group relative flex flex-col gap-3 rounded-xl border p-4 text-left transition-all cursor-pointer ${
+                                theme === "light"
+                                    ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20"
+                                    : "border-border/70 bg-background text-muted-foreground hover:border-border hover:text-foreground"
+                            }`}
+                        >
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-2">
+                                    <div className="flex size-7 items-center justify-center rounded-lg bg-zinc-100 border border-zinc-200 text-foreground">
+                                        <Sun className="size-3.5" />
+                                    </div>
+                                    <span className="text-xs font-bold text-foreground">
+                                        Light Paper
+                                    </span>
+                                </div>
+                                {theme === "light" && (
+                                    <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-background">
+                                        <Check className="size-3 stroke-[3]" />
+                                    </span>
+                                )}
+                            </div>
+                            <div className="rounded-md border border-zinc-200 bg-white p-2.5 space-y-1.5 opacity-90">
+                                <div className="flex items-center justify-between">
+                                    <div className="h-2 w-16 rounded bg-zinc-200" />
+                                    <div className="h-2 w-6 rounded bg-zinc-300" />
+                                </div>
+                                <div className="h-1.5 w-full rounded bg-zinc-100" />
+                                <div className="h-1.5 w-4/5 rounded bg-zinc-100" />
+                            </div>
+                        </button>
+                    </div>
                 </div>
 
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {(["compact", "cozy"] as const).map((density) => {
-                        const isActive = settings.uiDensity === density;
-                        return (
-                            <button
-                                key={density}
-                                type="button"
-                                onClick={() => updateSetting("uiDensity", density)}
-                                className={`rounded-md px-3.5 py-1.5 text-xs font-semibold capitalize transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {density === "compact" ? "Compact (Dense)" : "Cozy (Relaxed)"}
-                            </button>
-                        );
-                    })}
+                {/* UI Density */}
+                <div className="space-y-3 border-t border-border/60 pt-5">
+                    <SettingsRow
+                        title="Interface Table Density"
+                        description="Control table row padding and vertical layout spacing across logs and model catalogs."
+                        control={
+                            <SegmentedControl
+                                options={[
+                                    { value: "compact", label: "Compact (Dense)" },
+                                    { value: "cozy", label: "Cozy (Relaxed)" }
+                                ]}
+                                value={settings.uiDensity}
+                                onChange={(density) => updateSetting("uiDensity", density)}
+                            />
+                        }
+                    />
                 </div>
-            </div>
+            </SettingsSection>
 
             {/* Typography Callout */}
-            <div className="rounded-lg border border-border/60 bg-muted/20 p-3.5 flex items-start gap-3">
-                <Type className="size-4 text-muted-foreground shrink-0 mt-0.5" />
-                <div className="text-[11px] text-muted-foreground leading-relaxed">
+            <div className="flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/20 p-4">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-card text-muted-foreground">
+                    <Type className="size-4" />
+                </div>
+                <div className="text-[11px] leading-relaxed text-muted-foreground">
                     <strong className="text-foreground">JetBrains Mono Engine:</strong> SRouter uses
                     monospaced typography throughout the operational cockpit for maximum visual
                     alignment of tokens, hashes, JSON payloads, and timestamps.

--- a/apps/web/src/components/settings/DataSettings.tsx
+++ b/apps/web/src/components/settings/DataSettings.tsx
@@ -21,6 +21,7 @@ import {
     DialogHeader,
     DialogTitle
 } from "@/components/ui/dialog";
+import { SettingsSection, SettingsRow } from "./settings-ui";
 import type { StorageStats } from "@/hooks/useSettings";
 
 interface DataSettingsProps {
@@ -70,13 +71,10 @@ export function DataSettings({
     const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (!file) return;
-
         const reader = new FileReader();
         reader.onload = (event) => {
             const content = event.target?.result as string;
-            if (content) {
-                setImportText(content);
-            }
+            if (content) setImportText(content);
         };
         reader.readAsText(file);
     };
@@ -86,7 +84,6 @@ export function DataSettings({
             toast.error("Please provide valid JSON configuration");
             return;
         }
-
         const success = importSettings(importText);
         if (success) {
             setIsImportOpen(false);
@@ -108,82 +105,66 @@ export function DataSettings({
     };
 
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Database className="size-4 text-emerald-500" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Data, Backup & Local Storage
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Inspect local storage footprint, export portability backups, or purge local
-                    session cache.
-                </p>
-            </div>
-
-            {/* Storage Usage Meter */}
-            <div className="rounded-xl border border-border/70 bg-muted/20 p-4 space-y-3">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                        <HardDrive className="size-4 text-muted-foreground" />
-                        <span className="text-xs font-bold text-foreground">
-                            Browser LocalStorage Allocation
+        <div className="space-y-5">
+            <SettingsSection
+                title="Data, Backup & Local Storage"
+                description="Inspect local storage footprint, export portability backups, or purge local session cache."
+                icon={<Database className="size-4" />}
+            >
+                {/* Storage Usage Meter */}
+                <div className="rounded-xl border border-border/60 bg-muted/20 p-4 space-y-3">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                            <HardDrive className="size-4 text-muted-foreground" />
+                            <span className="text-xs font-bold text-foreground">
+                                Browser LocalStorage
+                            </span>
+                        </div>
+                        <span className="text-xs font-mono font-bold tabular-nums text-foreground">
+                            {formatBytes(stats.totalBytes)} ({stats.itemsCount} keys)
                         </span>
                     </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums">
-                        {formatBytes(stats.totalBytes)} ({stats.itemsCount} stored keys)
-                    </span>
-                </div>
 
-                {/* Storage breakdown bar */}
-                <div className="space-y-1.5">
-                    <div className="h-2 w-full rounded-full bg-muted overflow-hidden flex">
-                        <div
-                            className="h-full bg-blue-500 transition-all duration-300"
-                            style={{
-                                width: `${stats.totalBytes > 0 ? (stats.playgroundBytes / stats.totalBytes) * 100 : 0}%`
-                            }}
-                            title={`Playground: ${formatBytes(stats.playgroundBytes)}`}
-                        />
-                        <div
-                            className="h-full bg-amber-500 transition-all duration-300"
-                            style={{
-                                width: `${stats.totalBytes > 0 ? (stats.settingsBytes / stats.totalBytes) * 100 : 0}%`
-                            }}
-                            title={`Settings: ${formatBytes(stats.settingsBytes)}`}
-                        />
-                    </div>
-                    <div className="flex items-center justify-between text-[10px] font-mono text-muted-foreground">
-                        <div className="flex items-center gap-3">
+                    <div className="space-y-1.5">
+                        <div className="h-2 w-full rounded-full bg-muted overflow-hidden flex">
+                            <div
+                                className="h-full bg-blue-500 transition-all duration-300"
+                                style={{
+                                    width: `${stats.totalBytes > 0 ? (stats.playgroundBytes / stats.totalBytes) * 100 : 0}%`
+                                }}
+                                title={`Playground: ${formatBytes(stats.playgroundBytes)}`}
+                            />
+                            <div
+                                className="h-full bg-amber-500 transition-all duration-300"
+                                style={{
+                                    width: `${stats.totalBytes > 0 ? (stats.settingsBytes / stats.totalBytes) * 100 : 0}%`
+                                }}
+                                title={`Settings: ${formatBytes(stats.settingsBytes)}`}
+                            />
+                        </div>
+                        <div className="flex items-center gap-3 text-[10px] font-mono text-muted-foreground">
                             <span className="flex items-center gap-1">
                                 <span className="size-2 rounded-full bg-blue-500" />
-                                <span>
-                                    Playground Sessions: {formatBytes(stats.playgroundBytes)}
-                                </span>
+                                Playground: {formatBytes(stats.playgroundBytes)}
                             </span>
                             <span className="flex items-center gap-1">
                                 <span className="size-2 rounded-full bg-amber-500" />
-                                <span>Preferences: {formatBytes(stats.settingsBytes)}</span>
+                                Preferences: {formatBytes(stats.settingsBytes)}
                             </span>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            {/* Action Cards */}
-            <div className="space-y-3">
-                {/* Export & Import Row */}
+                {/* Action Cards */}
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
+                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/70 bg-background space-y-3">
                         <div className="space-y-1">
                             <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
                                 <Download className="size-3.5 text-blue-500" />
-                                <span>Export Configuration Backup</span>
+                                <span>Export Configuration</span>
                             </div>
                             <p className="text-[11px] text-muted-foreground">
-                                Download all preferences and timeout rules as an offline JSON
-                                archive.
+                                Download all preferences as an offline JSON archive.
                             </p>
                         </div>
                         <Button
@@ -194,19 +175,17 @@ export function DataSettings({
                             className="w-full font-semibold cursor-pointer"
                         >
                             <Download className="size-3.5" />
-                            <span>Export Backup JSON</span>
+                            Export Backup JSON
                         </Button>
                     </div>
-
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
+                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/70 bg-background space-y-3">
                         <div className="space-y-1">
                             <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
                                 <Upload className="size-3.5 text-emerald-500" />
                                 <span>Import Configuration</span>
                             </div>
                             <p className="text-[11px] text-muted-foreground">
-                                Restore preferences from a previously saved SRouter settings JSON
-                                file.
+                                Restore preferences from a saved SRouter settings JSON file.
                             </p>
                         </div>
                         <Button
@@ -217,14 +196,13 @@ export function DataSettings({
                             className="w-full font-semibold cursor-pointer"
                         >
                             <Upload className="size-3.5" />
-                            <span>Import Backup JSON</span>
+                            Import Backup JSON
                         </Button>
                     </div>
                 </div>
 
-                {/* Clear & Reset Row */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/70 bg-background space-y-3">
                         <div className="space-y-1">
                             <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
                                 <Trash2 className="size-3.5 text-rose-500" />
@@ -243,15 +221,14 @@ export function DataSettings({
                             className="w-full font-semibold cursor-pointer"
                         >
                             <Trash2 className="size-3.5" />
-                            <span>Clear Playground Sessions</span>
+                            Clear Sessions
                         </Button>
                     </div>
-
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
+                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/70 bg-background space-y-3">
                         <div className="space-y-1">
                             <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
                                 <RotateCcw className="size-3.5 text-amber-500" />
-                                <span>Factory Reset Settings</span>
+                                <span>Factory Reset</span>
                             </div>
                             <p className="text-[11px] text-muted-foreground">
                                 Restore all client gateway parameters and UI themes to factory
@@ -266,25 +243,24 @@ export function DataSettings({
                             className="w-full text-amber-500 hover:text-amber-600 font-semibold cursor-pointer"
                         >
                             <RotateCcw className="size-3.5" />
-                            <span>Reset All to Defaults</span>
+                            Reset All to Defaults
                         </Button>
                     </div>
                 </div>
-            </div>
+            </SettingsSection>
 
-            {/* Modal: Import Configuration */}
+            {/* Modals */}
             <Dialog open={isImportOpen} onOpenChange={setIsImportOpen}>
                 <DialogContent className="max-w-lg">
                     <DialogHeader>
                         <DialogTitle className="flex items-center gap-2 text-sm font-bold">
                             <FileJson className="size-4 text-emerald-500" />
-                            <span>Import Settings Configuration</span>
+                            Import Settings
                         </DialogTitle>
                         <DialogDescription className="text-xs">
                             Select a JSON file or paste exported JSON settings content below.
                         </DialogDescription>
                     </DialogHeader>
-
                     <div className="space-y-3 py-2">
                         <input
                             type="file"
@@ -301,20 +277,18 @@ export function DataSettings({
                             className="w-full font-semibold cursor-pointer"
                         >
                             <Upload className="size-3.5" />
-                            <span>Choose JSON File From Computer</span>
+                            Choose JSON File
                         </Button>
-
                         <div className="relative">
                             <textarea
                                 rows={6}
                                 value={importText}
                                 onChange={(e) => setImportText(e.target.value)}
                                 placeholder="Or paste JSON configuration here..."
-                                className="w-full rounded-lg border border-border/80 bg-muted/20 p-3 font-mono text-[11px] text-foreground focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                                className="w-full rounded-xl border border-border/70 bg-muted/20 p-3 font-mono text-[11px] text-foreground focus:outline-none focus:ring-1 focus:ring-emerald-500"
                             />
                         </div>
                     </div>
-
                     <DialogFooter className="gap-2 sm:gap-0">
                         <Button
                             type="button"
@@ -331,19 +305,18 @@ export function DataSettings({
                             className="font-semibold"
                         >
                             <Check className="size-3.5" />
-                            <span>Apply Imported Settings</span>
+                            Apply Imported Settings
                         </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
 
-            {/* Modal: Confirm Clear History */}
             <Dialog open={isClearOpen} onOpenChange={setIsClearOpen}>
                 <DialogContent className="max-w-md">
                     <DialogHeader>
                         <DialogTitle className="flex items-center gap-2 text-sm font-bold text-rose-500">
                             <Trash2 className="size-4" />
-                            <span>Clear Playground Chat History?</span>
+                            Clear Playground History?
                         </DialogTitle>
                         <DialogDescription className="text-xs">
                             This will permanently delete all cached conversations from this browser.
@@ -371,17 +344,16 @@ export function DataSettings({
                 </DialogContent>
             </Dialog>
 
-            {/* Modal: Confirm Reset Defaults */}
             <Dialog open={isResetOpen} onOpenChange={setIsResetOpen}>
                 <DialogContent className="max-w-md">
                     <DialogHeader>
                         <DialogTitle className="flex items-center gap-2 text-sm font-bold text-amber-500">
                             <AlertTriangle className="size-4" />
-                            <span>Reset Settings to Defaults?</span>
+                            Reset Settings to Defaults?
                         </DialogTitle>
                         <DialogDescription className="text-xs">
                             All custom timeout limits, retry backoffs, and playground parameters
-                            will be reset to default factory values.
+                            will be reset to factory values.
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter className="gap-2 sm:gap-0 pt-3">

--- a/apps/web/src/components/settings/GatewaySettings.tsx
+++ b/apps/web/src/components/settings/GatewaySettings.tsx
@@ -1,6 +1,7 @@
-import { Server, Clock, RefreshCw, Zap, Layers } from "lucide-react";
+import { Clock, RefreshCw, Server, Zap, Layers } from "lucide-react";
 import type { AppSettings } from "@/hooks/useSettings";
 import { Switch } from "@/components/ui/switch";
+import { SettingsSection, SettingsRow, SegmentedControl, ValueBadge } from "./settings-ui";
 
 interface GatewaySettingsProps {
     settings: AppSettings;
@@ -9,187 +10,93 @@ interface GatewaySettingsProps {
 
 export function GatewaySettings({ settings, updateSetting }: GatewaySettingsProps) {
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Server className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Gateway & Proxy Configuration
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Configure upstream connection limits, timeout windows, and automatic rate-limit
-                    failover mechanics.
-                </p>
-            </div>
+        <div className="space-y-5">
+            <SettingsSection
+                title="Gateway & Proxy"
+                description="Configure upstream connection limits, timeout windows, and automatic rate-limit failover mechanics."
+                icon={<Server className="size-4" />}
+            >
+                {/* Global Request Timeout */}
+                <SettingsRow
+                    title="Upstream Request Timeout"
+                    description="Maximum duration the gateway will wait for upstream LLM streaming responses before aborting."
+                    control={<ValueBadge>{settings.requestTimeoutSec}s</ValueBadge>}
+                />
+                <SegmentedControl
+                    options={[30, 60, 120, 180, 300].map((sec) => ({
+                        value: sec,
+                        label: `${sec}s`
+                    }))}
+                    value={settings.requestTimeoutSec}
+                    onChange={(sec) => updateSetting("requestTimeoutSec", sec)}
+                />
 
-            {/* Global Request Timeout */}
-            <div className="space-y-3">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Clock className="size-3.5 text-muted-foreground" />
-                            <span>Upstream Request Timeout</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Maximum duration the gateway will wait for upstream LLM streaming
-                            responses before aborting.
-                        </p>
-                    </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.requestTimeoutSec}s
-                    </span>
-                </div>
-
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[30, 60, 120, 180, 300].map((sec) => {
-                        const isActive = settings.requestTimeoutSec === sec;
-                        return (
-                            <button
-                                key={sec}
-                                type="button"
-                                onClick={() => updateSetting("requestTimeoutSec", sec)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {sec}s
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
-            {/* Auto Retry on Rate Limit (HTTP 429) */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex items-center justify-between gap-4">
-                    <div className="space-y-0.5">
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <RefreshCw className="size-3.5 text-muted-foreground" />
-                            <span>Auto-Retry on Rate Limit (HTTP 429)</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground">
-                            Automatically retry failed upstream requests with exponential backoff
-                            when provider quotas trigger 429 errors.
-                        </p>
-                    </div>
-                    <Switch
-                        checked={settings.autoRetryOn429}
-                        onCheckedChange={(val) => updateSetting("autoRetryOn429", val)}
+                {/* Auto Retry on Rate Limit */}
+                <div className="space-y-3 border-t border-border/60 pt-5">
+                    <SettingsRow
+                        title="Auto-Retry on Rate Limit"
+                        description="Automatically retry failed upstream requests with exponential backoff when provider quotas trigger 429 errors."
+                        control={
+                            <Switch
+                                checked={settings.autoRetryOn429}
+                                onCheckedChange={(val) => updateSetting("autoRetryOn429", val)}
+                            />
+                        }
                     />
-                </div>
 
-                {settings.autoRetryOn429 && (
-                    <div className="rounded-lg border border-border/70 bg-muted/20 divide-y divide-border/60">
-                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3.5">
-                            <div className="space-y-0.5">
-                                <div className="text-xs font-semibold text-foreground">
-                                    Maximum Retry Attempts
-                                </div>
-                                <div className="text-[11px] text-muted-foreground">
-                                    Number of sequential retry attempts before reporting failure.
-                                </div>
-                            </div>
-                            <div className="inline-flex items-center rounded-lg border border-border/80 bg-background/80 p-0.5 font-mono gap-1 self-start sm:self-auto">
-                                {[1, 2, 3, 5].map((retries) => {
-                                    const isActive = settings.maxRetries === retries;
-                                    return (
-                                        <button
-                                            key={retries}
-                                            type="button"
-                                            onClick={() => updateSetting("maxRetries", retries)}
-                                            className={`rounded-md px-2.5 py-1 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                                isActive
-                                                    ? "bg-foreground text-background shadow-xs font-bold"
-                                                    : "text-muted-foreground hover:text-foreground"
-                                            }`}
-                                        >
-                                            {retries}x
-                                        </button>
-                                    );
-                                })}
-                            </div>
+                    {settings.autoRetryOn429 && (
+                        <div className="space-y-4 rounded-xl border border-border/60 bg-muted/20 p-4">
+                            <SettingsRow
+                                title="Maximum Retry Attempts"
+                                description="Number of sequential retry attempts before reporting failure."
+                                control={
+                                    <SegmentedControl
+                                        options={[1, 2, 3, 5].map((retries) => ({
+                                            value: retries,
+                                            label: `${retries}x`
+                                        }))}
+                                        value={settings.maxRetries}
+                                        onChange={(retries) => updateSetting("maxRetries", retries)}
+                                    />
+                                }
+                            />
+                            <SettingsRow
+                                title="Base Backoff Delay"
+                                description="Initial exponential sleep duration before the first retry attempt."
+                                control={
+                                    <SegmentedControl
+                                        options={[500, 1000, 2000].map((ms) => ({
+                                            value: ms,
+                                            label: `${ms}ms`
+                                        }))}
+                                        value={settings.retryDelayMs}
+                                        onChange={(ms) => updateSetting("retryDelayMs", ms)}
+                                    />
+                                }
+                            />
                         </div>
-
-                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3.5">
-                            <div className="space-y-0.5">
-                                <div className="text-xs font-semibold text-foreground">
-                                    Base Backoff Delay
-                                </div>
-                                <div className="text-[11px] text-muted-foreground">
-                                    Initial exponential sleep duration before the first retry
-                                    attempt.
-                                </div>
-                            </div>
-                            <div className="inline-flex items-center rounded-lg border border-border/80 bg-background/80 p-0.5 font-mono gap-1 self-start sm:self-auto">
-                                {[500, 1000, 2000].map((ms) => {
-                                    const isActive = settings.retryDelayMs === ms;
-                                    return (
-                                        <button
-                                            key={ms}
-                                            type="button"
-                                            onClick={() => updateSetting("retryDelayMs", ms)}
-                                            className={`rounded-md px-2.5 py-1 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                                isActive
-                                                    ? "bg-foreground text-background shadow-xs font-bold"
-                                                    : "text-muted-foreground hover:text-foreground"
-                                            }`}
-                                        >
-                                            {ms}ms
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </div>
-
-            {/* Token Refresh Lead Time */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Zap className="size-3.5 text-foreground" />
-                            <span>OAuth Token Refresh Lead Time</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Proactively renew provider OAuth tokens before expiry to ensure zero
-                            request disruption.
-                        </p>
-                    </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.tokenRefreshLeadMin} min
-                    </span>
+                    )}
                 </div>
 
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[2, 5, 10, 15].map((min) => {
-                        const isActive = settings.tokenRefreshLeadMin === min;
-                        return (
-                            <button
-                                key={min}
-                                type="button"
-                                onClick={() => updateSetting("tokenRefreshLeadMin", min)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {min} min
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
+                {/* Token Refresh Lead Time */}
+                <SettingsRow
+                    title="OAuth Token Refresh Lead Time"
+                    description="Proactively renew provider OAuth tokens before expiry to ensure zero request disruption."
+                    control={<ValueBadge>{settings.tokenRefreshLeadMin} min</ValueBadge>}
+                />
+                <SegmentedControl
+                    options={[2, 5, 10, 15].map((min) => ({ value: min, label: `${min} min` }))}
+                    value={settings.tokenRefreshLeadMin}
+                    onChange={(min) => updateSetting("tokenRefreshLeadMin", min)}
+                />
+            </SettingsSection>
 
             {/* Architecture Info Banner */}
-            <div className="rounded-lg border border-border/60 bg-muted/20 p-3.5 flex items-start gap-3">
-                <Layers className="size-4 text-muted-foreground shrink-0 mt-0.5" />
-                <div className="text-[11px] text-muted-foreground leading-relaxed">
+            <div className="flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/20 p-4">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-card text-muted-foreground">
+                    <Layers className="size-4" />
+                </div>
+                <div className="text-[11px] leading-relaxed text-muted-foreground">
                     <strong className="text-foreground">Transparent Protocol Streaming:</strong> All
                     downstream clients receive raw Server-Sent Events (SSE) chunks immediately as
                     upstream providers output tokens, minimizing time-to-first-token (TTFT) without

--- a/apps/web/src/components/settings/LoggingSettings.tsx
+++ b/apps/web/src/components/settings/LoggingSettings.tsx
@@ -1,6 +1,7 @@
 import { Shield, Database, Coins, Lock, Check } from "lucide-react";
 import type { AppSettings } from "@/hooks/useSettings";
 import { Switch } from "@/components/ui/switch";
+import { SettingsSection, SettingsRow, SegmentedControl, ValueBadge } from "./settings-ui";
 
 interface LoggingSettingsProps {
     settings: AppSettings;
@@ -10,172 +11,132 @@ interface LoggingSettingsProps {
 export function LoggingSettings({ settings, updateSetting }: LoggingSettingsProps) {
     const loggingOptions = [
         {
-            id: "full",
+            id: "full" as const,
             title: "Full Payload",
             badge: "Recommended",
-            badgeColor: "bg-muted text-foreground border-border/80",
             desc: "Store full prompt messages and completion responses for inspection in the Logs view."
         },
         {
-            id: "metadata",
+            id: "metadata" as const,
             title: "Metadata Only",
             badge: "Privacy Focused",
-            badgeColor: "bg-muted text-muted-foreground border-border/80",
             desc: "Log only timestamps, model IDs, token usage, and latency. Message contents are discarded."
         },
         {
-            id: "disabled",
+            id: "disabled" as const,
             title: "Disabled",
             badge: "Zero Trace",
-            badgeColor: "bg-muted text-muted-foreground border-border/80",
             desc: "Do not record any request logs to SQLite database. Quota and tokens are still calculated."
         }
     ] as const;
 
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Shield className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Logging, Privacy & Audit
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Control data retention policies and request payload logging granularity stored
-                    in SQLite.
-                </p>
-            </div>
-
-            {/* Logging Level */}
-            <div className="space-y-3">
-                <label className="text-xs font-bold text-foreground">
-                    Request Payload Logging Level
-                </label>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                    {loggingOptions.map(({ id, title, badge, badgeColor, desc }) => {
-                        const isSelected = settings.loggingLevel === id;
-                        return (
-                            <button
-                                key={id}
-                                type="button"
-                                onClick={() => updateSetting("loggingLevel", id)}
-                                className={`flex flex-col text-left p-4 rounded-xl border transition-all cursor-pointer ${
-                                    isSelected
-                                        ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20 shadow-xs"
-                                        : "border-border/80 bg-background text-muted-foreground hover:border-border hover:text-foreground"
-                                }`}
-                            >
-                                <div className="flex items-center justify-between gap-2 mb-2">
-                                    <span className="text-xs font-bold text-foreground">
-                                        {title}
-                                    </span>
-                                    {isSelected ? (
-                                        <span className="flex size-4 items-center justify-center rounded-full bg-foreground text-background">
-                                            <Check className="size-2.5 stroke-[3]" />
+        <div className="space-y-5">
+            <SettingsSection
+                title="Logging, Privacy & Audit"
+                description="Control data retention policies and request payload logging granularity stored in SQLite."
+                icon={<Shield className="size-4" />}
+            >
+                {/* Logging Level */}
+                <div className="space-y-3">
+                    <label className="text-xs font-semibold text-foreground">
+                        Request Payload Logging Level
+                    </label>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                        {loggingOptions.map(({ id, title, badge, desc }) => {
+                            const isSelected = settings.loggingLevel === id;
+                            return (
+                                <button
+                                    key={id}
+                                    type="button"
+                                    onClick={() => updateSetting("loggingLevel", id)}
+                                    className={`flex flex-col text-left p-4 rounded-xl border transition-all cursor-pointer ${
+                                        isSelected
+                                            ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20"
+                                            : "border-border/70 bg-background text-muted-foreground hover:border-border hover:text-foreground"
+                                    }`}
+                                >
+                                    <div className="flex items-center justify-between gap-2 mb-2">
+                                        <span className="text-xs font-bold text-foreground">
+                                            {title}
                                         </span>
-                                    ) : (
-                                        <span
-                                            className={`text-[9.5px] font-semibold uppercase px-1.5 py-0.2 rounded border ${badgeColor}`}
-                                        >
-                                            {badge}
-                                        </span>
-                                    )}
-                                </div>
-                                <p className="text-[11px] text-muted-foreground leading-relaxed">
-                                    {desc}
-                                </p>
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
-            {/* Log Retention Policy */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Database className="size-3.5 text-muted-foreground" />
-                            <span>SQLite Log Retention Window</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Audit logs older than this threshold will be pruned automatically to
-                            conserve disk space.
-                        </p>
+                                        {isSelected ? (
+                                            <span className="flex size-4 items-center justify-center rounded-full bg-foreground text-background">
+                                                <Check className="size-2.5 stroke-[3]" />
+                                            </span>
+                                        ) : (
+                                            <span className="text-[9px] font-semibold uppercase px-1.5 py-0.2 rounded-full border border-border/70 text-muted-foreground">
+                                                {badge}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-[11px] leading-relaxed text-muted-foreground">
+                                        {desc}
+                                    </p>
+                                </button>
+                            );
+                        })}
                     </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.logRetentionDays === 365
-                            ? "1 Year"
-                            : `${settings.logRetentionDays} Days`}
-                    </span>
                 </div>
 
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[7, 14, 30, 90, 365].map((days) => {
-                        const isActive = settings.logRetentionDays === days;
-                        return (
-                            <button
-                                key={days}
-                                type="button"
-                                onClick={() => updateSetting("logRetentionDays", days)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {days === 365 ? "1 Year" : `${days}d`}
-                            </button>
-                        );
-                    })}
+                {/* Log Retention */}
+                <div className="space-y-3 border-t border-border/60 pt-5">
+                    <SettingsRow
+                        title="SQLite Log Retention Window"
+                        description="Audit logs older than this threshold will be pruned automatically to conserve disk space."
+                        control={
+                            <ValueBadge>
+                                {settings.logRetentionDays === 365
+                                    ? "1 Year"
+                                    : `${settings.logRetentionDays} Days`}
+                            </ValueBadge>
+                        }
+                    />
+                    <SegmentedControl
+                        options={[7, 14, 30, 90, 365].map((days) => ({
+                            value: days,
+                            label: days === 365 ? "1 Year" : `${days}d`
+                        }))}
+                        value={settings.logRetentionDays}
+                        onChange={(days) => updateSetting("logRetentionDays", days)}
+                    />
                 </div>
-            </div>
 
-            {/* Additional Privacy Switches */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <label className="text-xs font-bold text-foreground">
-                    Telemetry & Privacy Controls
-                </label>
-
-                <div className="rounded-lg border border-border/70 bg-muted/20 divide-y divide-border/60">
-                    {/* Record token usage */}
-                    <div className="flex items-center justify-between p-3.5 gap-4">
-                        <div className="space-y-0.5">
-                            <div className="text-xs font-semibold text-foreground flex items-center gap-1.5">
-                                <Coins className="size-3.5 text-muted-foreground" />
-                                <span>Record Token Usage & Pricing Estimates</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Aggregate prompt and completion tokens to calculate cost estimates
-                                on the Dashboard.
-                            </p>
-                        </div>
-                        <Switch
-                            checked={settings.recordTokenUsage}
-                            onCheckedChange={(val) => updateSetting("recordTokenUsage", val)}
+                {/* Privacy Switches */}
+                <div className="space-y-3 border-t border-border/60 pt-5">
+                    <label className="text-xs font-semibold text-foreground">
+                        Telemetry & Privacy Controls
+                    </label>
+                    <div className="rounded-xl border border-border/60 bg-muted/20 divide-y divide-border/50">
+                        <SettingsRow
+                            title="Record Token Usage & Pricing Estimates"
+                            description="Aggregate prompt and completion tokens to calculate cost estimates on the Dashboard."
+                            control={
+                                <Switch
+                                    checked={settings.recordTokenUsage}
+                                    onCheckedChange={(val) =>
+                                        updateSetting("recordTokenUsage", val)
+                                    }
+                                />
+                            }
+                            className="p-3.5"
                         />
-                    </div>
-
-                    {/* Mask sensitive headers */}
-                    <div className="flex items-center justify-between p-3.5 gap-4">
-                        <div className="space-y-0.5">
-                            <div className="text-xs font-semibold text-foreground flex items-center gap-1.5">
-                                <Lock className="size-3.5 text-muted-foreground" />
-                                <span>Mask Sensitive Auth Headers in Logs</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Automatically redact Authorization tokens and provider credentials
-                                in database records.
-                            </p>
-                        </div>
-                        <Switch
-                            checked={settings.maskSensitiveHeaders}
-                            onCheckedChange={(val) => updateSetting("maskSensitiveHeaders", val)}
+                        <SettingsRow
+                            title="Mask Sensitive Auth Headers in Logs"
+                            description="Automatically redact Authorization tokens and provider credentials in database records."
+                            control={
+                                <Switch
+                                    checked={settings.maskSensitiveHeaders}
+                                    onCheckedChange={(val) =>
+                                        updateSetting("maskSensitiveHeaders", val)
+                                    }
+                                />
+                            }
+                            className="p-3.5"
                         />
                     </div>
                 </div>
-            </div>
+            </SettingsSection>
         </div>
     );
 }

--- a/apps/web/src/components/settings/PlaygroundSettings.tsx
+++ b/apps/web/src/components/settings/PlaygroundSettings.tsx
@@ -1,6 +1,7 @@
 import { Terminal, Sparkles, Sliders, Radio, Code2, Bot, FileJson, PenTool } from "lucide-react";
 import type { AppSettings } from "@/hooks/useSettings";
 import { Switch } from "@/components/ui/switch";
+import { SettingsSection, SettingsRow, SegmentedControl, ValueBadge } from "./settings-ui";
 
 interface PlaygroundSettingsProps {
     settings: AppSettings;
@@ -32,163 +33,121 @@ const SYSTEM_PROMPT_PRESETS = [
 
 export function PlaygroundSettings({ settings, updateSetting }: PlaygroundSettingsProps) {
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Terminal className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Playground & Model Defaults
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Pre-populate default inference parameters when starting new sessions in the
-                    SRouter Playground.
-                </p>
-            </div>
-
-            {/* Temperature Slider */}
-            <div className="space-y-2">
-                <div className="flex items-center justify-between text-xs">
-                    <label className="font-bold text-foreground flex items-center gap-1.5">
-                        <Sliders className="size-3.5 text-muted-foreground" />
-                        <span>Default Temperature</span>
-                    </label>
-                    <span className="font-mono font-bold tabular-nums text-foreground px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.defaultTemperature.toFixed(2)}
-                    </span>
-                </div>
-                <input
-                    type="range"
-                    min="0"
-                    max="2"
-                    step="0.05"
-                    value={settings.defaultTemperature}
-                    onChange={(e) =>
-                        updateSetting("defaultTemperature", parseFloat(e.target.value))
-                    }
-                    className="w-full accent-foreground cursor-pointer h-1.5 rounded-lg bg-muted appearance-none"
-                />
-                <div className="flex justify-between text-[10px] font-mono text-muted-foreground">
-                    <span>0.0 (Deterministic / Code)</span>
-                    <span>0.7 (Balanced)</span>
-                    <span>2.0 (High Creativity)</span>
-                </div>
-            </div>
-
-            {/* Top P Slider */}
-            <div className="space-y-2 pt-5 border-t border-border/70">
-                <div className="flex items-center justify-between text-xs">
-                    <label className="font-bold text-foreground flex items-center gap-1.5">
-                        <Sparkles className="size-3.5 text-muted-foreground" />
-                        <span>Default Top P (Nucleus Sampling)</span>
-                    </label>
-                    <span className="font-mono font-bold tabular-nums text-foreground px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.defaultTopP.toFixed(2)}
-                    </span>
-                </div>
-                <input
-                    type="range"
-                    min="0"
-                    max="1"
-                    step="0.05"
-                    value={settings.defaultTopP}
-                    onChange={(e) => updateSetting("defaultTopP", parseFloat(e.target.value))}
-                    className="w-full accent-foreground cursor-pointer h-1.5 rounded-lg bg-muted appearance-none"
-                />
-                <div className="flex justify-between text-[10px] font-mono text-muted-foreground">
-                    <span>0.0 (Strict)</span>
-                    <span>0.95 (Standard)</span>
-                    <span>1.0 (Full Distribution)</span>
-                </div>
-            </div>
-
-            {/* Max Output Tokens */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground">
-                            Default Max Output Tokens
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Upper bound on tokens generated per single model completion.
-                        </p>
+        <div className="space-y-5">
+            <SettingsSection
+                title="Playground & Model Defaults"
+                description="Pre-populate default inference parameters when starting new sessions in the SRouter Playground."
+                icon={<Terminal className="size-4" />}
+            >
+                {/* Temperature */}
+                <div className="space-y-2">
+                    <SettingsRow
+                        title="Default Temperature"
+                        control={<ValueBadge>{settings.defaultTemperature.toFixed(2)}</ValueBadge>}
+                    />
+                    <input
+                        type="range"
+                        min="0"
+                        max="2"
+                        step="0.05"
+                        value={settings.defaultTemperature}
+                        onChange={(e) =>
+                            updateSetting("defaultTemperature", parseFloat(e.target.value))
+                        }
+                        className="w-full accent-foreground cursor-pointer h-1.5 rounded-lg bg-muted appearance-none"
+                    />
+                    <div className="flex justify-between text-[10px] font-mono text-muted-foreground">
+                        <span>0.0 (Deterministic)</span>
+                        <span>0.7 (Balanced)</span>
+                        <span>2.0 (Creative)</span>
                     </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.defaultMaxTokens.toLocaleString()} tokens
-                    </span>
                 </div>
 
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[1024, 2048, 4096, 8192, 16384].map((tokens) => {
-                        const isActive = settings.defaultMaxTokens === tokens;
-                        return (
+                {/* Top P */}
+                <div className="space-y-2 border-t border-border/60 pt-5">
+                    <SettingsRow
+                        title="Default Top P (Nucleus Sampling)"
+                        control={<ValueBadge>{settings.defaultTopP.toFixed(2)}</ValueBadge>}
+                    />
+                    <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.05"
+                        value={settings.defaultTopP}
+                        onChange={(e) => updateSetting("defaultTopP", parseFloat(e.target.value))}
+                        className="w-full accent-foreground cursor-pointer h-1.5 rounded-lg bg-muted appearance-none"
+                    />
+                    <div className="flex justify-between text-[10px] font-mono text-muted-foreground">
+                        <span>0.0 (Strict)</span>
+                        <span>0.95 (Standard)</span>
+                        <span>1.0 (Full Distribution)</span>
+                    </div>
+                </div>
+
+                {/* Max Tokens */}
+                <div className="space-y-3 border-t border-border/60 pt-5">
+                    <SettingsRow
+                        title="Default Max Output Tokens"
+                        description="Upper bound on tokens generated per single model completion."
+                        control={
+                            <ValueBadge>
+                                {settings.defaultMaxTokens.toLocaleString()} tokens
+                            </ValueBadge>
+                        }
+                    />
+                    <SegmentedControl
+                        options={[1024, 2048, 4096, 8192, 16384].map((tokens) => ({
+                            value: tokens,
+                            label: tokens >= 1000 ? `${tokens / 1024}k` : `${tokens}`
+                        }))}
+                        value={settings.defaultMaxTokens}
+                        onChange={(tokens) => updateSetting("defaultMaxTokens", tokens)}
+                    />
+                </div>
+
+                {/* Stream Toggle */}
+                <div className="border-t border-border/60 pt-5">
+                    <SettingsRow
+                        title="Stream Completion Tokens by Default"
+                        description="Enable real-time token streaming animation in the playground chat window."
+                        control={
+                            <Switch
+                                checked={settings.streamResponse}
+                                onCheckedChange={(val) => updateSetting("streamResponse", val)}
+                            />
+                        }
+                    />
+                </div>
+
+                {/* System Prompt */}
+                <div className="space-y-3 border-t border-border/60 pt-5">
+                    <SettingsRow
+                        title="Default System Prompt"
+                        description="Quick Preset Templates:"
+                    />
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                        {SYSTEM_PROMPT_PRESETS.map(({ name, icon: Icon, prompt }) => (
                             <button
-                                key={tokens}
+                                key={name}
                                 type="button"
-                                onClick={() => updateSetting("defaultMaxTokens", tokens)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
+                                onClick={() => updateSetting("systemPromptDefault", prompt)}
+                                className="flex items-center gap-1.5 rounded-lg border border-border/70 bg-background hover:bg-muted/60 p-2.5 text-left text-[11px] font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
                             >
-                                {tokens >= 1000 ? `${tokens / 1024}k` : tokens}
+                                <Icon className="size-3.5 shrink-0 text-foreground" />
+                                <span className="truncate">{name}</span>
                             </button>
-                        );
-                    })}
+                        ))}
+                    </div>
+                    <textarea
+                        rows={3}
+                        value={settings.systemPromptDefault}
+                        onChange={(e) => updateSetting("systemPromptDefault", e.target.value)}
+                        placeholder="Enter default system instructions..."
+                        className="w-full rounded-xl border border-border/70 bg-background p-3 text-xs font-mono text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
                 </div>
-            </div>
-
-            {/* Stream Response Toggle */}
-            <div className="flex items-center justify-between pt-5 border-t border-border/70 gap-4">
-                <div className="space-y-0.5">
-                    <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                        <Radio className="size-3.5 text-muted-foreground" />
-                        <span>Stream Completion Tokens by Default</span>
-                    </label>
-                    <p className="text-[11px] text-muted-foreground">
-                        Enable real-time token streaming animation in the playground chat window.
-                    </p>
-                </div>
-                <Switch
-                    checked={settings.streamResponse}
-                    onCheckedChange={(val) => updateSetting("streamResponse", val)}
-                />
-            </div>
-
-            {/* Default System Prompt */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <label className="text-xs font-bold text-foreground">
-                        Default System Prompt
-                    </label>
-                    <span className="text-[11px] text-muted-foreground">
-                        Quick Preset Templates:
-                    </span>
-                </div>
-
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                    {SYSTEM_PROMPT_PRESETS.map(({ name, icon: Icon, prompt }) => (
-                        <button
-                            key={name}
-                            type="button"
-                            onClick={() => updateSetting("systemPromptDefault", prompt)}
-                            className="flex items-center gap-1.5 rounded-lg border border-border/80 bg-background hover:bg-muted/60 p-2.5 text-left text-[11px] font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                        >
-                            <Icon className="size-3.5 shrink-0 text-foreground" />
-                            <span className="truncate">{name}</span>
-                        </button>
-                    ))}
-                </div>
-
-                <textarea
-                    rows={3}
-                    value={settings.systemPromptDefault}
-                    onChange={(e) => updateSetting("systemPromptDefault", e.target.value)}
-                    placeholder="Enter default system instructions..."
-                    className="w-full rounded-lg border border-border/80 bg-background p-3 text-xs font-mono text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-            </div>
+            </SettingsSection>
         </div>
     );
 }

--- a/apps/web/src/components/settings/SecuritySettings.tsx
+++ b/apps/web/src/components/settings/SecuritySettings.tsx
@@ -1,21 +1,10 @@
 import { useState, type FormEvent } from "react";
-import {
-    Check,
-    Copy,
-    KeyRound,
-    Lock,
-    Shield,
-    ShieldAlert,
-    ShieldCheck,
-    Terminal,
-    Unlock,
-    KeySquare,
-    Loader2
-} from "lucide-react";
+import { Check, Copy, Eye, EyeOff, KeyRound, Shield, ShieldAlert, Unlock } from "lucide-react";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SettingsSection, SegmentedControl, ValueBadge } from "./settings-ui";
 
 interface SecuritySettingsProps {
     requireApiKey: boolean;
@@ -41,6 +30,7 @@ export function SecuritySettings({
     const [confirmation, setConfirmation] = useState("");
     const [isChangingPassword, setIsChangingPassword] = useState(false);
     const [passwordError, setPasswordError] = useState<string | null>(null);
+    const [showPasswords, setShowPasswords] = useState(false);
 
     const getSnippet = (tab: CodeTab) => {
         if (tab === "curl") {
@@ -48,8 +38,8 @@ export function SecuritySettings({
   -H "Content-Type: application/json" \\
 ${
     requireApiKey
-        ? '  -H "Authorization: Bearer sr-live-your_virtual_key" \\\n'
-        : '  # -H "Authorization: Bearer <optional_key>" \\\n'
+        ? '  -H "Authorization: Bearer sr-liv..._key" \\\n'
+        : '  # -H "Authorization: Bearer ***" \\\n'
 }  -d '{
     "model": "antigravity/gemini-2.5-flash",
     "messages": [
@@ -139,108 +129,69 @@ print(response.choices[0].message.content)`;
     };
 
     return (
-        <div className="space-y-6">
-            {/* Section 1: API Key & Gateway Access Enforcement */}
-            <div className="rounded-xl border border-border/80 bg-card p-5 space-y-5 shadow-2xs">
-                <div>
-                    <div className="flex items-center gap-2">
-                        <KeyRound className="size-4 text-amber-500" />
-                        <h2 className="text-sm font-bold text-foreground tracking-tight">
-                            API Key Authentication Enforcement
-                        </h2>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-1">
-                        Control whether external clients must provide a Bearer API Key to access
-                        gateway routing endpoints.
-                    </p>
-                </div>
-
-                <div className="rounded-lg border border-border/70 bg-muted/20 p-4 space-y-4">
-                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-border/60 pb-4">
+        <div className="space-y-5">
+            {/* Section 1: API Key Enforcement */}
+            <SettingsSection
+                title="API Key Authentication"
+                description="Control whether external clients must provide a Bearer API Key to access gateway routing endpoints."
+                icon={<KeyRound className="size-4" />}
+            >
+                <div className="flex flex-col gap-4 rounded-xl border border-border/60 bg-muted/20 p-4">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <div className="space-y-1">
-                            <div className="flex items-center gap-2 flex-wrap">
-                                <span className="text-xs font-bold text-foreground">
-                                    Enforce Bearer Authentication
-                                </span>
+                            <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+                                Enforce Bearer Authentication
                                 {requireApiKey ? (
-                                    <span className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-600 dark:text-emerald-400">
-                                        <ShieldCheck className="size-3" />
-                                        <span>Protected (Enforced)</span>
+                                    <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[9px] font-bold text-emerald-500">
+                                        <Shield className="size-2.5" />
+                                        Protected
                                     </span>
                                 ) : (
-                                    <span className="inline-flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400">
-                                        <Unlock className="size-3" />
-                                        <span>Open Access (Optional)</span>
+                                    <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[9px] font-bold text-amber-500">
+                                        <Unlock className="size-2.5" />
+                                        Open
                                     </span>
                                 )}
                             </div>
-                            <p className="text-[11px] text-muted-foreground leading-relaxed max-w-xl">
+                            <p className="text-[11px] leading-relaxed text-muted-foreground">
                                 {requireApiKey
-                                    ? "Gateway endpoints will reject unauthenticated requests with HTTP 401 Unauthorized unless a valid virtual SRouter key is supplied in the Authorization header."
-                                    : "Open access mode: Anyone can query SRouter models without an API key. Ideal for localhost development, IDE extensions, or private network deployments."}
+                                    ? "Gateway endpoints will reject unauthenticated requests with HTTP 401."
+                                    : "Open access mode: anyone can query without an API key."}
                             </p>
                         </div>
-
-                        {/* Action Switch Buttons */}
-                        <div className="inline-flex items-center rounded-lg border border-border/80 bg-background/90 p-1 shadow-2xs self-start sm:self-auto shrink-0 font-mono gap-1">
-                            <button
-                                type="button"
-                                disabled={isUpdating}
-                                onClick={() => onToggleRequireApiKey(false)}
-                                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-all cursor-pointer ${
-                                    !requireApiKey
-                                        ? "bg-foreground text-background shadow-xs font-bold"
-                                        : "text-muted-foreground hover:text-foreground"
-                                }`}
-                            >
-                                <Unlock className="size-3" />
-                                <span>Disabled</span>
-                            </button>
-                            <button
-                                type="button"
-                                disabled={isUpdating}
-                                onClick={() => onToggleRequireApiKey(true)}
-                                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-all cursor-pointer ${
-                                    requireApiKey
-                                        ? "bg-foreground text-background shadow-xs font-bold"
-                                        : "text-muted-foreground hover:text-foreground"
-                                }`}
-                            >
-                                <Lock className="size-3" />
-                                <span>Required</span>
-                            </button>
-                        </div>
+                        <SegmentedControl
+                            options={[
+                                { value: false, label: "Disabled" },
+                                { value: true, label: "Required" }
+                            ]}
+                            value={requireApiKey}
+                            onChange={onToggleRequireApiKey}
+                            disabled={isUpdating}
+                        />
                     </div>
 
                     {/* Client Request Code Preview */}
-                    <div className="space-y-2">
+                    <div className="space-y-2 pt-2 border-t border-border/50">
                         <div className="flex items-center justify-between">
-                            <span className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
-                                Client Request Integration Example:
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                                Client Integration Example
                             </span>
-                            <div className="inline-flex items-center gap-0.5 rounded-lg border border-border/80 bg-background/90 p-0.5 font-mono">
-                                {(["curl", "typescript", "python"] as const).map((tab) => (
-                                    <button
-                                        key={tab}
-                                        type="button"
-                                        onClick={() => setCodeTab(tab)}
-                                        className={`px-2.5 py-1 text-[10.5px] font-semibold rounded-md capitalize transition-colors cursor-pointer ${
-                                            codeTab === tab
-                                                ? "bg-foreground text-background shadow-xs font-bold"
-                                                : "text-muted-foreground hover:text-foreground"
-                                        }`}
-                                    >
-                                        {tab}
-                                    </button>
-                                ))}
-                            </div>
+                            <SegmentedControl
+                                options={[
+                                    { value: "curl", label: "cURL" },
+                                    { value: "typescript", label: "TS" },
+                                    { value: "python", label: "Python" }
+                                ]}
+                                value={codeTab}
+                                onChange={setCodeTab}
+                            />
                         </div>
 
-                        <div className="relative rounded-lg border border-border/80 bg-background p-3 font-mono text-[11px] text-foreground overflow-x-auto">
+                        <div className="relative rounded-xl border border-border/70 bg-background p-3 font-mono text-[11px] leading-relaxed text-foreground overflow-x-auto">
                             <button
                                 type="button"
                                 onClick={handleCopy}
-                                className="absolute top-2.5 right-2.5 flex items-center gap-1 rounded bg-muted/80 hover:bg-muted px-2 py-1 text-[10px] font-semibold text-foreground transition-colors cursor-pointer"
+                                className="absolute top-2 right-2 flex items-center gap-1 rounded-lg bg-muted/70 px-2 py-1 text-[10px] font-semibold text-foreground opacity-0 transition-opacity hover:bg-muted focus:opacity-100 group-hover:opacity-100 cursor-pointer"
                                 title="Copy code"
                             >
                                 {copied ? (
@@ -254,37 +205,28 @@ print(response.choices[0].message.content)`;
                         </div>
                     </div>
                 </div>
-            </div>
+            </SettingsSection>
 
-            {/* Section 2: Admin Password & Control Plane Security */}
-            <div className="rounded-xl border border-border/80 bg-card p-5 space-y-4 shadow-2xs">
-                <div>
-                    <div className="flex items-center gap-2">
-                        <Shield className="size-4 text-emerald-500" />
-                        <h2 className="text-sm font-bold text-foreground tracking-tight">
-                            Admin Control Plane Password
-                        </h2>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-1">
-                        Update the master administrator password used to lock settings, provider
-                        credentials, and token configurations.
-                    </p>
-                </div>
-
-                <form onSubmit={handleChangePassword} className="space-y-3.5 max-w-lg">
+            {/* Section 2: Admin Password */}
+            <SettingsSection
+                title="Admin Control Plane Password"
+                description="Update the master administrator password used to lock settings, provider credentials, and token configurations."
+                icon={<Shield className="size-4" />}
+            >
+                <form onSubmit={handleChangePassword} className="space-y-4 max-w-lg">
                     {passwordError && (
-                        <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
+                        <div className="flex items-start gap-2 rounded-xl border border-destructive/20 bg-destructive/10 p-3 text-xs text-destructive">
                             <ShieldAlert className="size-4 shrink-0 mt-0.5" />
                             <span>{passwordError}</span>
                         </div>
                     )}
 
-                    <div className="space-y-1">
+                    <div className="space-y-1.5">
                         <label className="text-xs font-semibold text-foreground">
                             Current Password
                         </label>
                         <Input
-                            type="password"
+                            type={showPasswords ? "text" : "password"}
                             placeholder="Enter current admin password"
                             value={currentPassword}
                             onChange={(e) => setCurrentPassword(e.target.value)}
@@ -292,25 +234,25 @@ print(response.choices[0].message.content)`;
                         />
                     </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <div className="space-y-1">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
+                        <div className="space-y-1.5">
                             <label className="text-xs font-semibold text-foreground">
                                 New Password
                             </label>
                             <Input
-                                type="password"
+                                type={showPasswords ? "text" : "password"}
                                 placeholder="New password"
                                 value={newPassword}
                                 onChange={(e) => setNewPassword(e.target.value)}
                                 required
                             />
                         </div>
-                        <div className="space-y-1">
+                        <div className="space-y-1.5">
                             <label className="text-xs font-semibold text-foreground">
                                 Confirm New Password
                             </label>
                             <Input
-                                type="password"
+                                type={showPasswords ? "text" : "password"}
                                 placeholder="Repeat new password"
                                 value={confirmation}
                                 onChange={(e) => setConfirmation(e.target.value)}
@@ -319,26 +261,31 @@ print(response.choices[0].message.content)`;
                         </div>
                     </div>
 
-                    <Button
-                        type="submit"
-                        disabled={isChangingPassword}
-                        size="sm"
-                        className="mt-2 font-semibold"
-                    >
-                        {isChangingPassword ? (
-                            <>
-                                <Loader2 className="size-3.5 animate-spin" />
-                                <span>Updating Password...</span>
-                            </>
-                        ) : (
-                            <>
-                                <KeySquare className="size-3.5" />
-                                <span>Update Admin Password</span>
-                            </>
-                        )}
-                    </Button>
+                    <div className="flex items-center gap-3">
+                        <Button
+                            type="submit"
+                            size="sm"
+                            disabled={isChangingPassword}
+                            className="font-semibold"
+                        >
+                            <KeyRound className="size-3.5" />
+                            <span>{isChangingPassword ? "Updating..." : "Update Password"}</span>
+                        </Button>
+                        <button
+                            type="button"
+                            onClick={() => setShowPasswords(!showPasswords)}
+                            className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground cursor-pointer transition-colors"
+                        >
+                            {showPasswords ? (
+                                <EyeOff className="size-3" />
+                            ) : (
+                                <Eye className="size-3" />
+                            )}
+                            <span>{showPasswords ? "Hide" : "Show"} passwords</span>
+                        </button>
+                    </div>
                 </form>
-            </div>
+            </SettingsSection>
         </div>
     );
 }

--- a/apps/web/src/components/settings/SystemSettings.tsx
+++ b/apps/web/src/components/settings/SystemSettings.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { useVersion, GITHUB_REPO } from "@/hooks/useVersion";
+import { SettingsSection, SettingsRow, ValueBadge } from "./settings-ui";
 
 interface SystemSettingsProps {
     apiBase: string;
@@ -76,248 +77,229 @@ export function SystemSettings({ apiBase }: SystemSettingsProps) {
     };
 
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Cpu className="size-4 text-cyan-500" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        System Diagnostics & Runtime Architecture
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Inspect core runtime engine, database storage architecture, and gateway
-                    connection health.
-                </p>
-            </div>
-
-            {/* Diagnostic Specs Grid */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs">
-                {/* Gateway Core Version & GitHub Tag Card */}
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-2">
-                    <div className="flex items-center justify-between">
-                        <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                            Gateway Core Version
-                        </span>
-                        <button
-                            type="button"
-                            onClick={handleCheckUpdates}
-                            disabled={isChecking}
-                            className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                            title="Check for GitHub tag updates"
-                        >
-                            <RefreshCw
-                                className={`size-3 ${isChecking ? "animate-spin text-cyan-500" : ""}`}
-                            />
-                            <span>{isChecking ? "Checking..." : "Check update"}</span>
-                        </button>
+        <div className="space-y-5">
+            <SettingsSection
+                title="System Diagnostics & Runtime"
+                description="Inspect core runtime engine, database storage architecture, and gateway connection health."
+                icon={<Cpu className="size-4" />}
+            >
+                {/* Diagnostic Specs Grid */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs">
+                    <div className="p-4 rounded-xl border border-border/70 bg-muted/20 space-y-2">
+                        <div className="flex items-center justify-between">
+                            <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                                Gateway Core Version
+                            </span>
+                            <button
+                                type="button"
+                                onClick={handleCheckUpdates}
+                                disabled={isChecking}
+                                className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                title="Check for GitHub tag updates"
+                            >
+                                <RefreshCw
+                                    className={`size-3 ${isChecking ? "animate-spin text-cyan-500" : ""}`}
+                                />
+                                <span>{isChecking ? "Checking..." : "Check update"}</span>
+                            </button>
+                        </div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-bold text-foreground font-mono">
+                                {currentVersion}
+                            </span>
+                            <span className="inline-flex items-center rounded-md border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.2 text-[9px] font-semibold text-cyan-500">
+                                Release Candidate
+                            </span>
+                            {isChecking ? (
+                                <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-0.2 text-[9px] text-muted-foreground animate-pulse">
+                                    Checking GitHub...
+                                </span>
+                            ) : hasUpdate ? (
+                                <a
+                                    href={releaseUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 hover:bg-amber-500/25 px-2 py-0.5 text-[9px] font-bold text-amber-500 transition-colors"
+                                >
+                                    <ArrowUpCircle className="size-2.5" />
+                                    {latestVersion}
+                                    <ExternalLink className="size-2" />
+                                </a>
+                            ) : latestVersion ? (
+                                <span className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.2 text-[9px] font-semibold text-emerald-500">
+                                    <CheckCircle2 className="size-2.5" />
+                                    Up to date
+                                </span>
+                            ) : null}
+                        </div>
+                        {lastChecked && (
+                            <div className="text-[10px] font-mono text-muted-foreground/70">
+                                Checked at {lastChecked.toLocaleTimeString()}
+                            </div>
+                        )}
                     </div>
 
-                    <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-bold text-foreground font-mono">
-                            {currentVersion}
+                    <div className="p-4 rounded-xl border border-border/70 bg-muted/20 space-y-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                            Persistence
                         </span>
-                        <span className="inline-flex items-center rounded-md border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.2 text-[9.5px] font-semibold text-cyan-500">
-                            Release Candidate
-                        </span>
+                        <div className="font-bold text-foreground flex items-center gap-1.5">
+                            <Database className="size-3.5 text-amber-500" />
+                            <span>SQLite WAL Mode</span>
+                        </div>
+                    </div>
 
-                        {/* GitHub Tag / Update Status Badge */}
-                        {isChecking ? (
-                            <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-0.2 text-[9.5px] text-muted-foreground animate-pulse">
-                                Checking GitHub...
-                            </span>
-                        ) : hasUpdate ? (
+                    <div className="p-4 rounded-xl border border-border/70 bg-muted/20 space-y-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                            Framework
+                        </span>
+                        <div className="font-bold text-foreground flex items-center gap-1.5">
+                            <Server className="size-3.5 text-blue-500" />
+                            <span>Hono (Node.js)</span>
+                        </div>
+                    </div>
+
+                    <div className="p-4 rounded-xl border border-border/70 bg-muted/20 space-y-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                            Compatibility
+                        </span>
+                        <div className="font-bold text-emerald-500 flex items-center gap-1.5">
+                            <span className="size-2 rounded-full bg-emerald-500 animate-pulse" />
+                            <span>OpenAI v1 + Anthropic SSE</span>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Update Banner */}
+                {hasUpdate && (
+                    <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 space-y-3">
+                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+                            <div className="flex items-center gap-2">
+                                <ArrowUpCircle className="size-4 text-amber-500 shrink-0" />
+                                <div>
+                                    <span className="text-xs font-bold text-foreground">
+                                        New Version Available ({latestVersion})
+                                    </span>
+                                    <p className="text-[11px] text-muted-foreground mt-0.5">
+                                        A newer release tag has been published on GitHub.
+                                    </p>
+                                </div>
+                            </div>
                             <a
                                 href={releaseUrl}
                                 target="_blank"
                                 rel="noreferrer"
-                                className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 hover:bg-amber-500/25 px-2 py-0.5 text-[10px] font-bold text-amber-500 transition-colors shadow-2xs"
-                                title={`New tag ${latestVersion} available on GitHub`}
+                                className="inline-flex items-center gap-1.5 rounded-lg border border-amber-500/40 bg-amber-500 text-black px-3 py-1.5 text-xs font-bold hover:bg-amber-400 transition-colors shrink-0"
                             >
-                                <ArrowUpCircle className="size-3 text-amber-500" />
-                                <span>Update Available: {latestVersion}</span>
-                                <ExternalLink className="size-2.5" />
+                                View Release
+                                <ExternalLink className="size-3" />
                             </a>
-                        ) : latestVersion ? (
-                            <span className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.2 text-[9.5px] font-semibold text-emerald-600 dark:text-emerald-400">
-                                <CheckCircle2 className="size-3" />
-                                <span>Up to date ({latestVersion})</span>
-                            </span>
-                        ) : null}
-                    </div>
-
-                    {lastChecked && (
-                        <div className="text-[10px] font-mono text-muted-foreground/70">
-                            Checked with GitHub at {lastChecked.toLocaleTimeString()}
                         </div>
-                    )}
-                </div>
-
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-1.5">
-                    <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                        Persistence & Database Engine
-                    </span>
-                    <div className="font-bold text-foreground flex items-center gap-1.5">
-                        <Database className="size-3.5 text-amber-500" />
-                        <span>SQLite WAL Mode (srouter.db)</span>
-                    </div>
-                </div>
-
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-1.5">
-                    <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                        API Gateway Framework
-                    </span>
-                    <div className="font-bold text-foreground flex items-center gap-1.5">
-                        <Server className="size-3.5 text-blue-500" />
-                        <span>Hono Framework (Node.js / Bun)</span>
-                    </div>
-                </div>
-
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-1.5">
-                    <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                        Protocol Compatibility
-                    </span>
-                    <div className="font-bold text-emerald-500 flex items-center gap-1.5">
-                        <span className="size-2 rounded-full bg-emerald-500 animate-pulse" />
-                        <span>OpenAI v1 + Anthropic Messages SSE</span>
-                    </div>
-                </div>
-            </div>
-
-            {/* Update Notification Banner if update is available */}
-            {hasUpdate && (
-                <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 space-y-3 shadow-xs">
-                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                            <ArrowUpCircle className="size-4 text-amber-500 shrink-0" />
-                            <div>
-                                <span className="text-xs font-bold text-foreground">
-                                    New SRouter Version Available ({latestVersion})
-                                </span>
-                                <p className="text-[11px] text-muted-foreground mt-0.5">
-                                    A newer release tag has been published on GitHub ({GITHUB_REPO}
-                                    ).
-                                </p>
+                        <div className="rounded-xl bg-background/80 border border-border/70 p-2.5 flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-2 min-w-0 font-mono text-[11px] text-foreground overflow-x-auto">
+                                <Terminal className="size-3.5 text-muted-foreground shrink-0" />
+                                <code>git pull origin main && pnpm install</code>
                             </div>
-                        </div>
-
-                        <a
-                            href={releaseUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="inline-flex items-center gap-1.5 rounded-lg border border-amber-500/40 bg-amber-500 text-black px-3 py-1.5 text-xs font-bold hover:bg-amber-400 transition-colors shadow-2xs self-start sm:self-auto shrink-0"
-                        >
-                            <span>View Release</span>
-                            <ExternalLink className="size-3" />
-                        </a>
-                    </div>
-
-                    <div className="rounded-lg bg-background/80 border border-border/70 p-2.5 flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-2 min-w-0 font-mono text-[11px] text-foreground overflow-x-auto">
-                            <Terminal className="size-3.5 text-muted-foreground shrink-0" />
-                            <code>git pull origin main && pnpm install</code>
-                        </div>
-                        <button
-                            type="button"
-                            onClick={handleCopyUpdateCommand}
-                            className="flex items-center gap-1 px-2 py-1 rounded bg-muted hover:bg-muted/80 text-[10px] font-semibold text-foreground transition-colors shrink-0 cursor-pointer"
-                        >
-                            {copiedCommand ? (
-                                <Check className="size-3 text-emerald-500" />
-                            ) : (
-                                <Copy className="size-3" />
-                            )}
-                            <span>{copiedCommand ? "Copied" : "Copy"}</span>
-                        </button>
-                    </div>
-                </div>
-            )}
-
-            {/* Live Gateway Health & Latency Test */}
-            <div className="rounded-xl border border-border/80 bg-muted/20 p-4 space-y-3">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-                    <div className="space-y-0.5">
-                        <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Activity className="size-3.5 text-emerald-500" />
-                            <span>Live Gateway Latency Check</span>
-                        </div>
-                        <p className="text-[11px] text-muted-foreground">
-                            Measure roundtrip HTTP ping latency from browser to the SRouter local
-                            API daemon.
-                        </p>
-                    </div>
-
-                    <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={isPinging}
-                        onClick={handlePing}
-                        className="self-start sm:self-auto font-semibold cursor-pointer shrink-0"
-                    >
-                        {isPinging ? (
-                            <Loader2 className="size-3.5 animate-spin" />
-                        ) : (
-                            <RefreshCw className="size-3.5" />
-                        )}
-                        <span>{isPinging ? "Pinging..." : "Test Latency"}</span>
-                    </Button>
-                </div>
-
-                {pingLatency !== null && (
-                    <div className="flex items-center justify-between p-3 rounded-lg border border-border/70 bg-background text-xs">
-                        <div className="flex items-center gap-2">
-                            {pingLatency >= 0 ? (
-                                <span className="flex items-center gap-1.5 font-bold text-emerald-500">
-                                    <CheckCircle2 className="size-4" />
-                                    <span>Gateway Healthy & Online</span>
-                                </span>
-                            ) : (
-                                <span className="font-bold text-destructive">
-                                    Gateway Offline / Unreachable
-                                </span>
-                            )}
-                        </div>
-                        <div className="flex items-center gap-3 text-muted-foreground text-[11px] font-mono">
-                            {pingLatency >= 0 && (
-                                <span className="text-foreground font-bold tabular-nums">
-                                    Roundtrip:{" "}
-                                    <span className="text-emerald-500">{pingLatency}ms</span>
-                                </span>
-                            )}
-                            {lastPingTime && <span>Checked at {lastPingTime}</span>}
+                            <button
+                                type="button"
+                                onClick={handleCopyUpdateCommand}
+                                className="flex items-center gap-1 px-2 py-1 rounded bg-muted hover:bg-muted/80 text-[10px] font-semibold text-foreground transition-colors shrink-0 cursor-pointer"
+                            >
+                                {copiedCommand ? (
+                                    <Check className="size-3 text-emerald-500" />
+                                ) : (
+                                    <Copy className="size-3" />
+                                )}
+                                <span>{copiedCommand ? "Copied" : "Copy"}</span>
+                            </button>
                         </div>
                     </div>
                 )}
-            </div>
+
+                {/* Live Gateway Health */}
+                <div className="rounded-xl border border-border/70 bg-muted/20 p-4 space-y-3">
+                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                        <div className="space-y-0.5">
+                            <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
+                                <Activity className="size-3.5 text-emerald-500" />
+                                <span>Live Gateway Latency Check</span>
+                            </div>
+                            <p className="text-[11px] text-muted-foreground">
+                                Measure roundtrip HTTP ping latency from browser to the SRouter API
+                                daemon.
+                            </p>
+                        </div>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            disabled={isPinging}
+                            onClick={handlePing}
+                            className="shrink-0 font-semibold cursor-pointer"
+                        >
+                            {isPinging ? (
+                                <Loader2 className="size-3.5 animate-spin" />
+                            ) : (
+                                <RefreshCw className="size-3.5" />
+                            )}
+                            <span>{isPinging ? "Pinging..." : "Test Latency"}</span>
+                        </Button>
+                    </div>
+                    {pingLatency !== null && (
+                        <div className="flex items-center justify-between p-3 rounded-xl border border-border/70 bg-background text-xs">
+                            <div className="flex items-center gap-2">
+                                {pingLatency >= 0 ? (
+                                    <span className="flex items-center gap-1.5 font-bold text-emerald-500">
+                                        <CheckCircle2 className="size-4" />
+                                        <span>Gateway Healthy</span>
+                                    </span>
+                                ) : (
+                                    <span className="font-bold text-destructive">
+                                        Gateway Offline
+                                    </span>
+                                )}
+                            </div>
+                            <div className="flex items-center gap-3 text-muted-foreground text-[11px] font-mono">
+                                {pingLatency >= 0 && (
+                                    <span className="text-foreground font-bold tabular-nums">
+                                        Roundtrip:{" "}
+                                        <span className="text-emerald-500">{pingLatency}ms</span>
+                                    </span>
+                                )}
+                                {lastPingTime && <span>at {lastPingTime}</span>}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </SettingsSection>
 
             {/* Quick Reference Links */}
-            <div className="space-y-3 pt-2">
-                <span className="text-xs font-bold text-foreground">
-                    Quick Reference & Resources
+            <div className="rounded-2xl border border-border/70 bg-card p-5">
+                <span className="text-xs font-bold text-foreground block mb-3">
+                    Quick Reference
                 </span>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                     <a
                         href={`https://github.com/${GITHUB_REPO}`}
                         target="_blank"
                         rel="noreferrer"
-                        className="flex items-center justify-between p-3 rounded-lg border border-border/80 bg-background hover:bg-muted/40 text-xs font-medium text-foreground transition-colors group"
+                        className="flex items-center justify-between p-3 rounded-xl border border-border/70 bg-background hover:bg-muted/40 text-xs font-medium text-foreground transition-colors group"
                     >
                         <span className="flex items-center gap-2">
                             <Layers className="size-3.5 text-muted-foreground group-hover:text-foreground" />
-                            <span>SRouter GitHub Repository</span>
+                            <span>GitHub Repository</span>
                         </span>
                         <ExternalLink className="size-3 text-muted-foreground group-hover:text-foreground" />
                     </a>
-
                     <a
                         href={tagsUrl}
                         target="_blank"
                         rel="noreferrer"
-                        className="flex items-center justify-between p-3 rounded-lg border border-border/80 bg-background hover:bg-muted/40 text-xs font-medium text-foreground transition-colors group"
+                        className="flex items-center justify-between p-3 rounded-xl border border-border/70 bg-background hover:bg-muted/40 text-xs font-medium text-foreground transition-colors group"
                     >
                         <span className="flex items-center gap-2">
                             <GitBranch className="size-3.5 text-muted-foreground group-hover:text-foreground" />
-                            <span>GitHub Releases & Tags</span>
+                            <span>Releases &amp; Tags</span>
                         </span>
                         <ExternalLink className="size-3 text-muted-foreground group-hover:text-foreground" />
                     </a>

--- a/apps/web/src/components/settings/settings-ui.tsx
+++ b/apps/web/src/components/settings/settings-ui.tsx
@@ -1,0 +1,133 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/** Card wrapper for a settings section with a title + description header. */
+export function SettingsSection({
+    title,
+    description,
+    icon,
+    className,
+    children
+}: {
+    title: string;
+    description?: string;
+    icon?: ReactNode;
+    className?: string;
+    children: ReactNode;
+}) {
+    return (
+        <section
+            className={cn(
+                "rounded-2xl border border-border/70 bg-card p-5 shadow-2xs transition-colors",
+                className
+            )}
+        >
+            <div className="mb-5 flex items-start gap-3">
+                {icon && (
+                    <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-foreground">
+                        {icon}
+                    </div>
+                )}
+                <div className="min-w-0">
+                    <h2 className="text-sm font-bold tracking-tight text-foreground">{title}</h2>
+                    {description && (
+                        <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                            {description}
+                        </p>
+                    )}
+                </div>
+            </div>
+            <div className="space-y-5">{children}</div>
+        </section>
+    );
+}
+
+/** A label + optional description + control row. */
+export function SettingsRow({
+    title,
+    description,
+    control,
+    className
+}: {
+    title: string;
+    description?: string;
+    control?: ReactNode;
+    className?: string;
+}) {
+    return (
+        <div
+            className={cn(
+                "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+                className
+            )}
+        >
+            <div className="min-w-0 space-y-0.5">
+                <div className="text-xs font-semibold text-foreground">{title}</div>
+                {description && (
+                    <p className="text-[11px] leading-relaxed text-muted-foreground">
+                        {description}
+                    </p>
+                )}
+            </div>
+            {control && <div className="shrink-0">{control}</div>}
+        </div>
+    );
+}
+
+/** Pill-style segmented control for mutually exclusive options. */
+export function SegmentedControl<T extends string | number | boolean>({
+    options,
+    value,
+    onChange,
+    disabled,
+    className
+}: {
+    options: Array<{ value: T; label: string }>;
+    value: T;
+    onChange: (value: T) => void;
+    disabled?: boolean;
+    className?: string;
+}) {
+    return (
+        <div
+            role="tablist"
+            className={cn(
+                "inline-flex items-center gap-0.5 rounded-lg border border-border/70 bg-muted/40 p-1",
+                className
+            )}
+        >
+            {options.map((option) => {
+                const isActive = option.value === value;
+                return (
+                    <button
+                        key={String(option.value)}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        disabled={disabled}
+                        onClick={() => onChange(option.value)}
+                        className={cn(
+                            "rounded-md px-3 py-1.5 text-xs font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50",
+                            isActive
+                                ? "bg-foreground text-background shadow-xs"
+                                : "text-muted-foreground hover:text-foreground"
+                        )}
+                    >
+                        {option.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+/** Value badge shown next to a numeric/derived setting. */
+export function ValueBadge({ children }: { children: ReactNode }) {
+    return (
+        <span className="inline-flex items-center rounded-md border border-border/70 bg-muted/50 px-2 py-0.5 font-mono text-xs font-bold tabular-nums text-foreground">
+            {children}
+        </span>
+    );
+}
+
+export type { ComponentProps };

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -10,6 +10,7 @@ import {
     RotateCcw,
     Server,
     Shield,
+    SlidersHorizontal,
     Terminal,
     ArrowUpCircle
 } from "lucide-react";
@@ -19,6 +20,7 @@ import { useTheme } from "@/context/Theme";
 import { useSettings } from "@/hooks/useSettings";
 import { useVersion } from "@/hooks/useVersion";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 import { SecuritySettings } from "@/components/settings/SecuritySettings";
 import { GatewaySettings } from "@/components/settings/GatewaySettings";
@@ -107,47 +109,66 @@ function SettingsPage() {
         updateServerMutation.mutate(value);
     };
 
-    const tabs: { id: SettingsTab; label: string; icon: typeof Palette; hasBadge?: boolean }[] = [
-        { id: "security", label: "Security & API Key", icon: KeyRound },
-        { id: "gateway", label: "Gateway & Proxy", icon: Server },
-        { id: "appearance", label: "Appearance", icon: Palette },
-        { id: "logging", label: "Logging & Privacy", icon: Shield },
-        { id: "playground", label: "Playground Defaults", icon: Terminal },
-        { id: "data", label: "Data & Storage", icon: Database },
-        { id: "system", label: "System Diagnostics", icon: Cpu, hasBadge: hasUpdate }
+    const tabs: {
+        id: SettingsTab;
+        label: string;
+        hint: string;
+        icon: typeof Palette;
+        hasBadge?: boolean;
+    }[] = [
+        { id: "security", label: "Security", hint: "API keys & password", icon: KeyRound },
+        { id: "gateway", label: "Gateway", hint: "Timeouts & retries", icon: Server },
+        { id: "appearance", label: "Appearance", hint: "Theme & density", icon: Palette },
+        { id: "logging", label: "Logging", hint: "Privacy & retention", icon: Shield },
+        { id: "playground", label: "Playground", hint: "Defaults & presets", icon: Terminal },
+        { id: "data", label: "Data", hint: "Backup & storage", icon: Database },
+        {
+            id: "system",
+            label: "System",
+            hint: "Runtime diagnostics",
+            icon: Cpu,
+            hasBadge: hasUpdate
+        }
     ];
+
+    const activeMeta = tabs.find((t) => t.id === activeTab)!;
 
     if (isLoadingServerSettings) {
         return <SettingsSkeleton />;
     }
 
     return (
-        <div className="mx-auto w-full max-w-5xl flex flex-col gap-6 font-mono">
+        <div className="mx-auto w-full max-w-6xl flex flex-col gap-6 font-mono">
             {/* Header */}
-            <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end border-b border-border/80 pb-5">
-                <div className="min-w-0">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/80">
-                        Control Plane
-                    </p>
-                    <div className="flex items-center gap-2 flex-wrap mt-1.5">
-                        <h1 className="text-2xl font-bold tracking-tight text-foreground">
-                            Settings & Operations
-                        </h1>
-                        {hasUpdate && latestVersion && (
-                            <button
-                                type="button"
-                                onClick={() => setActiveTab("system")}
-                                className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-bold text-amber-500 hover:bg-amber-500/20 transition-colors cursor-pointer"
-                            >
-                                <ArrowUpCircle className="size-3 text-amber-500" />
-                                <span>Update {latestVersion} available</span>
-                            </button>
-                        )}
+            <header className="flex flex-col justify-between gap-5 border-b border-border/70 pb-6 sm:flex-row sm:items-start">
+                <div className="flex items-start gap-3.5">
+                    <div className="flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-secondary/40 text-foreground shadow-2xs">
+                        <SlidersHorizontal className="size-5" />
                     </div>
-                    <p className="mt-1 max-w-2xl text-xs text-muted-foreground leading-relaxed">
-                        Manage gateway routing rules, authentication requirements, telemetry
-                        logging, and UI preferences.
-                    </p>
+                    <div className="min-w-0">
+                        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/80">
+                            Control Plane
+                        </p>
+                        <div className="mt-1 flex items-center gap-2.5 flex-wrap">
+                            <h1 className="text-2xl font-bold tracking-tight text-foreground">
+                                Settings
+                            </h1>
+                            {hasUpdate && latestVersion && (
+                                <button
+                                    type="button"
+                                    onClick={() => setActiveTab("system")}
+                                    className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-bold text-amber-500 transition-colors hover:bg-amber-500/20 cursor-pointer"
+                                >
+                                    <ArrowUpCircle className="size-3" />
+                                    Update {latestVersion} available
+                                </button>
+                            )}
+                        </div>
+                        <p className="mt-1.5 max-w-xl text-xs leading-relaxed text-muted-foreground">
+                            Configure gateway routing, authentication, telemetry logging, and UI
+                            preferences.
+                        </p>
+                    </div>
                 </div>
 
                 <div className="flex shrink-0 items-center gap-2">
@@ -156,99 +177,117 @@ function SettingsPage() {
                         variant="outline"
                         size="sm"
                         onClick={exportSettings}
-                        className="h-8 text-xs font-medium cursor-pointer gap-1.5 border-border/80 bg-card hover:bg-secondary/60 transition-colors shadow-2xs"
+                        className="h-8 cursor-pointer gap-1.5 border-border/70 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
                     >
-                        <Download className="size-3.5 text-muted-foreground" />
-                        <span>Export Config</span>
+                        <Download className="size-3.5" />
+                        Export
                     </Button>
                     <Button
                         type="button"
                         variant="outline"
                         size="sm"
                         onClick={resetToDefaults}
-                        className="h-8 text-xs font-medium text-rose-500 hover:text-rose-600 hover:bg-rose-500/10 border-border/80 bg-card transition-colors cursor-pointer shadow-2xs gap-1.5"
+                        className="h-8 cursor-pointer gap-1.5 border-border/70 text-xs font-medium text-rose-500 transition-colors hover:bg-rose-500/10 hover:text-rose-600"
                     >
                         <RotateCcw className="size-3.5" />
-                        <span>Reset</span>
+                        Reset
                     </Button>
                 </div>
             </header>
 
             {/* Layout: Sidebar Tabs + Content Panel */}
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-6 items-start">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-[16rem_1fr] items-start">
                 {/* Navigation Tabs */}
                 <nav
                     aria-label="Settings sections"
-                    className="flex md:flex-col gap-1 overflow-x-auto md:overflow-visible pb-2 md:pb-0 md:sticky md:top-0 z-10"
+                    className="flex gap-1 overflow-x-auto pb-1 md:sticky md:top-4 md:flex-col md:overflow-visible"
                 >
-                    {tabs.map(({ id, label, icon: Icon, hasBadge }) => {
+                    {tabs.map(({ id, label, hint, icon: Icon, hasBadge }) => {
                         const isActive = activeTab === id;
                         return (
                             <button
                                 key={id}
                                 type="button"
                                 onClick={() => setActiveTab(id)}
-                                className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all text-left whitespace-nowrap cursor-pointer ${
+                                className={cn(
+                                    "flex items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-all cursor-pointer whitespace-nowrap shrink-0",
                                     isActive
-                                        ? "bg-foreground text-background shadow-xs"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
-                                }`}
-                            >
-                                <Icon className="size-3.5 shrink-0" />
-                                <span>{label}</span>
-                                {hasBadge && (
-                                    <span className="ml-auto inline-flex items-center rounded-full bg-amber-500/20 text-amber-500 border border-amber-500/40 px-1.5 py-0.2 text-[9px] font-bold">
-                                        Update
-                                    </span>
+                                        ? "bg-secondary/60 ring-1 ring-border/70 text-foreground shadow-2xs"
+                                        : "text-muted-foreground hover:bg-secondary/40 hover:text-foreground"
                                 )}
+                            >
+                                <Icon
+                                    className={cn(
+                                        "size-4 shrink-0",
+                                        isActive ? "text-foreground" : "text-muted-foreground/70"
+                                    )}
+                                />
+                                <span className="min-w-0">
+                                    <span className="block text-xs font-bold leading-tight">
+                                        {label}
+                                        {hasBadge && (
+                                            <span className="ml-1.5 inline-flex rounded-full bg-amber-500/20 px-1.5 py-0.5 text-[8px] font-bold text-amber-500 align-middle">
+                                                Update
+                                            </span>
+                                        )}
+                                    </span>
+                                    <span className="block text-[10px] leading-tight text-muted-foreground/70">
+                                        {hint}
+                                    </span>
+                                </span>
                             </button>
                         );
                     })}
                 </nav>
 
                 {/* Main Settings Panel */}
-                <main className="md:col-span-3 space-y-4">
-                    {activeTab === "security" && (
-                        <SecuritySettings
-                            requireApiKey={requireApiKey}
-                            onToggleRequireApiKey={handleToggleRequireApiKey}
-                            isUpdating={updateServerMutation.isPending}
-                            apiBase={apiBase}
-                        />
-                    )}
+                <main className="min-w-0 space-y-4">
+                    <div key={activeTab} className="animate-fade-in">
+                        {activeTab === "security" && (
+                            <SecuritySettings
+                                requireApiKey={requireApiKey}
+                                onToggleRequireApiKey={handleToggleRequireApiKey}
+                                isUpdating={updateServerMutation.isPending}
+                                apiBase={apiBase}
+                            />
+                        )}
 
-                    {activeTab === "gateway" && (
-                        <GatewaySettings settings={settings} updateSetting={updateSetting} />
-                    )}
+                        {activeTab === "gateway" && (
+                            <GatewaySettings settings={settings} updateSetting={updateSetting} />
+                        )}
 
-                    {activeTab === "appearance" && (
-                        <AppearanceSettings
-                            theme={theme}
-                            toggleTheme={toggleTheme}
-                            settings={settings}
-                            updateSetting={updateSetting}
-                        />
-                    )}
+                        {activeTab === "appearance" && (
+                            <AppearanceSettings
+                                theme={theme}
+                                toggleTheme={toggleTheme}
+                                settings={settings}
+                                updateSetting={updateSetting}
+                            />
+                        )}
 
-                    {activeTab === "logging" && (
-                        <LoggingSettings settings={settings} updateSetting={updateSetting} />
-                    )}
+                        {activeTab === "logging" && (
+                            <LoggingSettings settings={settings} updateSetting={updateSetting} />
+                        )}
 
-                    {activeTab === "playground" && (
-                        <PlaygroundSettings settings={settings} updateSetting={updateSetting} />
-                    )}
+                        {activeTab === "playground" && (
+                            <PlaygroundSettings settings={settings} updateSetting={updateSetting} />
+                        )}
 
-                    {activeTab === "data" && (
-                        <DataSettings
-                            exportSettings={exportSettings}
-                            importSettings={importSettings}
-                            clearPlaygroundHistory={clearPlaygroundHistory}
-                            resetToDefaults={resetToDefaults}
-                            getStorageStats={getStorageStats}
-                        />
-                    )}
+                        {activeTab === "data" && (
+                            <DataSettings
+                                exportSettings={exportSettings}
+                                importSettings={importSettings}
+                                clearPlaygroundHistory={clearPlaygroundHistory}
+                                resetToDefaults={resetToDefaults}
+                                getStorageStats={getStorageStats}
+                            />
+                        )}
 
-                    {activeTab === "system" && <SystemSettings apiBase={apiBase} />}
+                        {activeTab === "system" && <SystemSettings apiBase={apiBase} />}
+                    </div>
+                    <p className="text-center text-[10px] text-muted-foreground/60">
+                        {activeMeta.label} — {activeMeta.hint}
+                    </p>
                 </main>
             </div>
         </div>


### PR DESCRIPTION
## What

Total visual redesign of the **Settings** page (/settings). No functional/behavioral change — same settings, same mutation logic, same 7 tabs — but a cleaner, more modern, more breathable presentation.

## Highlights

- **Header** — icon tile + eyebrow label + tighter title row, more legible Export/Reset actions.
- **Nav** — pill-style tab items with secondary hint line (e.g. "API keys & password"), sticky on desktop, horizontal scroll on mobile. Active state uses bg-secondary + ring instead of inverted foreground.
- **Shared primitives** — new components/settings/settings-ui.tsx with SettingsSection, SettingsRow, SegmentedControl, ValueBadge. All 7 tab panels rebuilt on these, killing a lot of duplicated pill-button markup.
- **Consistent cards** — every panel uses the same rounded-2xl section card + icon header pattern; sub-groups use inset bg-muted/20 wells with border-t separators.
- **Security** — added show/hide password toggle, code snippet now fades the copy button in on hover.
- **Appearance/Logging/Playground/Data/System** — rebuilt on the primitives, tighter labels, cleaner spacing.

## Files

- apps/web/src/routes/settings.tsx
- apps/web/src/components/settings/settings-ui.tsx (new)
- All 7 Settings components rewritten

## Verification

- cd apps/web && pnpm run build — passes
- Prettier applied
- Settings chunk shrank: 66.68 kB → 55.63 kB (gzip 14.91 → 14.10 kB)