### PR TITLE
feat(web): minimal single-scroll settings page

### DIFF
--- a/apps/web/src/components/settings/AppearanceSettings.tsx
+++ b/apps/web/src/components/settings/AppearanceSettings.tsx
@@ -1,5 +1,6 @@
-import { Check, Moon, Palette, Sun, LayoutGrid, Type } from "lucide-react";
+import { Check, Moon, Sun } from "lucide-react";
 import type { AppSettings } from "@/hooks/useSettings";
+import { SettingsSection, SettingsRow, SegmentedControl } from "./settings-ui";
 
 interface AppearanceSettingsProps {
     theme: "light" | "dark";
@@ -15,142 +16,53 @@ export function AppearanceSettings({
     updateSetting
 }: AppearanceSettingsProps) {
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Palette className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Appearance & Interface
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Customize your color palette, table density, and dashboard visual presentation.
-                </p>
-            </div>
-
-            {/* Theme Selection */}
-            <div className="space-y-3">
-                <label className="text-xs font-bold text-foreground">Color Theme Mode</label>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-lg">
-                    {/* Dark Mode Option */}
-                    <button
-                        type="button"
-                        onClick={(e) => theme !== "dark" && toggleTheme(e)}
-                        className={`group relative flex flex-col gap-3 rounded-xl border p-4 text-left transition-all cursor-pointer ${
-                            theme === "dark"
-                                ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20 shadow-xs"
-                                : "border-border/80 bg-background text-muted-foreground hover:border-border hover:text-foreground"
-                        }`}
-                    >
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                                <div className="flex size-7 items-center justify-center rounded-lg bg-zinc-900 border border-zinc-800 text-foreground">
-                                    <Moon className="size-3.5" />
-                                </div>
-                                <span className="text-xs font-bold text-foreground">
-                                    Dark Cockpit
-                                </span>
-                            </div>
-                            {theme === "dark" && (
-                                <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-background">
-                                    <Check className="size-3 stroke-[3]" />
-                                </span>
-                            )}
-                        </div>
-
-                        {/* Dark Mode Mini Mockup */}
-                        <div className="rounded-md border border-zinc-800 bg-zinc-950 p-2.5 space-y-1.5 opacity-90">
-                            <div className="flex items-center justify-between">
-                                <div className="h-2 w-16 rounded bg-zinc-800" />
-                                <div className="h-2 w-6 rounded bg-zinc-700" />
-                            </div>
-                            <div className="h-1.5 w-full rounded bg-zinc-900" />
-                            <div className="h-1.5 w-4/5 rounded bg-zinc-900" />
-                        </div>
-                    </button>
-
-                    {/* Light Mode Option */}
-                    <button
-                        type="button"
-                        onClick={(e) => theme !== "light" && toggleTheme(e)}
-                        className={`group relative flex flex-col gap-3 rounded-xl border p-4 text-left transition-all cursor-pointer ${
-                            theme === "light"
-                                ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20 shadow-xs"
-                                : "border-border/80 bg-background text-muted-foreground hover:border-border hover:text-foreground"
-                        }`}
-                    >
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                                <div className="flex size-7 items-center justify-center rounded-lg bg-zinc-100 border border-zinc-200 text-foreground">
-                                    <Sun className="size-3.5" />
-                                </div>
-                                <span className="text-xs font-bold text-foreground">
-                                    Light Paper
-                                </span>
-                            </div>
-                            {theme === "light" && (
-                                <span className="flex size-5 items-center justify-center rounded-full bg-foreground text-background">
-                                    <Check className="size-3 stroke-[3]" />
-                                </span>
-                            )}
-                        </div>
-
-                        {/* Light Mode Mini Mockup */}
-                        <div className="rounded-md border border-zinc-200 bg-white p-2.5 space-y-1.5 opacity-90">
-                            <div className="flex items-center justify-between">
-                                <div className="h-2 w-16 rounded bg-zinc-200" />
-                                <div className="h-2 w-6 rounded bg-zinc-300" />
-                            </div>
-                            <div className="h-1.5 w-full rounded bg-zinc-100" />
-                            <div className="h-1.5 w-4/5 rounded bg-zinc-100" />
-                        </div>
-                    </button>
-                </div>
-            </div>
-
-            {/* UI Density */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="space-y-0.5">
-                    <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                        <LayoutGrid className="size-3.5 text-muted-foreground" />
-                        <span>Interface Table & Row Density</span>
-                    </label>
-                    <p className="text-[11px] text-muted-foreground">
-                        Control table row padding and vertical layout spacing across logs and model
-                        catalogs.
-                    </p>
-                </div>
-
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {(["compact", "cozy"] as const).map((density) => {
-                        const isActive = settings.uiDensity === density;
-                        return (
-                            <button
-                                key={density}
-                                type="button"
-                                onClick={() => updateSetting("uiDensity", density)}
-                                className={`rounded-md px-3.5 py-1.5 text-xs font-semibold capitalize transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {density === "compact" ? "Compact (Dense)" : "Cozy (Relaxed)"}
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
-            {/* Typography Callout */}
-            <div className="rounded-lg border border-border/60 bg-muted/20 p-3.5 flex items-start gap-3">
-                <Type className="size-4 text-muted-foreground shrink-0 mt-0.5" />
-                <div className="text-[11px] text-muted-foreground leading-relaxed">
-                    <strong className="text-foreground">JetBrains Mono Engine:</strong> SRouter uses
-                    monospaced typography throughout the operational cockpit for maximum visual
-                    alignment of tokens, hashes, JSON payloads, and timestamps.
-                </div>
-            </div>
-        </div>
+        <SettingsSection index="03" title="Appearance" description="Theme mode and table density.">
+            <SettingsRow
+                title="Color Theme"
+                control={
+                    <div className="flex gap-1.5">
+                        <button
+                            type="button"
+                            onClick={(e) => theme !== "dark" && toggleTheme(e)}
+                            className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-medium cursor-pointer transition-all ${
+                                theme === "dark"
+                                    ? "border-foreground bg-foreground text-background"
+                                    : "border-border/70 text-muted-foreground hover:text-foreground"
+                            }`}
+                        >
+                            <Moon className="size-3" />
+                            Dark
+                            {theme === "dark" && <Check className="size-2.5" />}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={(e) => theme !== "light" && toggleTheme(e)}
+                            className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-medium cursor-pointer transition-all ${
+                                theme === "light"
+                                    ? "border-foreground bg-foreground text-background"
+                                    : "border-border/70 text-muted-foreground hover:text-foreground"
+                            }`}
+                        >
+                            <Sun className="size-3" />
+                            Light
+                            {theme === "light" && <Check className="size-2.5" />}
+                        </button>
+                    </div>
+                }
+            />
+            <SettingsRow
+                title="Table Density"
+                control={
+                    <SegmentedControl
+                        options={[
+                            { value: "compact", label: "Compact" },
+                            { value: "cozy", label: "Cozy" }
+                        ]}
+                        value={settings.uiDensity}
+                        onChange={(density) => updateSetting("uiDensity", density)}
+                    />
+                }
+            />
+        </SettingsSection>
     );
 }

--- a/apps/web/src/components/settings/DataSettings.tsx
+++ b/apps/web/src/components/settings/DataSettings.tsx
@@ -1,16 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import {
-    Database,
-    Download,
-    Upload,
-    Trash2,
-    RotateCcw,
-    HardDrive,
-    AlertTriangle,
-    FileJson,
-    Check,
-    Loader2
-} from "lucide-react";
+import { Download, Upload, Trash2, RotateCcw, HardDrive } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,6 +10,7 @@ import {
     DialogHeader,
     DialogTitle
 } from "@/components/ui/dialog";
+import { SettingsSection, SettingsRow, ValueBadge } from "./settings-ui";
 import type { StorageStats } from "@/hooks/useSettings";
 
 interface DataSettingsProps {
@@ -39,258 +29,143 @@ function formatBytes(bytes: number): string {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }
 
-export function DataSettings({
-    exportSettings,
-    importSettings,
-    clearPlaygroundHistory,
-    resetToDefaults,
-    getStorageStats
-}: DataSettingsProps) {
+export function DataSettings(props: DataSettingsProps) {
+    const {
+        exportSettings,
+        importSettings,
+        clearPlaygroundHistory,
+        resetToDefaults,
+        getStorageStats
+    } = props;
     const [stats, setStats] = useState<StorageStats>({
         totalBytes: 0,
         itemsCount: 0,
         playgroundBytes: 0,
         settingsBytes: 0
     });
-
     const [isImportOpen, setIsImportOpen] = useState(false);
     const [importText, setImportText] = useState("");
     const [isClearOpen, setIsClearOpen] = useState(false);
     const [isResetOpen, setIsResetOpen] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
-    const refreshStats = () => {
-        setStats(getStorageStats());
-    };
-
+    const refresh = () => setStats(getStorageStats());
     useEffect(() => {
-        refreshStats();
+        refresh();
     }, []);
 
-    const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (!file) return;
-
         const reader = new FileReader();
-        reader.onload = (event) => {
-            const content = event.target?.result as string;
-            if (content) {
-                setImportText(content);
-            }
+        reader.onload = (ev) => {
+            const c = ev.target?.result as string;
+            if (c) setImportText(c);
         };
         reader.readAsText(file);
     };
 
-    const handleImportSubmit = () => {
+    const handleImport = () => {
         if (!importText.trim()) {
-            toast.error("Please provide valid JSON configuration");
+            toast.error("Please provide valid JSON");
             return;
         }
-
-        const success = importSettings(importText);
-        if (success) {
+        if (importSettings(importText)) {
             setIsImportOpen(false);
             setImportText("");
-            refreshStats();
+            refresh();
         }
-    };
-
-    const handleConfirmClear = () => {
-        clearPlaygroundHistory();
-        setIsClearOpen(false);
-        refreshStats();
-    };
-
-    const handleConfirmReset = () => {
-        resetToDefaults();
-        setIsResetOpen(false);
-        refreshStats();
     };
 
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
+        <SettingsSection index="06" title="Data" description="Storage backup, import, and cleanup.">
+            <div className="flex items-center justify-between py-2">
                 <div className="flex items-center gap-2">
-                    <Database className="size-4 text-emerald-500" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Data, Backup & Local Storage
-                    </h2>
+                    <HardDrive className="size-3.5 text-muted-foreground" />
+                    <span className="text-xs font-semibold text-foreground">LocalStorage</span>
                 </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Inspect local storage footprint, export portability backups, or purge local
-                    session cache.
-                </p>
+                <span className="font-mono text-[11px] font-bold tabular-nums text-foreground">
+                    {formatBytes(stats.totalBytes)} ({stats.itemsCount} keys)
+                </span>
+            </div>
+            <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden flex mb-2">
+                <div
+                    className="h-full bg-blue-500"
+                    style={{
+                        width: `${stats.totalBytes > 0 ? (stats.playgroundBytes / stats.totalBytes) * 100 : 0}%`
+                    }}
+                />
+                <div
+                    className="h-full bg-amber-500"
+                    style={{
+                        width: `${stats.totalBytes > 0 ? (stats.settingsBytes / stats.totalBytes) * 100 : 0}%`
+                    }}
+                />
+            </div>
+            <div className="flex gap-3 text-[10px] font-mono text-muted-foreground pb-2">
+                <span className="flex items-center gap-1">
+                    <span className="size-1.5 rounded-full bg-blue-500" /> Playground:{" "}
+                    {formatBytes(stats.playgroundBytes)}
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="size-1.5 rounded-full bg-amber-500" /> Settings:{" "}
+                    {formatBytes(stats.settingsBytes)}
+                </span>
             </div>
 
-            {/* Storage Usage Meter */}
-            <div className="rounded-xl border border-border/70 bg-muted/20 p-4 space-y-3">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                        <HardDrive className="size-4 text-muted-foreground" />
-                        <span className="text-xs font-bold text-foreground">
-                            Browser LocalStorage Allocation
-                        </span>
-                    </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums">
-                        {formatBytes(stats.totalBytes)} ({stats.itemsCount} stored keys)
-                    </span>
-                </div>
-
-                {/* Storage breakdown bar */}
-                <div className="space-y-1.5">
-                    <div className="h-2 w-full rounded-full bg-muted overflow-hidden flex">
-                        <div
-                            className="h-full bg-blue-500 transition-all duration-300"
-                            style={{
-                                width: `${stats.totalBytes > 0 ? (stats.playgroundBytes / stats.totalBytes) * 100 : 0}%`
-                            }}
-                            title={`Playground: ${formatBytes(stats.playgroundBytes)}`}
-                        />
-                        <div
-                            className="h-full bg-amber-500 transition-all duration-300"
-                            style={{
-                                width: `${stats.totalBytes > 0 ? (stats.settingsBytes / stats.totalBytes) * 100 : 0}%`
-                            }}
-                            title={`Settings: ${formatBytes(stats.settingsBytes)}`}
-                        />
-                    </div>
-                    <div className="flex items-center justify-between text-[10px] font-mono text-muted-foreground">
-                        <div className="flex items-center gap-3">
-                            <span className="flex items-center gap-1">
-                                <span className="size-2 rounded-full bg-blue-500" />
-                                <span>
-                                    Playground Sessions: {formatBytes(stats.playgroundBytes)}
-                                </span>
-                            </span>
-                            <span className="flex items-center gap-1">
-                                <span className="size-2 rounded-full bg-amber-500" />
-                                <span>Preferences: {formatBytes(stats.settingsBytes)}</span>
-                            </span>
-                        </div>
-                    </div>
-                </div>
+            <div className="flex flex-wrap gap-2 py-2">
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={exportSettings}
+                    className="text-[11px] cursor-pointer"
+                >
+                    <Download className="size-3" /> Export
+                </Button>
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setIsImportOpen(true)}
+                    className="text-[11px] cursor-pointer"
+                >
+                    <Upload className="size-3" /> Import
+                </Button>
+                <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setIsClearOpen(true)}
+                    className="text-[11px] cursor-pointer"
+                >
+                    <Trash2 className="size-3" /> Clear
+                </Button>
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setIsResetOpen(true)}
+                    className="text-[11px] text-amber-500 cursor-pointer"
+                >
+                    <RotateCcw className="size-3" /> Reset
+                </Button>
             </div>
 
-            {/* Action Cards */}
-            <div className="space-y-3">
-                {/* Export & Import Row */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
-                        <div className="space-y-1">
-                            <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                                <Download className="size-3.5 text-blue-500" />
-                                <span>Export Configuration Backup</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Download all preferences and timeout rules as an offline JSON
-                                archive.
-                            </p>
-                        </div>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={exportSettings}
-                            className="w-full font-semibold cursor-pointer"
-                        >
-                            <Download className="size-3.5" />
-                            <span>Export Backup JSON</span>
-                        </Button>
-                    </div>
-
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
-                        <div className="space-y-1">
-                            <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                                <Upload className="size-3.5 text-emerald-500" />
-                                <span>Import Configuration</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Restore preferences from a previously saved SRouter settings JSON
-                                file.
-                            </p>
-                        </div>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setIsImportOpen(true)}
-                            className="w-full font-semibold cursor-pointer"
-                        >
-                            <Upload className="size-3.5" />
-                            <span>Import Backup JSON</span>
-                        </Button>
-                    </div>
-                </div>
-
-                {/* Clear & Reset Row */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-2">
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
-                        <div className="space-y-1">
-                            <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                                <Trash2 className="size-3.5 text-rose-500" />
-                                <span>Clear Playground History</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Delete all cached chat threads and conversations from browser
-                                memory.
-                            </p>
-                        </div>
-                        <Button
-                            type="button"
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => setIsClearOpen(true)}
-                            className="w-full font-semibold cursor-pointer"
-                        >
-                            <Trash2 className="size-3.5" />
-                            <span>Clear Playground Sessions</span>
-                        </Button>
-                    </div>
-
-                    <div className="flex flex-col justify-between p-4 rounded-xl border border-border/80 bg-background space-y-3">
-                        <div className="space-y-1">
-                            <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                                <RotateCcw className="size-3.5 text-amber-500" />
-                                <span>Factory Reset Settings</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Restore all client gateway parameters and UI themes to factory
-                                defaults.
-                            </p>
-                        </div>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setIsResetOpen(true)}
-                            className="w-full text-amber-500 hover:text-amber-600 font-semibold cursor-pointer"
-                        >
-                            <RotateCcw className="size-3.5" />
-                            <span>Reset All to Defaults</span>
-                        </Button>
-                    </div>
-                </div>
-            </div>
-
-            {/* Modal: Import Configuration */}
             <Dialog open={isImportOpen} onOpenChange={setIsImportOpen}>
-                <DialogContent className="max-w-lg">
+                <DialogContent>
                     <DialogHeader>
-                        <DialogTitle className="flex items-center gap-2 text-sm font-bold">
-                            <FileJson className="size-4 text-emerald-500" />
-                            <span>Import Settings Configuration</span>
-                        </DialogTitle>
+                        <DialogTitle className="text-sm font-bold">Import Settings</DialogTitle>
                         <DialogDescription className="text-xs">
-                            Select a JSON file or paste exported JSON settings content below.
+                            Paste exported JSON or select a file.
                         </DialogDescription>
                     </DialogHeader>
-
-                    <div className="space-y-3 py-2">
+                    <div className="space-y-2 py-2">
                         <input
                             type="file"
                             accept=".json,application/json"
                             ref={fileInputRef}
-                            onChange={handleFileSelect}
+                            onChange={handleFile}
                             className="hidden"
                         />
                         <Button
@@ -298,24 +173,19 @@ export function DataSettings({
                             variant="outline"
                             size="sm"
                             onClick={() => fileInputRef.current?.click()}
-                            className="w-full font-semibold cursor-pointer"
+                            className="w-full cursor-pointer"
                         >
-                            <Upload className="size-3.5" />
-                            <span>Choose JSON File From Computer</span>
+                            <Upload className="size-3" /> Choose File
                         </Button>
-
-                        <div className="relative">
-                            <textarea
-                                rows={6}
-                                value={importText}
-                                onChange={(e) => setImportText(e.target.value)}
-                                placeholder="Or paste JSON configuration here..."
-                                className="w-full rounded-lg border border-border/80 bg-muted/20 p-3 font-mono text-[11px] text-foreground focus:outline-none focus:ring-1 focus:ring-emerald-500"
-                            />
-                        </div>
+                        <textarea
+                            rows={5}
+                            value={importText}
+                            onChange={(e) => setImportText(e.target.value)}
+                            placeholder="Or paste JSON here..."
+                            className="w-full rounded-md border border-border/70 bg-muted/20 p-2.5 font-mono text-[11px] text-foreground focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                        />
                     </div>
-
-                    <DialogFooter className="gap-2 sm:gap-0">
+                    <DialogFooter>
                         <Button
                             type="button"
                             variant="outline"
@@ -327,30 +197,27 @@ export function DataSettings({
                         <Button
                             type="button"
                             size="sm"
-                            onClick={handleImportSubmit}
+                            onClick={handleImport}
                             className="font-semibold"
                         >
-                            <Check className="size-3.5" />
-                            <span>Apply Imported Settings</span>
+                            Apply Import
                         </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
 
-            {/* Modal: Confirm Clear History */}
             <Dialog open={isClearOpen} onOpenChange={setIsClearOpen}>
-                <DialogContent className="max-w-md">
+                <DialogContent>
                     <DialogHeader>
-                        <DialogTitle className="flex items-center gap-2 text-sm font-bold text-rose-500">
-                            <Trash2 className="size-4" />
-                            <span>Clear Playground Chat History?</span>
+                        <DialogTitle className="text-sm font-bold text-rose-500">
+                            Clear Playground History?
                         </DialogTitle>
                         <DialogDescription className="text-xs">
-                            This will permanently delete all cached conversations from this browser.
-                            This action cannot be undone.
+                            This deletes all cached conversations from this browser. Cannot be
+                            undone.
                         </DialogDescription>
                     </DialogHeader>
-                    <DialogFooter className="gap-2 sm:gap-0 pt-3">
+                    <DialogFooter>
                         <Button
                             type="button"
                             variant="outline"
@@ -363,28 +230,30 @@ export function DataSettings({
                             type="button"
                             variant="destructive"
                             size="sm"
-                            onClick={handleConfirmClear}
+                            onClick={() => {
+                                clearPlaygroundHistory();
+                                setIsClearOpen(false);
+                                refresh();
+                            }}
                         >
-                            Yes, Clear All History
+                            Clear All
                         </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
 
-            {/* Modal: Confirm Reset Defaults */}
             <Dialog open={isResetOpen} onOpenChange={setIsResetOpen}>
-                <DialogContent className="max-w-md">
+                <DialogContent>
                     <DialogHeader>
-                        <DialogTitle className="flex items-center gap-2 text-sm font-bold text-amber-500">
-                            <AlertTriangle className="size-4" />
-                            <span>Reset Settings to Defaults?</span>
+                        <DialogTitle className="text-sm font-bold text-amber-500">
+                            Reset to Defaults?
                         </DialogTitle>
                         <DialogDescription className="text-xs">
-                            All custom timeout limits, retry backoffs, and playground parameters
-                            will be reset to default factory values.
+                            Timeouts, retries, and playground parameters will be restored to factory
+                            values.
                         </DialogDescription>
                     </DialogHeader>
-                    <DialogFooter className="gap-2 sm:gap-0 pt-3">
+                    <DialogFooter>
                         <Button
                             type="button"
                             variant="outline"
@@ -396,14 +265,18 @@ export function DataSettings({
                         <Button
                             type="button"
                             size="sm"
-                            onClick={handleConfirmReset}
+                            onClick={() => {
+                                resetToDefaults();
+                                setIsResetOpen(false);
+                                refresh();
+                            }}
                             className="bg-amber-600 hover:bg-amber-700 text-white"
                         >
-                            Yes, Reset to Defaults
+                            Reset
                         </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
-        </div>
+        </SettingsSection>
     );
 }

--- a/apps/web/src/components/settings/GatewaySettings.tsx
+++ b/apps/web/src/components/settings/GatewaySettings.tsx
@@ -1,6 +1,6 @@
-import { Server, Clock, RefreshCw, Zap, Layers } from "lucide-react";
-import type { AppSettings } from "@/hooks/useSettings";
 import { Switch } from "@/components/ui/switch";
+import type { AppSettings } from "@/hooks/useSettings";
+import { SettingsSection, SettingsRow, SegmentedControl, ValueBadge } from "./settings-ui";
 
 interface GatewaySettingsProps {
     settings: AppSettings;
@@ -9,193 +9,77 @@ interface GatewaySettingsProps {
 
 export function GatewaySettings({ settings, updateSetting }: GatewaySettingsProps) {
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Server className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Gateway & Proxy Configuration
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Configure upstream connection limits, timeout windows, and automatic rate-limit
-                    failover mechanics.
-                </p>
+        <SettingsSection
+            index="02"
+            title="Gateway"
+            description="Timeouts, retry behavior, and OAuth token refresh cadence."
+        >
+            <SettingsRow
+                title="Request Timeout"
+                description="How long to wait for upstream LLM responses before aborting."
+                control={<ValueBadge>{settings.requestTimeoutSec}s</ValueBadge>}
+            />
+            <div className="py-2">
+                <SegmentedControl
+                    options={[30, 60, 120, 180, 300].map((sec) => ({
+                        value: sec,
+                        label: `${sec}s`
+                    }))}
+                    value={settings.requestTimeoutSec}
+                    onChange={(sec) => updateSetting("requestTimeoutSec", sec)}
+                />
             </div>
 
-            {/* Global Request Timeout */}
-            <div className="space-y-3">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Clock className="size-3.5 text-muted-foreground" />
-                            <span>Upstream Request Timeout</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Maximum duration the gateway will wait for upstream LLM streaming
-                            responses before aborting.
-                        </p>
-                    </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.requestTimeoutSec}s
-                    </span>
-                </div>
-
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[30, 60, 120, 180, 300].map((sec) => {
-                        const isActive = settings.requestTimeoutSec === sec;
-                        return (
-                            <button
-                                key={sec}
-                                type="button"
-                                onClick={() => updateSetting("requestTimeoutSec", sec)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {sec}s
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
-            {/* Auto Retry on Rate Limit (HTTP 429) */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex items-center justify-between gap-4">
-                    <div className="space-y-0.5">
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <RefreshCw className="size-3.5 text-muted-foreground" />
-                            <span>Auto-Retry on Rate Limit (HTTP 429)</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground">
-                            Automatically retry failed upstream requests with exponential backoff
-                            when provider quotas trigger 429 errors.
-                        </p>
-                    </div>
+            <SettingsRow
+                title="Auto-Retry on 429"
+                description="Exponential backoff retry when provider quotas trigger rate limits."
+                control={
                     <Switch
                         checked={settings.autoRetryOn429}
                         onCheckedChange={(val) => updateSetting("autoRetryOn429", val)}
                     />
+                }
+            />
+            {settings.autoRetryOn429 && (
+                <div className="pl-4 space-y-2 py-2">
+                    <SettingsRow
+                        title="Max Retries"
+                        control={
+                            <SegmentedControl
+                                options={[1, 2, 3, 5].map((r) => ({ value: r, label: `${r}x` }))}
+                                value={settings.maxRetries}
+                                onChange={(r) => updateSetting("maxRetries", r)}
+                            />
+                        }
+                    />
+                    <SettingsRow
+                        title="Base Backoff"
+                        control={
+                            <SegmentedControl
+                                options={[500, 1000, 2000].map((ms) => ({
+                                    value: ms,
+                                    label: `${ms}ms`
+                                }))}
+                                value={settings.retryDelayMs}
+                                onChange={(ms) => updateSetting("retryDelayMs", ms)}
+                            />
+                        }
+                    />
                 </div>
+            )}
 
-                {settings.autoRetryOn429 && (
-                    <div className="rounded-lg border border-border/70 bg-muted/20 divide-y divide-border/60">
-                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3.5">
-                            <div className="space-y-0.5">
-                                <div className="text-xs font-semibold text-foreground">
-                                    Maximum Retry Attempts
-                                </div>
-                                <div className="text-[11px] text-muted-foreground">
-                                    Number of sequential retry attempts before reporting failure.
-                                </div>
-                            </div>
-                            <div className="inline-flex items-center rounded-lg border border-border/80 bg-background/80 p-0.5 font-mono gap-1 self-start sm:self-auto">
-                                {[1, 2, 3, 5].map((retries) => {
-                                    const isActive = settings.maxRetries === retries;
-                                    return (
-                                        <button
-                                            key={retries}
-                                            type="button"
-                                            onClick={() => updateSetting("maxRetries", retries)}
-                                            className={`rounded-md px-2.5 py-1 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                                isActive
-                                                    ? "bg-foreground text-background shadow-xs font-bold"
-                                                    : "text-muted-foreground hover:text-foreground"
-                                            }`}
-                                        >
-                                            {retries}x
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                        </div>
-
-                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3.5">
-                            <div className="space-y-0.5">
-                                <div className="text-xs font-semibold text-foreground">
-                                    Base Backoff Delay
-                                </div>
-                                <div className="text-[11px] text-muted-foreground">
-                                    Initial exponential sleep duration before the first retry
-                                    attempt.
-                                </div>
-                            </div>
-                            <div className="inline-flex items-center rounded-lg border border-border/80 bg-background/80 p-0.5 font-mono gap-1 self-start sm:self-auto">
-                                {[500, 1000, 2000].map((ms) => {
-                                    const isActive = settings.retryDelayMs === ms;
-                                    return (
-                                        <button
-                                            key={ms}
-                                            type="button"
-                                            onClick={() => updateSetting("retryDelayMs", ms)}
-                                            className={`rounded-md px-2.5 py-1 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                                isActive
-                                                    ? "bg-foreground text-background shadow-xs font-bold"
-                                                    : "text-muted-foreground hover:text-foreground"
-                                            }`}
-                                        >
-                                            {ms}ms
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                        </div>
-                    </div>
-                )}
+            <SettingsRow
+                title="Token Refresh Lead Time"
+                description="Renew provider OAuth tokens this far before expiry."
+                control={<ValueBadge>{settings.tokenRefreshLeadMin} min</ValueBadge>}
+            />
+            <div className="py-2">
+                <SegmentedControl
+                    options={[2, 5, 10, 15].map((min) => ({ value: min, label: `${min} min` }))}
+                    value={settings.tokenRefreshLeadMin}
+                    onChange={(min) => updateSetting("tokenRefreshLeadMin", min)}
+                />
             </div>
-
-            {/* Token Refresh Lead Time */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Zap className="size-3.5 text-foreground" />
-                            <span>OAuth Token Refresh Lead Time</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Proactively renew provider OAuth tokens before expiry to ensure zero
-                            request disruption.
-                        </p>
-                    </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.tokenRefreshLeadMin} min
-                    </span>
-                </div>
-
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[2, 5, 10, 15].map((min) => {
-                        const isActive = settings.tokenRefreshLeadMin === min;
-                        return (
-                            <button
-                                key={min}
-                                type="button"
-                                onClick={() => updateSetting("tokenRefreshLeadMin", min)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {min} min
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
-            {/* Architecture Info Banner */}
-            <div className="rounded-lg border border-border/60 bg-muted/20 p-3.5 flex items-start gap-3">
-                <Layers className="size-4 text-muted-foreground shrink-0 mt-0.5" />
-                <div className="text-[11px] text-muted-foreground leading-relaxed">
-                    <strong className="text-foreground">Transparent Protocol Streaming:</strong> All
-                    downstream clients receive raw Server-Sent Events (SSE) chunks immediately as
-                    upstream providers output tokens, minimizing time-to-first-token (TTFT) without
-                    proxy buffering overhead.
-                </div>
-            </div>
-        </div>
+        </SettingsSection>
     );
 }

--- a/apps/web/src/components/settings/LoggingSettings.tsx
+++ b/apps/web/src/components/settings/LoggingSettings.tsx
@@ -1,6 +1,7 @@
-import { Shield, Database, Coins, Lock, Check } from "lucide-react";
+import { Check } from "lucide-react";
 import type { AppSettings } from "@/hooks/useSettings";
 import { Switch } from "@/components/ui/switch";
+import { SettingsSection, SettingsRow, SegmentedControl, ValueBadge } from "./settings-ui";
 
 interface LoggingSettingsProps {
     settings: AppSettings;
@@ -8,174 +9,83 @@ interface LoggingSettingsProps {
 }
 
 export function LoggingSettings({ settings, updateSetting }: LoggingSettingsProps) {
-    const loggingOptions = [
-        {
-            id: "full",
-            title: "Full Payload",
-            badge: "Recommended",
-            badgeColor: "bg-muted text-foreground border-border/80",
-            desc: "Store full prompt messages and completion responses for inspection in the Logs view."
-        },
-        {
-            id: "metadata",
-            title: "Metadata Only",
-            badge: "Privacy Focused",
-            badgeColor: "bg-muted text-muted-foreground border-border/80",
-            desc: "Log only timestamps, model IDs, token usage, and latency. Message contents are discarded."
-        },
-        {
-            id: "disabled",
-            title: "Disabled",
-            badge: "Zero Trace",
-            badgeColor: "bg-muted text-muted-foreground border-border/80",
-            desc: "Do not record any request logs to SQLite database. Quota and tokens are still calculated."
-        }
-    ] as const;
+    const levels = [
+        { id: "full" as const, label: "Full Payload" },
+        { id: "metadata" as const, label: "Metadata Only" },
+        { id: "disabled" as const, label: "Disabled" }
+    ];
 
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Shield className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Logging, Privacy & Audit
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Control data retention policies and request payload logging granularity stored
-                    in SQLite.
-                </p>
-            </div>
-
-            {/* Logging Level */}
-            <div className="space-y-3">
-                <label className="text-xs font-bold text-foreground">
-                    Request Payload Logging Level
-                </label>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                    {loggingOptions.map(({ id, title, badge, badgeColor, desc }) => {
-                        const isSelected = settings.loggingLevel === id;
+        <SettingsSection
+            index="04"
+            title="Logging"
+            description="Request payload capture and retention policies."
+        >
+            <div className="py-3">
+                <div className="flex gap-2">
+                    {levels.map(({ id, label }) => {
+                        const isActive = settings.loggingLevel === id;
                         return (
                             <button
                                 key={id}
                                 type="button"
                                 onClick={() => updateSetting("loggingLevel", id)}
-                                className={`flex flex-col text-left p-4 rounded-xl border transition-all cursor-pointer ${
-                                    isSelected
-                                        ? "border-foreground bg-muted/60 text-foreground ring-1 ring-foreground/20 shadow-xs"
-                                        : "border-border/80 bg-background text-muted-foreground hover:border-border hover:text-foreground"
+                                className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-medium cursor-pointer transition-all ${
+                                    isActive
+                                        ? "border-foreground bg-foreground text-background"
+                                        : "border-border/70 text-muted-foreground hover:text-foreground"
                                 }`}
                             >
-                                <div className="flex items-center justify-between gap-2 mb-2">
-                                    <span className="text-xs font-bold text-foreground">
-                                        {title}
-                                    </span>
-                                    {isSelected ? (
-                                        <span className="flex size-4 items-center justify-center rounded-full bg-foreground text-background">
-                                            <Check className="size-2.5 stroke-[3]" />
-                                        </span>
-                                    ) : (
-                                        <span
-                                            className={`text-[9.5px] font-semibold uppercase px-1.5 py-0.2 rounded border ${badgeColor}`}
-                                        >
-                                            {badge}
-                                        </span>
-                                    )}
-                                </div>
-                                <p className="text-[11px] text-muted-foreground leading-relaxed">
-                                    {desc}
-                                </p>
+                                {label}
+                                {isActive && <Check className="size-2.5" />}
                             </button>
                         );
                     })}
                 </div>
             </div>
 
-            {/* Log Retention Policy */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Database className="size-3.5 text-muted-foreground" />
-                            <span>SQLite Log Retention Window</span>
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Audit logs older than this threshold will be pruned automatically to
-                            conserve disk space.
-                        </p>
-                    </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
+            <SettingsRow
+                title="Log Retention"
+                description="Auto-prune logs older than this threshold."
+                control={
+                    <ValueBadge>
                         {settings.logRetentionDays === 365
                             ? "1 Year"
                             : `${settings.logRetentionDays} Days`}
-                    </span>
-                </div>
-
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[7, 14, 30, 90, 365].map((days) => {
-                        const isActive = settings.logRetentionDays === days;
-                        return (
-                            <button
-                                key={days}
-                                type="button"
-                                onClick={() => updateSetting("logRetentionDays", days)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {days === 365 ? "1 Year" : `${days}d`}
-                            </button>
-                        );
-                    })}
-                </div>
+                    </ValueBadge>
+                }
+            />
+            <div className="py-2">
+                <SegmentedControl
+                    options={[7, 14, 30, 90, 365].map((days) => ({
+                        value: days,
+                        label: days === 365 ? "1 Year" : `${days}d`
+                    }))}
+                    value={settings.logRetentionDays}
+                    onChange={(days) => updateSetting("logRetentionDays", days)}
+                />
             </div>
 
-            {/* Additional Privacy Switches */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <label className="text-xs font-bold text-foreground">
-                    Telemetry & Privacy Controls
-                </label>
-
-                <div className="rounded-lg border border-border/70 bg-muted/20 divide-y divide-border/60">
-                    {/* Record token usage */}
-                    <div className="flex items-center justify-between p-3.5 gap-4">
-                        <div className="space-y-0.5">
-                            <div className="text-xs font-semibold text-foreground flex items-center gap-1.5">
-                                <Coins className="size-3.5 text-muted-foreground" />
-                                <span>Record Token Usage & Pricing Estimates</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Aggregate prompt and completion tokens to calculate cost estimates
-                                on the Dashboard.
-                            </p>
-                        </div>
-                        <Switch
-                            checked={settings.recordTokenUsage}
-                            onCheckedChange={(val) => updateSetting("recordTokenUsage", val)}
-                        />
-                    </div>
-
-                    {/* Mask sensitive headers */}
-                    <div className="flex items-center justify-between p-3.5 gap-4">
-                        <div className="space-y-0.5">
-                            <div className="text-xs font-semibold text-foreground flex items-center gap-1.5">
-                                <Lock className="size-3.5 text-muted-foreground" />
-                                <span>Mask Sensitive Auth Headers in Logs</span>
-                            </div>
-                            <p className="text-[11px] text-muted-foreground">
-                                Automatically redact Authorization tokens and provider credentials
-                                in database records.
-                            </p>
-                        </div>
-                        <Switch
-                            checked={settings.maskSensitiveHeaders}
-                            onCheckedChange={(val) => updateSetting("maskSensitiveHeaders", val)}
-                        />
-                    </div>
-                </div>
-            </div>
-        </div>
+            <SettingsRow
+                title="Record Token Usage"
+                description="Aggregate prompt/completion tokens for cost estimates on the dashboard."
+                control={
+                    <Switch
+                        checked={settings.recordTokenUsage}
+                        onCheckedChange={(val) => updateSetting("recordTokenUsage", val)}
+                    />
+                }
+            />
+            <SettingsRow
+                title="Mask Sensitive Headers"
+                description="Redact Authorization tokens in database records."
+                control={
+                    <Switch
+                        checked={settings.maskSensitiveHeaders}
+                        onCheckedChange={(val) => updateSetting("maskSensitiveHeaders", val)}
+                    />
+                }
+            />
+        </SettingsSection>
     );
 }

--- a/apps/web/src/components/settings/PlaygroundSettings.tsx
+++ b/apps/web/src/components/settings/PlaygroundSettings.tsx
@@ -1,30 +1,31 @@
-import { Terminal, Sparkles, Sliders, Radio, Code2, Bot, FileJson, PenTool } from "lucide-react";
+import { Terminal, Sparkles, Radio, Code2, Bot, FileJson, PenTool } from "lucide-react";
 import type { AppSettings } from "@/hooks/useSettings";
 import { Switch } from "@/components/ui/switch";
+import { SettingsSection, SettingsRow, SegmentedControl, ValueBadge } from "./settings-ui";
 
 interface PlaygroundSettingsProps {
     settings: AppSettings;
     updateSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void;
 }
 
-const SYSTEM_PROMPT_PRESETS = [
+const PRESETS = [
     {
-        name: "General Assistant",
+        name: "General",
         icon: Bot,
         prompt: "You are a helpful, versatile, and precise AI assistant."
     },
     {
-        name: "Senior Engineer",
+        name: "Engineer",
         icon: Code2,
         prompt: "You are a senior full-stack software engineer. Provide robust, clean, idiomatic code with clear explanations and best practices."
     },
     {
-        name: "JSON Extractor",
+        name: "JSON",
         icon: FileJson,
         prompt: "You are an automated data extractor. Always output raw, valid JSON only without markdown formatting or introductory text."
     },
     {
-        name: "Technical Writer",
+        name: "Writer",
         icon: PenTool,
         prompt: "You are an expert technical writer. Explain complex engineering concepts clearly using concise metaphors and structured tables."
     }
@@ -32,31 +33,16 @@ const SYSTEM_PROMPT_PRESETS = [
 
 export function PlaygroundSettings({ settings, updateSetting }: PlaygroundSettingsProps) {
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Terminal className="size-4 text-foreground" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        Playground & Model Defaults
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Pre-populate default inference parameters when starting new sessions in the
-                    SRouter Playground.
-                </p>
-            </div>
-
-            {/* Temperature Slider */}
-            <div className="space-y-2">
-                <div className="flex items-center justify-between text-xs">
-                    <label className="font-bold text-foreground flex items-center gap-1.5">
-                        <Sliders className="size-3.5 text-muted-foreground" />
-                        <span>Default Temperature</span>
-                    </label>
-                    <span className="font-mono font-bold tabular-nums text-foreground px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.defaultTemperature.toFixed(2)}
-                    </span>
-                </div>
+        <SettingsSection
+            index="05"
+            title="Playground"
+            description="Default inference parameters for new playground sessions."
+        >
+            <SettingsRow
+                title="Temperature"
+                control={<ValueBadge>{settings.defaultTemperature.toFixed(2)}</ValueBadge>}
+            />
+            <div className="py-2 space-y-1">
                 <input
                     type="range"
                     min="0"
@@ -66,26 +52,20 @@ export function PlaygroundSettings({ settings, updateSetting }: PlaygroundSettin
                     onChange={(e) =>
                         updateSetting("defaultTemperature", parseFloat(e.target.value))
                     }
-                    className="w-full accent-foreground cursor-pointer h-1.5 rounded-lg bg-muted appearance-none"
+                    className="w-full accent-foreground cursor-pointer h-1 rounded-lg bg-muted appearance-none"
                 />
-                <div className="flex justify-between text-[10px] font-mono text-muted-foreground">
-                    <span>0.0 (Deterministic / Code)</span>
-                    <span>0.7 (Balanced)</span>
-                    <span>2.0 (High Creativity)</span>
+                <div className="flex justify-between text-[9px] font-mono text-muted-foreground">
+                    <span>0.0</span>
+                    <span>0.7</span>
+                    <span>2.0</span>
                 </div>
             </div>
 
-            {/* Top P Slider */}
-            <div className="space-y-2 pt-5 border-t border-border/70">
-                <div className="flex items-center justify-between text-xs">
-                    <label className="font-bold text-foreground flex items-center gap-1.5">
-                        <Sparkles className="size-3.5 text-muted-foreground" />
-                        <span>Default Top P (Nucleus Sampling)</span>
-                    </label>
-                    <span className="font-mono font-bold tabular-nums text-foreground px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.defaultTopP.toFixed(2)}
-                    </span>
-                </div>
+            <SettingsRow
+                title="Top P"
+                control={<ValueBadge>{settings.defaultTopP.toFixed(2)}</ValueBadge>}
+            />
+            <div className="py-2 space-y-1">
                 <input
                     type="range"
                     min="0"
@@ -93,102 +73,62 @@ export function PlaygroundSettings({ settings, updateSetting }: PlaygroundSettin
                     step="0.05"
                     value={settings.defaultTopP}
                     onChange={(e) => updateSetting("defaultTopP", parseFloat(e.target.value))}
-                    className="w-full accent-foreground cursor-pointer h-1.5 rounded-lg bg-muted appearance-none"
+                    className="w-full accent-foreground cursor-pointer h-1 rounded-lg bg-muted appearance-none"
                 />
-                <div className="flex justify-between text-[10px] font-mono text-muted-foreground">
-                    <span>0.0 (Strict)</span>
-                    <span>0.95 (Standard)</span>
-                    <span>1.0 (Full Distribution)</span>
+                <div className="flex justify-between text-[9px] font-mono text-muted-foreground">
+                    <span>0.0</span>
+                    <span>0.95</span>
+                    <span>1.0</span>
                 </div>
             </div>
 
-            {/* Max Output Tokens */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <div>
-                        <label className="text-xs font-bold text-foreground">
-                            Default Max Output Tokens
-                        </label>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                            Upper bound on tokens generated per single model completion.
-                        </p>
-                    </div>
-                    <span className="text-xs font-mono font-bold text-foreground tabular-nums px-2 py-0.5 rounded bg-muted/60 border border-border/60">
-                        {settings.defaultMaxTokens.toLocaleString()} tokens
-                    </span>
-                </div>
-
-                <div className="inline-flex items-center rounded-lg border border-border/80 bg-muted/40 p-1 font-mono gap-1">
-                    {[1024, 2048, 4096, 8192, 16384].map((tokens) => {
-                        const isActive = settings.defaultMaxTokens === tokens;
-                        return (
-                            <button
-                                key={tokens}
-                                type="button"
-                                onClick={() => updateSetting("defaultMaxTokens", tokens)}
-                                className={`rounded-md px-3 py-1.5 text-xs tabular-nums font-semibold transition-all cursor-pointer ${
-                                    isActive
-                                        ? "bg-background text-foreground shadow-xs border border-border/80 font-bold"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60 border border-transparent"
-                                }`}
-                            >
-                                {tokens >= 1000 ? `${tokens / 1024}k` : tokens}
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
-            {/* Stream Response Toggle */}
-            <div className="flex items-center justify-between pt-5 border-t border-border/70 gap-4">
-                <div className="space-y-0.5">
-                    <label className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                        <Radio className="size-3.5 text-muted-foreground" />
-                        <span>Stream Completion Tokens by Default</span>
-                    </label>
-                    <p className="text-[11px] text-muted-foreground">
-                        Enable real-time token streaming animation in the playground chat window.
-                    </p>
-                </div>
-                <Switch
-                    checked={settings.streamResponse}
-                    onCheckedChange={(val) => updateSetting("streamResponse", val)}
+            <SettingsRow
+                title="Max Output Tokens"
+                control={<ValueBadge>{settings.defaultMaxTokens.toLocaleString()}</ValueBadge>}
+            />
+            <div className="py-2">
+                <SegmentedControl
+                    options={[1024, 2048, 4096, 8192, 16384].map((t) => ({
+                        value: t,
+                        label: t >= 1000 ? `${t / 1024}k` : `${t}`
+                    }))}
+                    value={settings.defaultMaxTokens}
+                    onChange={(t) => updateSetting("defaultMaxTokens", t)}
                 />
             </div>
 
-            {/* Default System Prompt */}
-            <div className="space-y-3 pt-5 border-t border-border/70">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-                    <label className="text-xs font-bold text-foreground">
-                        Default System Prompt
-                    </label>
-                    <span className="text-[11px] text-muted-foreground">
-                        Quick Preset Templates:
-                    </span>
-                </div>
+            <SettingsRow
+                title="Stream by Default"
+                description="Enable real-time token streaming in the playground."
+                control={
+                    <Switch
+                        checked={settings.streamResponse}
+                        onCheckedChange={(val) => updateSetting("streamResponse", val)}
+                    />
+                }
+            />
 
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                    {SYSTEM_PROMPT_PRESETS.map(({ name, icon: Icon, prompt }) => (
-                        <button
-                            key={name}
-                            type="button"
-                            onClick={() => updateSetting("systemPromptDefault", prompt)}
-                            className="flex items-center gap-1.5 rounded-lg border border-border/80 bg-background hover:bg-muted/60 p-2.5 text-left text-[11px] font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                        >
-                            <Icon className="size-3.5 shrink-0 text-foreground" />
-                            <span className="truncate">{name}</span>
-                        </button>
-                    ))}
-                </div>
-
-                <textarea
-                    rows={3}
-                    value={settings.systemPromptDefault}
-                    onChange={(e) => updateSetting("systemPromptDefault", e.target.value)}
-                    placeholder="Enter default system instructions..."
-                    className="w-full rounded-lg border border-border/80 bg-background p-3 text-xs font-mono text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                />
+            <SettingsRow title="Default System Prompt" description="Quick presets:" />
+            <div className="flex flex-wrap gap-1.5 pb-2">
+                {PRESETS.map(({ name, icon: Icon, prompt }) => (
+                    <button
+                        key={name}
+                        type="button"
+                        onClick={() => updateSetting("systemPromptDefault", prompt)}
+                        className="flex items-center gap-1 rounded-md border border-border/70 bg-background hover:bg-muted/60 px-2 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                    >
+                        <Icon className="size-3" />
+                        {name}
+                    </button>
+                ))}
             </div>
-        </div>
+            <textarea
+                rows={3}
+                value={settings.systemPromptDefault}
+                onChange={(e) => updateSetting("systemPromptDefault", e.target.value)}
+                placeholder="Enter default system instructions..."
+                className="w-full rounded-md border border-border/70 bg-background p-2.5 text-xs font-mono text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+        </SettingsSection>
     );
 }

--- a/apps/web/src/components/settings/SecuritySettings.tsx
+++ b/apps/web/src/components/settings/SecuritySettings.tsx
@@ -1,21 +1,10 @@
 import { useState, type FormEvent } from "react";
-import {
-    Check,
-    Copy,
-    KeyRound,
-    Lock,
-    Shield,
-    ShieldAlert,
-    ShieldCheck,
-    Terminal,
-    Unlock,
-    KeySquare,
-    Loader2
-} from "lucide-react";
+import { Check, Copy, KeyRound, Eye, EyeOff } from "lucide-react";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SettingsSection, SettingsRow, SegmentedControl } from "./settings-ui";
 
 interface SecuritySettingsProps {
     requireApiKey: boolean;
@@ -34,13 +23,12 @@ export function SecuritySettings({
 }: SecuritySettingsProps) {
     const [codeTab, setCodeTab] = useState<CodeTab>("curl");
     const [copied, setCopied] = useState(false);
-
-    // Password change state
     const [currentPassword, setCurrentPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
     const [confirmation, setConfirmation] = useState("");
     const [isChangingPassword, setIsChangingPassword] = useState(false);
     const [passwordError, setPasswordError] = useState<string | null>(null);
+    const [showPasswords, setShowPasswords] = useState(false);
 
     const getSnippet = (tab: CodeTab) => {
         if (tab === "curl") {
@@ -48,8 +36,8 @@ export function SecuritySettings({
   -H "Content-Type: application/json" \\
 ${
     requireApiKey
-        ? '  -H "Authorization: Bearer sr-live-your_virtual_key" \\\n'
-        : '  # -H "Authorization: Bearer <optional_key>" \\\n'
+        ? '  -H "Authorization: Bearer sr-liv..._key" \\\n'
+        : '  # -H "Authorization: Bearer ***" \\\n'
 }  -d '{
     "model": "antigravity/gemini-2.5-flash",
     "messages": [
@@ -57,7 +45,6 @@ ${
     ]
   }'`;
         }
-
         if (tab === "typescript") {
             return `import OpenAI from "openai";
 
@@ -71,25 +58,20 @@ async function main() {
     model: "antigravity/gemini-2.5-flash",
     messages: [{ role: "user", content: "Hello SRouter!" }],
   });
-
   console.log(response.choices[0].message.content);
 }
-
 main();`;
         }
-
         return `from openai import OpenAI
 
 client = OpenAI(
     base_url="${apiBase}",
     api_key="${requireApiKey ? "sr-live-your_virtual_key" : "optional_or_any_string"}"
 )
-
 response = client.chat.completions.create(
     model="antigravity/gemini-2.5-flash",
     messages=[{"role": "user", "content": "Hello SRouter!"}]
 )
-
 print(response.choices[0].message.content)`;
     };
 
@@ -97,7 +79,7 @@ print(response.choices[0].message.content)`;
         try {
             await navigator.clipboard.writeText(getSnippet(codeTab));
             setCopied(true);
-            toast.success("Code snippet copied to clipboard");
+            toast.success("Code snippet copied");
             setTimeout(() => setCopied(false), 2000);
         } catch {
             toast.error("Failed to copy code snippet");
@@ -107,17 +89,14 @@ print(response.choices[0].message.content)`;
     const handleChangePassword = async (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         setPasswordError(null);
-
         if (!currentPassword) {
             setPasswordError("Please enter your current admin password.");
             return;
         }
-
         if (newPassword !== confirmation) {
             setPasswordError("New password and confirmation do not match.");
             return;
         }
-
         setIsChangingPassword(true);
         try {
             await api.post("/v1/admin/change-password", {
@@ -139,206 +118,118 @@ print(response.choices[0].message.content)`;
     };
 
     return (
-        <div className="space-y-6">
-            {/* Section 1: API Key & Gateway Access Enforcement */}
-            <div className="rounded-xl border border-border/80 bg-card p-5 space-y-5 shadow-2xs">
-                <div>
-                    <div className="flex items-center gap-2">
-                        <KeyRound className="size-4 text-amber-500" />
-                        <h2 className="text-sm font-bold text-foreground tracking-tight">
-                            API Key Authentication Enforcement
-                        </h2>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-1">
-                        Control whether external clients must provide a Bearer API Key to access
-                        gateway routing endpoints.
-                    </p>
+        <SettingsSection
+            index="01"
+            title="Security"
+            description="API key enforcement and the admin control plane password."
+        >
+            <SettingsRow
+                title="Enforce Bearer Authentication"
+                description={
+                    requireApiKey
+                        ? "Unauthenticated requests are rejected with HTTP 401."
+                        : "Anyone can query without an API key."
+                }
+                control={
+                    <SegmentedControl
+                        options={[
+                            { value: false, label: "OFF" },
+                            { value: true, label: "ON" }
+                        ]}
+                        value={requireApiKey}
+                        onChange={onToggleRequireApiKey}
+                        disabled={isUpdating}
+                    />
+                }
+            />
+
+            <div className="py-3.5">
+                <div className="flex items-center justify-between mb-2">
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                        Client Integration
+                    </span>
+                    <SegmentedControl
+                        options={[
+                            { value: "curl", label: "curl" },
+                            { value: "typescript", label: "ts" },
+                            { value: "python", label: "py" }
+                        ]}
+                        value={codeTab}
+                        onChange={setCodeTab}
+                    />
                 </div>
-
-                <div className="rounded-lg border border-border/70 bg-muted/20 p-4 space-y-4">
-                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-border/60 pb-4">
-                        <div className="space-y-1">
-                            <div className="flex items-center gap-2 flex-wrap">
-                                <span className="text-xs font-bold text-foreground">
-                                    Enforce Bearer Authentication
-                                </span>
-                                {requireApiKey ? (
-                                    <span className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-600 dark:text-emerald-400">
-                                        <ShieldCheck className="size-3" />
-                                        <span>Protected (Enforced)</span>
-                                    </span>
-                                ) : (
-                                    <span className="inline-flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400">
-                                        <Unlock className="size-3" />
-                                        <span>Open Access (Optional)</span>
-                                    </span>
-                                )}
-                            </div>
-                            <p className="text-[11px] text-muted-foreground leading-relaxed max-w-xl">
-                                {requireApiKey
-                                    ? "Gateway endpoints will reject unauthenticated requests with HTTP 401 Unauthorized unless a valid virtual SRouter key is supplied in the Authorization header."
-                                    : "Open access mode: Anyone can query SRouter models without an API key. Ideal for localhost development, IDE extensions, or private network deployments."}
-                            </p>
-                        </div>
-
-                        {/* Action Switch Buttons */}
-                        <div className="inline-flex items-center rounded-lg border border-border/80 bg-background/90 p-1 shadow-2xs self-start sm:self-auto shrink-0 font-mono gap-1">
-                            <button
-                                type="button"
-                                disabled={isUpdating}
-                                onClick={() => onToggleRequireApiKey(false)}
-                                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-all cursor-pointer ${
-                                    !requireApiKey
-                                        ? "bg-foreground text-background shadow-xs font-bold"
-                                        : "text-muted-foreground hover:text-foreground"
-                                }`}
-                            >
-                                <Unlock className="size-3" />
-                                <span>Disabled</span>
-                            </button>
-                            <button
-                                type="button"
-                                disabled={isUpdating}
-                                onClick={() => onToggleRequireApiKey(true)}
-                                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-all cursor-pointer ${
-                                    requireApiKey
-                                        ? "bg-foreground text-background shadow-xs font-bold"
-                                        : "text-muted-foreground hover:text-foreground"
-                                }`}
-                            >
-                                <Lock className="size-3" />
-                                <span>Required</span>
-                            </button>
-                        </div>
-                    </div>
-
-                    {/* Client Request Code Preview */}
-                    <div className="space-y-2">
-                        <div className="flex items-center justify-between">
-                            <span className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
-                                Client Request Integration Example:
-                            </span>
-                            <div className="inline-flex items-center gap-0.5 rounded-lg border border-border/80 bg-background/90 p-0.5 font-mono">
-                                {(["curl", "typescript", "python"] as const).map((tab) => (
-                                    <button
-                                        key={tab}
-                                        type="button"
-                                        onClick={() => setCodeTab(tab)}
-                                        className={`px-2.5 py-1 text-[10.5px] font-semibold rounded-md capitalize transition-colors cursor-pointer ${
-                                            codeTab === tab
-                                                ? "bg-foreground text-background shadow-xs font-bold"
-                                                : "text-muted-foreground hover:text-foreground"
-                                        }`}
-                                    >
-                                        {tab}
-                                    </button>
-                                ))}
-                            </div>
-                        </div>
-
-                        <div className="relative rounded-lg border border-border/80 bg-background p-3 font-mono text-[11px] text-foreground overflow-x-auto">
-                            <button
-                                type="button"
-                                onClick={handleCopy}
-                                className="absolute top-2.5 right-2.5 flex items-center gap-1 rounded bg-muted/80 hover:bg-muted px-2 py-1 text-[10px] font-semibold text-foreground transition-colors cursor-pointer"
-                                title="Copy code"
-                            >
-                                {copied ? (
-                                    <Check className="size-3 text-emerald-500" />
-                                ) : (
-                                    <Copy className="size-3" />
-                                )}
-                                <span>{copied ? "Copied" : "Copy"}</span>
-                            </button>
-                            <pre className="pr-16">{getSnippet(codeTab)}</pre>
-                        </div>
-                    </div>
+                <div className="relative rounded-md border border-border/70 bg-background p-3 font-mono text-[10.5px] leading-relaxed text-foreground overflow-x-auto">
+                    <button
+                        type="button"
+                        onClick={handleCopy}
+                        className="absolute right-1.5 top-1.5 flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[9px] font-semibold text-muted-foreground hover:text-foreground cursor-pointer"
+                    >
+                        {copied ? (
+                            <Check className="size-2.5 text-emerald-500" />
+                        ) : (
+                            <Copy className="size-2.5" />
+                        )}
+                        {copied ? "done" : "copy"}
+                    </button>
+                    <pre className="pr-14">{getSnippet(codeTab)}</pre>
                 </div>
             </div>
 
-            {/* Section 2: Admin Password & Control Plane Security */}
-            <div className="rounded-xl border border-border/80 bg-card p-5 space-y-4 shadow-2xs">
-                <div>
-                    <div className="flex items-center gap-2">
-                        <Shield className="size-4 text-emerald-500" />
-                        <h2 className="text-sm font-bold text-foreground tracking-tight">
-                            Admin Control Plane Password
-                        </h2>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-1">
-                        Update the master administrator password used to lock settings, provider
-                        credentials, and token configurations.
-                    </p>
-                </div>
-
-                <form onSubmit={handleChangePassword} className="space-y-3.5 max-w-lg">
+            <div className="py-3.5">
+                <div className="mb-2 text-xs font-semibold text-foreground">Admin Password</div>
+                <form onSubmit={handleChangePassword} className="space-y-2 max-w-xl">
                     {passwordError && (
-                        <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-                            <ShieldAlert className="size-4 shrink-0 mt-0.5" />
-                            <span>{passwordError}</span>
-                        </div>
+                        <div className="text-[11px] text-destructive">{passwordError}</div>
                     )}
-
-                    <div className="space-y-1">
-                        <label className="text-xs font-semibold text-foreground">
-                            Current Password
-                        </label>
+                    <div className="flex flex-wrap items-center gap-2">
                         <Input
-                            type="password"
-                            placeholder="Enter current admin password"
+                            type={showPasswords ? "text" : "password"}
+                            placeholder="Current"
                             value={currentPassword}
                             onChange={(e) => setCurrentPassword(e.target.value)}
                             required
+                            className="w-36 text-[11px]"
                         />
+                        <Input
+                            type={showPasswords ? "text" : "password"}
+                            placeholder="New"
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                            required
+                            className="w-36 text-[11px]"
+                        />
+                        <Input
+                            type={showPasswords ? "text" : "password"}
+                            placeholder="Confirm"
+                            value={confirmation}
+                            onChange={(e) => setConfirmation(e.target.value)}
+                            required
+                            className="w-36 text-[11px]"
+                        />
+                        <Button
+                            type="submit"
+                            size="sm"
+                            disabled={isChangingPassword}
+                            className="font-semibold"
+                        >
+                            <KeyRound className="size-3.5" />
+                            {isChangingPassword ? "Updating..." : "Update"}
+                        </Button>
+                        <button
+                            type="button"
+                            onClick={() => setShowPasswords(!showPasswords)}
+                            className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground cursor-pointer"
+                        >
+                            {showPasswords ? (
+                                <EyeOff className="size-3" />
+                            ) : (
+                                <Eye className="size-3" />
+                            )}
+                            {showPasswords ? "Hide" : "Show"}
+                        </button>
                     </div>
-
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <div className="space-y-1">
-                            <label className="text-xs font-semibold text-foreground">
-                                New Password
-                            </label>
-                            <Input
-                                type="password"
-                                placeholder="New password"
-                                value={newPassword}
-                                onChange={(e) => setNewPassword(e.target.value)}
-                                required
-                            />
-                        </div>
-                        <div className="space-y-1">
-                            <label className="text-xs font-semibold text-foreground">
-                                Confirm New Password
-                            </label>
-                            <Input
-                                type="password"
-                                placeholder="Repeat new password"
-                                value={confirmation}
-                                onChange={(e) => setConfirmation(e.target.value)}
-                                required
-                            />
-                        </div>
-                    </div>
-
-                    <Button
-                        type="submit"
-                        disabled={isChangingPassword}
-                        size="sm"
-                        className="mt-2 font-semibold"
-                    >
-                        {isChangingPassword ? (
-                            <>
-                                <Loader2 className="size-3.5 animate-spin" />
-                                <span>Updating Password...</span>
-                            </>
-                        ) : (
-                            <>
-                                <KeySquare className="size-3.5" />
-                                <span>Update Admin Password</span>
-                            </>
-                        )}
-                    </Button>
                 </form>
             </div>
-        </div>
+        </SettingsSection>
     );
 }

--- a/apps/web/src/components/settings/SystemSettings.tsx
+++ b/apps/web/src/components/settings/SystemSettings.tsx
@@ -1,26 +1,20 @@
 import { useState } from "react";
 import {
-    Cpu,
     Activity,
     ExternalLink,
-    Zap,
-    Layers,
-    Server,
-    Database,
-    Clock,
-    CheckCircle2,
     RefreshCw,
     Loader2,
-    ArrowUpCircle,
+    CheckCircle2,
     Copy,
     Check,
-    GitBranch,
-    Terminal
+    Terminal,
+    ArrowUpCircle
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { useVersion, GITHUB_REPO } from "@/hooks/useVersion";
+import { SettingsSection, SettingsRow } from "./settings-ui";
 
 interface SystemSettingsProps {
     apiBase: string;
@@ -31,7 +25,6 @@ export function SystemSettings({ apiBase }: SystemSettingsProps) {
     const [isPinging, setIsPinging] = useState(false);
     const [lastPingTime, setLastPingTime] = useState<string | null>(null);
     const [copiedCommand, setCopiedCommand] = useState(false);
-
     const {
         currentVersion,
         latestVersion,
@@ -48,8 +41,7 @@ export function SystemSettings({ apiBase }: SystemSettingsProps) {
         const start = performance.now();
         try {
             await api.get("/v1/settings");
-            const duration = Math.round(performance.now() - start);
-            setPingLatency(duration);
+            setPingLatency(Math.round(performance.now() - start));
             setLastPingTime(new Date().toLocaleTimeString());
         } catch {
             setPingLatency(-1);
@@ -59,270 +51,173 @@ export function SystemSettings({ apiBase }: SystemSettingsProps) {
         }
     };
 
-    const handleCheckUpdates = () => {
-        refetchVersion();
-        toast.info("Checking GitHub for the latest SRouter tags...");
-    };
-
-    const handleCopyUpdateCommand = async () => {
+    const handleCopy = async () => {
         try {
             await navigator.clipboard.writeText("git pull origin main && pnpm install");
             setCopiedCommand(true);
-            toast.success("Update command copied to clipboard");
+            toast.success("Command copied");
             setTimeout(() => setCopiedCommand(false), 2000);
         } catch {
-            toast.error("Failed to copy command");
+            toast.error("Failed to copy");
         }
     };
 
     return (
-        <div className="rounded-xl border border-border/80 bg-card p-5 space-y-6 shadow-2xs">
-            <div>
-                <div className="flex items-center gap-2">
-                    <Cpu className="size-4 text-cyan-500" />
-                    <h2 className="text-sm font-bold text-foreground tracking-tight">
-                        System Diagnostics & Runtime Architecture
-                    </h2>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                    Inspect core runtime engine, database storage architecture, and gateway
-                    connection health.
-                </p>
-            </div>
-
-            {/* Diagnostic Specs Grid */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs">
-                {/* Gateway Core Version & GitHub Tag Card */}
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-2">
+        <SettingsSection
+            index="07"
+            title="System"
+            description="Runtime diagnostics, version info, and health checks."
+        >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 py-2">
+                <div className="rounded-md border border-border/70 bg-muted/20 p-3 space-y-1.5">
                     <div className="flex items-center justify-between">
-                        <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                            Gateway Core Version
+                        <span className="text-[9px] font-bold uppercase tracking-wider text-muted-foreground">
+                            Version
                         </span>
                         <button
                             type="button"
-                            onClick={handleCheckUpdates}
+                            onClick={() => {
+                                refetchVersion();
+                                toast.info("Checking GitHub...");
+                            }}
                             disabled={isChecking}
-                            className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-                            title="Check for GitHub tag updates"
+                            className="text-[9px] text-muted-foreground hover:text-foreground cursor-pointer"
                         >
                             <RefreshCw
-                                className={`size-3 ${isChecking ? "animate-spin text-cyan-500" : ""}`}
-                            />
-                            <span>{isChecking ? "Checking..." : "Check update"}</span>
+                                className={`size-2.5 inline ${isChecking ? "animate-spin" : ""}`}
+                            />{" "}
+                            {isChecking ? "..." : "check"}
                         </button>
                     </div>
-
                     <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-bold text-foreground font-mono">
+                        <span className="font-bold font-mono text-xs text-foreground">
                             {currentVersion}
                         </span>
-                        <span className="inline-flex items-center rounded-md border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.2 text-[9.5px] font-semibold text-cyan-500">
-                            Release Candidate
-                        </span>
-
-                        {/* GitHub Tag / Update Status Badge */}
-                        {isChecking ? (
-                            <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-0.2 text-[9.5px] text-muted-foreground animate-pulse">
-                                Checking GitHub...
-                            </span>
-                        ) : hasUpdate ? (
+                        {hasUpdate ? (
                             <a
                                 href={releaseUrl}
                                 target="_blank"
                                 rel="noreferrer"
-                                className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 hover:bg-amber-500/25 px-2 py-0.5 text-[10px] font-bold text-amber-500 transition-colors shadow-2xs"
-                                title={`New tag ${latestVersion} available on GitHub`}
+                                className="flex items-center gap-1 text-[9px] font-bold text-amber-500 border border-amber-500/30 rounded-sm px-1.5 py-0.5 hover:bg-amber-500/10"
                             >
-                                <ArrowUpCircle className="size-3 text-amber-500" />
-                                <span>Update Available: {latestVersion}</span>
-                                <ExternalLink className="size-2.5" />
+                                {latestVersion} <ExternalLink className="size-2" />
                             </a>
                         ) : latestVersion ? (
-                            <span className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.2 text-[9.5px] font-semibold text-emerald-600 dark:text-emerald-400">
-                                <CheckCircle2 className="size-3" />
-                                <span>Up to date ({latestVersion})</span>
+                            <span className="flex items-center gap-1 text-[9px] text-emerald-500">
+                                <CheckCircle2 className="size-2.5" /> up to date
                             </span>
                         ) : null}
                     </div>
-
                     {lastChecked && (
-                        <div className="text-[10px] font-mono text-muted-foreground/70">
-                            Checked with GitHub at {lastChecked.toLocaleTimeString()}
+                        <div className="text-[9px] font-mono text-muted-foreground/70">
+                            checked {lastChecked.toLocaleTimeString()}
                         </div>
                     )}
                 </div>
-
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-1.5">
-                    <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                        Persistence & Database Engine
+                <div className="rounded-md border border-border/70 bg-muted/20 p-3 space-y-1">
+                    <span className="text-[9px] font-bold uppercase tracking-wider text-muted-foreground">
+                        Stack
                     </span>
-                    <div className="font-bold text-foreground flex items-center gap-1.5">
-                        <Database className="size-3.5 text-amber-500" />
-                        <span>SQLite WAL Mode (srouter.db)</span>
-                    </div>
-                </div>
-
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-1.5">
-                    <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                        API Gateway Framework
-                    </span>
-                    <div className="font-bold text-foreground flex items-center gap-1.5">
-                        <Server className="size-3.5 text-blue-500" />
-                        <span>Hono Framework (Node.js / Bun)</span>
-                    </div>
-                </div>
-
-                <div className="p-4 rounded-xl border border-border/80 bg-muted/20 space-y-1.5">
-                    <span className="text-[10.5px] font-bold uppercase tracking-wider text-muted-foreground">
-                        Protocol Compatibility
-                    </span>
-                    <div className="font-bold text-emerald-500 flex items-center gap-1.5">
-                        <span className="size-2 rounded-full bg-emerald-500 animate-pulse" />
-                        <span>OpenAI v1 + Anthropic Messages SSE</span>
+                    <div className="text-xs font-bold text-foreground">
+                        SQLite WAL · Hono · Node.js
                     </div>
                 </div>
             </div>
 
-            {/* Update Notification Banner if update is available */}
             {hasUpdate && (
-                <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 space-y-3 shadow-xs">
-                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+                <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 space-y-2">
+                    <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
-                            <ArrowUpCircle className="size-4 text-amber-500 shrink-0" />
-                            <div>
-                                <span className="text-xs font-bold text-foreground">
-                                    New SRouter Version Available ({latestVersion})
-                                </span>
-                                <p className="text-[11px] text-muted-foreground mt-0.5">
-                                    A newer release tag has been published on GitHub ({GITHUB_REPO}
-                                    ).
-                                </p>
-                            </div>
+                            <ArrowUpCircle className="size-3.5 text-amber-500" />
+                            <span className="text-xs font-bold text-foreground">
+                                Update {latestVersion} available
+                            </span>
                         </div>
-
                         <a
                             href={releaseUrl}
                             target="_blank"
                             rel="noreferrer"
-                            className="inline-flex items-center gap-1.5 rounded-lg border border-amber-500/40 bg-amber-500 text-black px-3 py-1.5 text-xs font-bold hover:bg-amber-400 transition-colors shadow-2xs self-start sm:self-auto shrink-0"
+                            className="text-[10px] font-bold text-amber-500 border border-amber-500/30 rounded px-2 py-0.5 hover:bg-amber-500/10"
                         >
-                            <span>View Release</span>
-                            <ExternalLink className="size-3" />
+                            View <ExternalLink className="size-2 inline" />
                         </a>
                     </div>
-
-                    <div className="rounded-lg bg-background/80 border border-border/70 p-2.5 flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-2 min-w-0 font-mono text-[11px] text-foreground overflow-x-auto">
-                            <Terminal className="size-3.5 text-muted-foreground shrink-0" />
-                            <code>git pull origin main && pnpm install</code>
-                        </div>
+                    <div className="flex items-center justify-between rounded-md bg-background/80 border border-border/70 p-2">
+                        <code className="text-[10px] font-mono text-foreground">
+                            git pull origin main && pnpm install
+                        </code>
                         <button
                             type="button"
-                            onClick={handleCopyUpdateCommand}
-                            className="flex items-center gap-1 px-2 py-1 rounded bg-muted hover:bg-muted/80 text-[10px] font-semibold text-foreground transition-colors shrink-0 cursor-pointer"
+                            onClick={handleCopy}
+                            className="flex items-center gap-1 text-[9px] text-muted-foreground hover:text-foreground cursor-pointer"
                         >
                             {copiedCommand ? (
-                                <Check className="size-3 text-emerald-500" />
+                                <Check className="size-2.5 text-emerald-500" />
                             ) : (
-                                <Copy className="size-3" />
-                            )}
-                            <span>{copiedCommand ? "Copied" : "Copy"}</span>
+                                <Copy className="size-2.5" />
+                            )}{" "}
+                            {copiedCommand ? "done" : "copy"}
                         </button>
                     </div>
                 </div>
             )}
 
-            {/* Live Gateway Health & Latency Test */}
-            <div className="rounded-xl border border-border/80 bg-muted/20 p-4 space-y-3">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-                    <div className="space-y-0.5">
-                        <div className="text-xs font-bold text-foreground flex items-center gap-1.5">
-                            <Activity className="size-3.5 text-emerald-500" />
-                            <span>Live Gateway Latency Check</span>
-                        </div>
-                        <p className="text-[11px] text-muted-foreground">
-                            Measure roundtrip HTTP ping latency from browser to the SRouter local
-                            API daemon.
-                        </p>
+            <div className="rounded-md border border-border/70 bg-muted/20 p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Activity className="size-3.5 text-emerald-500" />
+                        <span className="text-xs font-semibold text-foreground">
+                            Gateway Latency
+                        </span>
                     </div>
-
                     <Button
                         type="button"
                         variant="outline"
                         size="sm"
                         disabled={isPinging}
                         onClick={handlePing}
-                        className="self-start sm:self-auto font-semibold cursor-pointer shrink-0"
+                        className="cursor-pointer"
                     >
                         {isPinging ? (
-                            <Loader2 className="size-3.5 animate-spin" />
+                            <Loader2 className="size-3 animate-spin" />
                         ) : (
-                            <RefreshCw className="size-3.5" />
+                            <RefreshCw className="size-3" />
                         )}
-                        <span>{isPinging ? "Pinging..." : "Test Latency"}</span>
+                        {isPinging ? "pinging..." : "ping"}
                     </Button>
                 </div>
-
                 {pingLatency !== null && (
-                    <div className="flex items-center justify-between p-3 rounded-lg border border-border/70 bg-background text-xs">
-                        <div className="flex items-center gap-2">
-                            {pingLatency >= 0 ? (
-                                <span className="flex items-center gap-1.5 font-bold text-emerald-500">
-                                    <CheckCircle2 className="size-4" />
-                                    <span>Gateway Healthy & Online</span>
-                                </span>
-                            ) : (
-                                <span className="font-bold text-destructive">
-                                    Gateway Offline / Unreachable
-                                </span>
-                            )}
-                        </div>
-                        <div className="flex items-center gap-3 text-muted-foreground text-[11px] font-mono">
-                            {pingLatency >= 0 && (
-                                <span className="text-foreground font-bold tabular-nums">
-                                    Roundtrip:{" "}
-                                    <span className="text-emerald-500">{pingLatency}ms</span>
-                                </span>
-                            )}
-                            {lastPingTime && <span>Checked at {lastPingTime}</span>}
-                        </div>
+                    <div className="flex items-center justify-between text-[11px] font-mono">
+                        {pingLatency >= 0 ? (
+                            <span className="text-emerald-500 font-semibold">{pingLatency}ms</span>
+                        ) : (
+                            <span className="text-destructive font-semibold">offline</span>
+                        )}
+                        {lastPingTime && (
+                            <span className="text-muted-foreground">at {lastPingTime}</span>
+                        )}
                     </div>
                 )}
             </div>
 
-            {/* Quick Reference Links */}
-            <div className="space-y-3 pt-2">
-                <span className="text-xs font-bold text-foreground">
-                    Quick Reference & Resources
-                </span>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                    <a
-                        href={`https://github.com/${GITHUB_REPO}`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex items-center justify-between p-3 rounded-lg border border-border/80 bg-background hover:bg-muted/40 text-xs font-medium text-foreground transition-colors group"
-                    >
-                        <span className="flex items-center gap-2">
-                            <Layers className="size-3.5 text-muted-foreground group-hover:text-foreground" />
-                            <span>SRouter GitHub Repository</span>
-                        </span>
-                        <ExternalLink className="size-3 text-muted-foreground group-hover:text-foreground" />
-                    </a>
-
-                    <a
-                        href={tagsUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex items-center justify-between p-3 rounded-lg border border-border/80 bg-background hover:bg-muted/40 text-xs font-medium text-foreground transition-colors group"
-                    >
-                        <span className="flex items-center gap-2">
-                            <GitBranch className="size-3.5 text-muted-foreground group-hover:text-foreground" />
-                            <span>GitHub Releases & Tags</span>
-                        </span>
-                        <ExternalLink className="size-3 text-muted-foreground group-hover:text-foreground" />
-                    </a>
-                </div>
+            <div className="flex gap-2 pt-2">
+                <a
+                    href={`https://github.com/${GITHUB_REPO}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-1.5 rounded-md border border-border/70 px-2.5 py-1.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
+                >
+                    GitHub <ExternalLink className="size-2.5" />
+                </a>
+                <a
+                    href={tagsUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-1.5 rounded-md border border-border/70 px-2.5 py-1.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
+                >
+                    Releases <ExternalLink className="size-2.5" />
+                </a>
             </div>
-        </div>
+        </SettingsSection>
     );
 }

--- a/apps/web/src/components/settings/settings-ui.tsx
+++ b/apps/web/src/components/settings/settings-ui.tsx
@@ -1,0 +1,118 @@
+export function SettingsSection({
+    index,
+    title,
+    description,
+    children
+}: {
+    index?: string;
+    title: string;
+    description?: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <section className="py-8 first:pt-2 last:pb-2">
+            <div className="mb-5">
+                <div className="flex items-baseline gap-3">
+                    {index && (
+                        <span className="font-mono text-[10px] text-muted-foreground/50">
+                            {index}
+                        </span>
+                    )}
+                    <h2 className="text-sm font-bold tracking-tight text-foreground">{title}</h2>
+                </div>
+                {description && (
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                        {description}
+                    </p>
+                )}
+            </div>
+            <div className="divide-y divide-border/60">{children}</div>
+        </section>
+    );
+}
+
+export function SettingsRow({
+    title,
+    description,
+    control,
+    className
+}: {
+    title: string;
+    description?: string;
+    control?: React.ReactNode;
+    className?: string;
+}) {
+    return (
+        <div
+            className={[
+                "flex flex-col gap-2 py-3.5 sm:flex-row sm:items-center sm:justify-between",
+                className ?? ""
+            ].join(" ")}
+        >
+            <div className="min-w-0 pr-4">
+                <div className="text-xs font-semibold text-foreground leading-tight">{title}</div>
+                {description && (
+                    <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                        {description}
+                    </p>
+                )}
+            </div>
+            {control && <div className="shrink-0">{control}</div>}
+        </div>
+    );
+}
+
+export function SegmentedControl<T extends string | number | boolean>({
+    options,
+    value,
+    onChange,
+    disabled,
+    className
+}: {
+    options: Array<{ value: T; label: string }>;
+    value: T;
+    onChange: (value: T) => void;
+    disabled?: boolean;
+    className?: string;
+}) {
+    return (
+        <div
+            role="tablist"
+            className={[
+                "inline-flex items-center gap-1 rounded-md border border-border/70 bg-secondary/30 p-0.5",
+                className ?? ""
+            ].join(" ")}
+        >
+            {options.map((option) => {
+                const isActive = option.value === value;
+                return (
+                    <button
+                        key={String(option.value)}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        disabled={disabled}
+                        onClick={() => onChange(option.value)}
+                        className={[
+                            "rounded px-2.5 py-1 text-[11px] font-medium transition-all",
+                            "disabled:pointer-events-none disabled:opacity-50",
+                            isActive
+                                ? "bg-foreground text-background font-semibold"
+                                : "text-muted-foreground hover:text-foreground"
+                        ].join(" ")}
+                    >
+                        {option.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+export function ValueBadge({ children }: { children: React.ReactNode }) {
+    return (
+        <span className="inline-flex items-center rounded-md border border-border/70 bg-background px-2 py-0.5 font-mono text-[11px] font-bold tabular-nums text-foreground">
+            {children}
+        </span>
+    );
+}

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,18 +1,6 @@
 import { useState, useEffect } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-    Cpu,
-    Database,
-    Download,
-    KeyRound,
-    Palette,
-    RotateCcw,
-    Server,
-    Shield,
-    Terminal,
-    ArrowUpCircle
-} from "lucide-react";
 import { toast } from "sonner";
 import { api, getGatewayBaseUrl } from "@/lib/api";
 import { useTheme } from "@/context/Theme";
@@ -33,9 +21,6 @@ export const Route = createFileRoute("/settings")({
     staticData: { title: "Settings" },
     component: SettingsPage
 });
-
-type SettingsTab =
-    "security" | "gateway" | "appearance" | "logging" | "playground" | "data" | "system";
 
 interface ServerSettingsResponse {
     require_api_key?: boolean;
@@ -58,9 +43,7 @@ function SettingsPage() {
     const { hasUpdate, latestVersion } = useVersion();
 
     const apiBase = getGatewayBaseUrl();
-    const [activeTab, setActiveTab] = useState<SettingsTab>("security");
 
-    // Fetch server settings from /v1/settings
     const { data: serverSettings, isPending: isLoadingServerSettings } =
         useQuery<ServerSettingsResponse>({
             queryKey: ["server_settings"],
@@ -78,21 +61,13 @@ function SettingsPage() {
         }
     }, [serverSettings]);
 
-    // Mutation to update server settings
     const updateServerMutation = useMutation({
         mutationFn: (newRequireApiKey: boolean) =>
-            api.post("/v1/settings", {
-                require_api_key: newRequireApiKey
-            }),
+            api.post("/v1/settings", { require_api_key: newRequireApiKey }),
         onSuccess: (_data, newRequireApiKey) => {
             queryClient.invalidateQueries({ queryKey: ["server_settings"] });
             toast.success(
-                newRequireApiKey ? "API Key Authentication Required" : "Open Access Mode Enabled",
-                {
-                    description: newRequireApiKey
-                        ? "Gateway endpoints will now require Bearer token authorization."
-                        : "Gateway endpoints are now accessible without an API key."
-                }
+                newRequireApiKey ? "API Key Authentication Required" : "Open Access Mode Enabled"
             );
         },
         onError: (err) => {
@@ -107,150 +82,72 @@ function SettingsPage() {
         updateServerMutation.mutate(value);
     };
 
-    const tabs: { id: SettingsTab; label: string; icon: typeof Palette; hasBadge?: boolean }[] = [
-        { id: "security", label: "Security & API Key", icon: KeyRound },
-        { id: "gateway", label: "Gateway & Proxy", icon: Server },
-        { id: "appearance", label: "Appearance", icon: Palette },
-        { id: "logging", label: "Logging & Privacy", icon: Shield },
-        { id: "playground", label: "Playground Defaults", icon: Terminal },
-        { id: "data", label: "Data & Storage", icon: Database },
-        { id: "system", label: "System Diagnostics", icon: Cpu, hasBadge: hasUpdate }
-    ];
-
     if (isLoadingServerSettings) {
         return <SettingsSkeleton />;
     }
 
     return (
-        <div className="mx-auto w-full max-w-5xl flex flex-col gap-6 font-mono">
+        <div className="mx-auto w-full max-w-3xl font-mono">
             {/* Header */}
-            <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end border-b border-border/80 pb-5">
-                <div className="min-w-0">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/80">
-                        Control Plane
-                    </p>
-                    <div className="flex items-center gap-2 flex-wrap mt-1.5">
-                        <h1 className="text-2xl font-bold tracking-tight text-foreground">
-                            Settings & Operations
-                        </h1>
-                        {hasUpdate && latestVersion && (
-                            <button
-                                type="button"
-                                onClick={() => setActiveTab("system")}
-                                className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-bold text-amber-500 hover:bg-amber-500/20 transition-colors cursor-pointer"
-                            >
-                                <ArrowUpCircle className="size-3 text-amber-500" />
-                                <span>Update {latestVersion} available</span>
-                            </button>
-                        )}
-                    </div>
-                    <p className="mt-1 max-w-2xl text-xs text-muted-foreground leading-relaxed">
-                        Manage gateway routing rules, authentication requirements, telemetry
-                        logging, and UI preferences.
-                    </p>
+            <header className="flex items-center justify-between border-b border-border/70 pb-4 mb-2">
+                <div className="flex items-center gap-3">
+                    <h1 className="text-lg font-bold text-foreground">Settings</h1>
+                    {hasUpdate && latestVersion && (
+                        <span className="text-[9px] font-bold tracking-wider uppercase text-amber-500 border border-amber-500/30 rounded-sm px-1.5 py-0.5">
+                            {latestVersion}
+                        </span>
+                    )}
                 </div>
-
-                <div className="flex shrink-0 items-center gap-2">
-                    <Button
+                <div className="flex items-center gap-1.5">
+                    <button
                         type="button"
-                        variant="outline"
-                        size="sm"
                         onClick={exportSettings}
-                        className="h-8 text-xs font-medium cursor-pointer gap-1.5 border-border/80 bg-card hover:bg-secondary/60 transition-colors shadow-2xs"
+                        className="text-[10px] text-muted-foreground hover:text-foreground border border-border/70 rounded px-2 py-1 cursor-pointer transition-colors"
                     >
-                        <Download className="size-3.5 text-muted-foreground" />
-                        <span>Export Config</span>
-                    </Button>
-                    <Button
+                        Export
+                    </button>
+                    <button
                         type="button"
-                        variant="outline"
-                        size="sm"
                         onClick={resetToDefaults}
-                        className="h-8 text-xs font-medium text-rose-500 hover:text-rose-600 hover:bg-rose-500/10 border-border/80 bg-card transition-colors cursor-pointer shadow-2xs gap-1.5"
+                        className="text-[10px] text-muted-foreground hover:text-rose-500 border border-border/70 rounded px-2 py-1 cursor-pointer transition-colors"
                     >
-                        <RotateCcw className="size-3.5" />
-                        <span>Reset</span>
-                    </Button>
+                        Reset
+                    </button>
                 </div>
             </header>
 
-            {/* Layout: Sidebar Tabs + Content Panel */}
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-6 items-start">
-                {/* Navigation Tabs */}
-                <nav
-                    aria-label="Settings sections"
-                    className="flex md:flex-col gap-1 overflow-x-auto md:overflow-visible pb-2 md:pb-0 md:sticky md:top-0 z-10"
-                >
-                    {tabs.map(({ id, label, icon: Icon, hasBadge }) => {
-                        const isActive = activeTab === id;
-                        return (
-                            <button
-                                key={id}
-                                type="button"
-                                onClick={() => setActiveTab(id)}
-                                className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all text-left whitespace-nowrap cursor-pointer ${
-                                    isActive
-                                        ? "bg-foreground text-background shadow-xs"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
-                                }`}
-                            >
-                                <Icon className="size-3.5 shrink-0" />
-                                <span>{label}</span>
-                                {hasBadge && (
-                                    <span className="ml-auto inline-flex items-center rounded-full bg-amber-500/20 text-amber-500 border border-amber-500/40 px-1.5 py-0.2 text-[9px] font-bold">
-                                        Update
-                                    </span>
-                                )}
-                            </button>
-                        );
-                    })}
-                </nav>
+            {/* Single scrollable content */}
+            <main className="min-w-0 pb-12">
+                <SecuritySettings
+                    requireApiKey={requireApiKey}
+                    onToggleRequireApiKey={handleToggleRequireApiKey}
+                    isUpdating={updateServerMutation.isPending}
+                    apiBase={apiBase}
+                />
 
-                {/* Main Settings Panel */}
-                <main className="md:col-span-3 space-y-4">
-                    {activeTab === "security" && (
-                        <SecuritySettings
-                            requireApiKey={requireApiKey}
-                            onToggleRequireApiKey={handleToggleRequireApiKey}
-                            isUpdating={updateServerMutation.isPending}
-                            apiBase={apiBase}
-                        />
-                    )}
+                <GatewaySettings settings={settings} updateSetting={updateSetting} />
 
-                    {activeTab === "gateway" && (
-                        <GatewaySettings settings={settings} updateSetting={updateSetting} />
-                    )}
+                <AppearanceSettings
+                    theme={theme}
+                    toggleTheme={toggleTheme}
+                    settings={settings}
+                    updateSetting={updateSetting}
+                />
 
-                    {activeTab === "appearance" && (
-                        <AppearanceSettings
-                            theme={theme}
-                            toggleTheme={toggleTheme}
-                            settings={settings}
-                            updateSetting={updateSetting}
-                        />
-                    )}
+                <LoggingSettings settings={settings} updateSetting={updateSetting} />
 
-                    {activeTab === "logging" && (
-                        <LoggingSettings settings={settings} updateSetting={updateSetting} />
-                    )}
+                <PlaygroundSettings settings={settings} updateSetting={updateSetting} />
 
-                    {activeTab === "playground" && (
-                        <PlaygroundSettings settings={settings} updateSetting={updateSetting} />
-                    )}
+                <DataSettings
+                    exportSettings={exportSettings}
+                    importSettings={importSettings}
+                    clearPlaygroundHistory={clearPlaygroundHistory}
+                    resetToDefaults={resetToDefaults}
+                    getStorageStats={getStorageStats}
+                />
 
-                    {activeTab === "data" && (
-                        <DataSettings
-                            exportSettings={exportSettings}
-                            importSettings={importSettings}
-                            clearPlaygroundHistory={clearPlaygroundHistory}
-                            resetToDefaults={resetToDefaults}
-                            getStorageStats={getStorageStats}
-                        />
-                    )}
-
-                    {activeTab === "system" && <SystemSettings apiBase={apiBase} />}
-                </main>
-            </div>
+                <SystemSettings apiBase={apiBase} />
+            </main>
         </div>
     );
 }


### PR DESCRIPTION
## What

Total redesign of the Settings page per feedback: **minimalist, single-scroll** — no tabs, no card boxes, no icon tiles. Just one clean scrollable column of settings sections separated by hairlines.

## Design

- **Single page scroll** — all 7 groups (Security, Gateway, Appearance, Logging, Playground, Data, System) stack vertically; index numbers 01–07 act as subtle section markers.
- **No card wrappers** — sections are open, separated by `divide-y` hairlines. Rows are label left / control right, tight 11px type.
- **Compact terminal-like controls** — segmented pills (OFF/ON, curl/ts/py, 30s/60s/120s...), monospace value badges, slim range sliders.
- **Header minimal** — title + version badge + Export/Reset as tiny ghost buttons.
- Keeps all existing behavior (API key toggle, password change form, import/export dialogs, storage meter, ping test).

## Files

- `apps/web/src/routes/settings.tsx` — single-scroll layout
- `apps/web/src/components/settings/settings-ui.tsx` — SettingsSection/SettingsRow/SegmentedControl/ValueBadge primitives
- All 7 settings components rewritten

## Verification

- `cd apps/web && pnpm run build` — passes
- Prettier applied
- Settings chunk: 66.68 kB → **34.58 kB** (gzip 14.91 → 9.93 kB)