### PR TITLE
feat(providers): real round-robin load balancing across multi-account connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ Thumbs.db
 # TypeScript incremental build metadata
 apps/web/tsconfig.tsbuildinfo
 
+# Graphify knowledge graph output
+graphify-out/
+.graphify-out/
+
 # Lockfiles from alternative package managers (pnpm-lock.yaml is tracked for CI/Docker)
 package-lock.json
 yarn.lock

--- a/apps/api/src/controllers/providers.controller.ts
+++ b/apps/api/src/controllers/providers.controller.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono";
 import type { CreateProviderPayload } from "@/logic/providers.logic.js";
 import { ProvidersLogic } from "@/logic/providers.logic.js";
 import { deleteProviderDB } from "@srouter/db";
-import { AddCustomModelSchema, CreateProviderSchema, VerifyProviderSchema } from "@srouter/types";
+import { AddCustomModelSchema, CreateProviderSchema, ToggleRoundRobinSchema, VerifyProviderSchema } from "@srouter/types";
 import { loadSavedProvidersFromDB, registry } from "@/services/registry.js";
 import { Err, Ok } from "@/utils/response.js";
 
@@ -97,6 +97,24 @@ export class ProvidersController {
             return Ok(c, { message: "Custom model deleted" });
         } catch (error) {
             return Err(c, error instanceof Error ? error.message : "Failed to delete model", 404);
+        }
+    }
+
+    public static async ToggleRoundRobin(c: Context): Promise<Response> {
+        const ProviderId = c.req.param("providerId");
+        if (!ProviderId) return Err(c, "Provider ID is required", 400);
+
+        const RawBody = await c.req.json().catch(() => null);
+        const Parsed = ToggleRoundRobinSchema.safeParse(RawBody);
+        if (!Parsed.success) {
+            return Err(c, Parsed.error.issues[0]?.message || "Invalid payload", 400);
+        }
+
+        try {
+            const Result = await ProvidersLogic.SetRoundRobin(ProviderId, Parsed.data.enabled);
+            return Ok(c, Result);
+        } catch (error) {
+            return Err(c, error instanceof Error ? error.message : "Failed to toggle round-robin mode", 400);
         }
     }
 }

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -18,6 +18,8 @@ import {
     deleteCustomModelDB,
     getAllProvidersDB,
     getCustomModelsByProviderDB,
+    getRoundRobinDB,
+    setRoundRobinDB,
     upsertProviderDB
 } from "@srouter/db";
 import { loadSavedProvidersFromDB, registry } from "@/services/registry.js";
@@ -113,6 +115,7 @@ function CatalogWithSavedProviders(): ProviderDefinition[] {
             requires_api_key: Seed ? Seed.requires_api_key : Boolean(Connection.apiKey),
             requires_oauth: Seed?.requires_oauth,
             supports_custom_url: Seed ? (Seed.supports_custom_url ?? true) : true,
+            roundRobin: getRoundRobinDB(BaseId),
             status: {
                 state: ConnectedCount > 0 ? "connected" : "no_connections",
                 message: Seed?.status_message,
@@ -135,6 +138,7 @@ function CatalogWithSavedProviders(): ProviderDefinition[] {
             requires_api_key: Seed.requires_api_key,
             requires_oauth: Seed.requires_oauth,
             supports_custom_url: Seed.supports_custom_url ?? true,
+            roundRobin: getRoundRobinDB(Seed.id),
             status: {
                 state: "no_connections",
                 message: Seed.status_message,
@@ -312,6 +316,23 @@ export class ProvidersLogic {
         const Deleted = deleteCustomModelDB(ProviderId.toLowerCase(), ModelId);
         if (!Deleted) throw new Error(`Custom model '${ModelId}' not found for '${ProviderId}'`);
         registry.clearModelsCache();
+    }
+
+    public static async SetRoundRobin(ProviderId: string, Enabled: boolean): Promise<ProviderDefinition> {
+        const Id = ProviderId.toLowerCase();
+        const Exists =
+            DEFAULT_PROVIDER_MAP[Id] !== undefined ||
+            getAllProvidersDB().some((P) => BaseIdOf(P.providerId || P.id) === Id);
+        if (!Exists) {
+            throw new Error(`Provider '${ProviderId}' not found`);
+        }
+
+        setRoundRobinDB(Id, Enabled);
+        // Keep the in-memory registry flag in sync — loadSavedProvidersFromDB only runs at boot
+        registry.setRoundRobin(Id, Enabled);
+        const Provider = await ProvidersLogic.GetProviderById(Id);
+        if (!Provider) throw new Error(`Provider '${ProviderId}' not found`);
+        return Provider;
     }
 
     public static ListCustomModels(ProviderId: string): ModelObject[] {

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -25,3 +25,10 @@ ProvidersRouter.delete(
     RequireAdmin,
     ProvidersController.DeleteCustomModel
 );
+
+// Round-robin load balancing toggle
+ProvidersRouter.patch(
+    "/providers/:providerId/round-robin",
+    RequireAdmin,
+    ProvidersController.ToggleRoundRobin
+);

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -11,12 +11,13 @@ import {
     isSeedProvider,
     NEOSANTARA_BASE_URL,
     OPENCODE_ZEN_BASE_URL,
+    providerBaseId,
     SEED_MARKER,
     SEEKAI_BASE_URL,
     TABITOKEN_BASE_URL,
     TOKENROUTER_BASE_URL
 } from "@srouter/constants";
-import { deleteProviderDB, getAllProvidersDB, upsertProviderDB } from "@srouter/db";
+import { deleteProviderDB, getAllProvidersDB, getRoundRobinDB, upsertProviderDB } from "@srouter/db";
 import {
     AntigravityExecutor,
     AnthropicExecutor,
@@ -102,6 +103,7 @@ export function loadSavedProvidersFromDB(): void {
 
         const providerType = p.providerId || p.id;
         const baseUrl = p.base_url;
+        registry.setRoundRobin(providerBaseId(p.id), getRoundRobinDB(providerBaseId(p.id)));
 
         switch (true) {
             case isProviderBaseId(p.id, "kiro"):

--- a/apps/api/tests/round-robin-endpoint.test.ts
+++ b/apps/api/tests/round-robin-endpoint.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { ProvidersRouter } from "../src/routes/v1/providers.js";
+import { registry } from "../src/services/registry.js";
+import type { AIProvider } from "@srouter/types";
+
+function mockProvider(id: string): AIProvider {
+    return {
+        id,
+        name: `Mock ${id}`,
+        listModels: async () => [{ id: `${id}/mock-model`, object: "model", owned_by: id }],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+}
+
+test("round-robin toggle persists and flips registry flag", async (t) => {
+    const openai1 = "openai_1789000001";
+    const openai2 = "openai_1789000002";
+    registry.registerProvider(mockProvider(openai1));
+    registry.registerProvider(mockProvider(openai2));
+
+    t.after(() => {
+        registry.unregisterProvider(openai1);
+        registry.unregisterProvider(openai2);
+        registry.setRoundRobin("openai", false);
+    });
+
+    const app = new Hono();
+    app.route("/v1", ProvidersRouter);
+
+    // Requires admin session — expect 401 without it (proves mutation guard)
+    const unauth = await app.request("/v1/providers/openai/round-robin", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true })
+    });
+    assert.equal(unauth.status, 401, "mutation without admin session should be rejected");
+});

--- a/apps/web/src/components/providers/ConnectionCard.tsx
+++ b/apps/web/src/components/providers/ConnectionCard.tsx
@@ -12,7 +12,7 @@ interface ConnectionCardProps {
     connections: ProviderConfig[];
     roundRobin: boolean;
     isDeleting: boolean;
-    onToggleRoundRobin: () => void;
+    onToggleRoundRobin: (enabled: boolean) => void;
     onRefresh: () => void;
     onAdd: () => void;
     onDelete: (connectionId: string) => void;

--- a/apps/web/src/hooks/useProvider.ts
+++ b/apps/web/src/hooks/useProvider.ts
@@ -58,6 +58,21 @@ export function useProvider(providerId: string) {
         }
     });
 
+    const toggleRoundRobinMutation = useMutation({
+        mutationFn: (enabled: boolean) =>
+            api.patch<ProviderDefinition>(`/v1/providers/${providerId}/round-robin`, { enabled }),
+        onSuccess: (data) => {
+            void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
+            void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
+            toast.success(
+                data.roundRobin ? "Round-robin load balancing enabled" : "Round-robin load balancing disabled"
+            );
+        },
+        onError: (err: Error) => {
+            toast.error(err.message || "Failed to update round-robin mode");
+        }
+    });
+
     const addModelMutation = useMutation({
         mutationFn: (modelId: string) =>
             api.post<ModelObject>(`/v1/providers/${providerId}/models`, { model_id: modelId }),
@@ -86,5 +101,12 @@ export function useProvider(providerId: string) {
         }
     });
 
-    return { ...query, addMutation, deleteMutation, addModelMutation, deleteModelMutation };
+    return {
+        ...query,
+        addMutation,
+        deleteMutation,
+        toggleRoundRobinMutation,
+        addModelMutation,
+        deleteModelMutation
+    };
 }

--- a/apps/web/src/routes/providers/$providerId.tsx
+++ b/apps/web/src/routes/providers/$providerId.tsx
@@ -329,9 +329,7 @@ function ProviderDetailPage() {
                 connections={connections}
                 roundRobin={provider.roundRobin ?? false}
                 isDeleting={deleteMutation.isPending}
-                onToggleRoundRobin={() =>
-                    toggleRoundRobinMutation.mutate(!(provider.roundRobin ?? false))
-                }
+                onToggleRoundRobin={(enabled) => toggleRoundRobinMutation.mutate(enabled)}
                 onRefresh={() => void refetch()}
                 onAdd={handleAddConnection}
                 onDelete={(connectionId) =>

--- a/apps/web/src/routes/providers/$providerId.tsx
+++ b/apps/web/src/routes/providers/$providerId.tsx
@@ -41,13 +41,13 @@ function ProviderDetailPage() {
         refetch,
         addMutation,
         deleteMutation,
+        toggleRoundRobinMutation,
         addModelMutation,
         deleteModelMutation
     } = useProvider(providerId);
 
     const [modelSearch, setModelSearch] = useState("");
     const [viewMode, setViewMode] = useState<"table" | "grid">("table");
-    const [roundRobin, setRoundRobin] = useState(false);
     const [isAddOpen, setIsAddOpen] = useState(false);
     const [isOAuthModalOpen, setIsOAuthModalOpen] = useState(false);
     const [isAddModelOpen, setIsAddModelOpen] = useState(false);
@@ -327,9 +327,11 @@ function ProviderDetailPage() {
             <ConnectionCard
                 providerName={provider.name}
                 connections={connections}
-                roundRobin={roundRobin}
+                roundRobin={provider.roundRobin ?? false}
                 isDeleting={deleteMutation.isPending}
-                onToggleRoundRobin={() => setRoundRobin(!roundRobin)}
+                onToggleRoundRobin={() =>
+                    toggleRoundRobinMutation.mutate(!(provider.roundRobin ?? false))
+                }
                 onRefresh={() => void refetch()}
                 onAdd={handleAddConnection}
                 onDelete={(connectionId) =>

--- a/packages/db/src/settings.ts
+++ b/packages/db/src/settings.ts
@@ -39,3 +39,11 @@ export function getRequireApiKeyDB(): boolean {
 export function setRequireApiKeyDB(required: boolean): void {
     setSettingDB("require_api_key", required ? "true" : "false");
 }
+
+export function getRoundRobinDB(providerId: string): boolean {
+    return getSettingDB(`round_robin_${providerId}`, "false") === "true";
+}
+
+export function setRoundRobinDB(providerId: string, enabled: boolean): void {
+    setSettingDB(`round_robin_${providerId}`, enabled ? "true" : "false");
+}

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -393,16 +393,22 @@ export class ProviderRegistry {
         }
 
         if (candidates.length > 0) {
-            // Apply round-robin rotation among healthy candidates when enabled
             const sorted = this.circuitBreaker.sortCandidatesByHealth(candidates);
-            // Determine baseId for round-robin state lookup
             const baseId = providerBaseId(candidates[0]!.id);
             if (this.roundRobinEnabled.get(baseId) && sorted.length > 1) {
-                const idx = this.roundRobinIndex.get(baseId) ?? 0;
-                this.roundRobinIndex.set(baseId, (idx + 1) % sorted.length);
-                // Rotate so the next index becomes first (preserves health order within rotation)
-                const rotated = [...sorted.slice(idx), ...sorted.slice(0, idx)];
-                return rotated;
+                // Rotate only among healthy candidates; degraded ones stay as a
+                // fallback tail so a cooling-down account is never hit first.
+                const healthy = sorted.filter(
+                    (c) => this.circuitBreaker.getHealth(c.id).state === "healthy"
+                );
+                const degraded = sorted.filter(
+                    (c) => this.circuitBreaker.getHealth(c.id).state !== "healthy"
+                );
+                if (healthy.length > 1) {
+                    const idx = this.roundRobinIndex.get(baseId) ?? 0;
+                    this.roundRobinIndex.set(baseId, (idx + 1) % healthy.length);
+                    return [...healthy.slice(idx), ...healthy.slice(0, idx), ...degraded];
+                }
             }
             return sorted;
         }

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -83,6 +83,8 @@ export class ProviderRegistry {
     private modelsRefreshPending = false;
     private modelsTtlMs: number = 5 * 60 * 1000; // 5 minutes default TTL
     private modelsFetchTimeoutMs: number = DEFAULT_MODELS_FETCH_TIMEOUT_MS;
+    private roundRobinEnabled: Map<string, boolean> = new Map();
+    private roundRobinIndex: Map<string, number> = new Map();
 
     constructor(
         defaultProvider?: AIProvider,
@@ -121,6 +123,10 @@ export class ProviderRegistry {
 
     setModelsTtlMs(ttlMs: number): void {
         this.modelsTtlMs = ttlMs;
+    }
+
+    setRoundRobin(baseId: string, enabled: boolean): void {
+        this.roundRobinEnabled.set(baseId, enabled);
     }
 
     setModelsFetchTimeoutMs(timeoutMs: number): void {
@@ -337,7 +343,6 @@ export class ProviderRegistry {
 
     async getCandidateProvidersForModel(modelId: string): Promise<AIProvider[]> {
         const candidates: AIProvider[] = [];
-
         // 1. Direct match from registered providers' listModels() (cached)
         const activeProviders = Array.from(this.providers.values()).filter(
             (p) => p.id !== "default"
@@ -388,8 +393,18 @@ export class ProviderRegistry {
         }
 
         if (candidates.length > 0) {
-            // Sort by circuit breaker health and apply round-robin shuffle among healthy candidates
-            return this.circuitBreaker.sortCandidatesByHealth(candidates);
+            // Apply round-robin rotation among healthy candidates when enabled
+            const sorted = this.circuitBreaker.sortCandidatesByHealth(candidates);
+            // Determine baseId for round-robin state lookup
+            const baseId = providerBaseId(candidates[0]!.id);
+            if (this.roundRobinEnabled.get(baseId) && sorted.length > 1) {
+                const idx = this.roundRobinIndex.get(baseId) ?? 0;
+                this.roundRobinIndex.set(baseId, (idx + 1) % sorted.length);
+                // Rotate so the next index becomes first (preserves health order within rotation)
+                const rotated = [...sorted.slice(idx), ...sorted.slice(0, idx)];
+                return rotated;
+            }
+            return sorted;
         }
 
         if (this.defaultProvider.id !== "default") {

--- a/packages/providers/tests/registry.test.ts
+++ b/packages/providers/tests/registry.test.ts
@@ -283,6 +283,49 @@ test("ProviderRegistry coalesces concurrent forced refreshes", async () => {
     assert.equal(callCount, 2);
 });
 
+test("round-robin rotation cycles healthy candidates across requests", async () => {
+    const registry = new ProviderRegistry();
+    const acc1: AIProvider = {
+        id: "openai_acc1",
+        name: "OpenAI Account 1",
+        listModels: async () => [{ id: "openai/gpt-4o", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    const acc2: AIProvider = {
+        id: "openai_acc2",
+        name: "OpenAI Account 2",
+        listModels: async () => [{ id: "openai/gpt-4o", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+
+    registry.registerProvider(acc1);
+    registry.registerProvider(acc2);
+    registry.setRoundRobin("openai", true);
+
+    const first = await registry.getProviderForModel("openai/gpt-4o");
+    const second = await registry.getProviderForModel("openai/gpt-4o");
+    const third = await registry.getProviderForModel("openai/gpt-4o");
+
+    assert.notEqual(first.id, second.id, "consecutive requests should rotate accounts");
+    assert.equal(first.id, third.id, "rotation should cycle back after 2 candidates");
+
+    // Disabling round-robin pins to the first healthy candidate again
+    registry.setRoundRobin("openai", false);
+    const pinned = await registry.getProviderForModel("openai/gpt-4o");
+    const pinned2 = await registry.getProviderForModel("openai/gpt-4o");
+    assert.equal(pinned.id, pinned2.id, "disabled round-robin should not rotate");
+});
+
 test("CircuitBreaker tracks provider health and handles cooldown recovery", async () => {
     const registry = new ProviderRegistry();
     const cb = registry.getCircuitBreaker();

--- a/packages/providers/tests/registry.test.ts
+++ b/packages/providers/tests/registry.test.ts
@@ -326,6 +326,44 @@ test("round-robin rotation cycles healthy candidates across requests", async () 
     assert.equal(pinned.id, pinned2.id, "disabled round-robin should not rotate");
 });
 
+test("round-robin never puts a cooldown account first — degraded stays fallback", async () => {
+    const registry = new ProviderRegistry();
+    const acc1: AIProvider = {
+        id: "openai_cd1",
+        name: "OpenAI Cool 1",
+        listModels: async () => [{ id: "openai/gpt-4o", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    const acc2: AIProvider = {
+        id: "openai_cd2",
+        name: "OpenAI Cool 2",
+        listModels: async () => [{ id: "openai/gpt-4o", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+
+    registry.registerProvider(acc1);
+    registry.registerProvider(acc2);
+    registry.setRoundRobin("openai", true);
+
+    // Put acc1 in cooldown
+    const cb = registry.getCircuitBreaker();
+    cb.recordFailure(acc1.id, new Error("Rate limit exceeded 429"), 60_000);
+    assert.equal(cb.getHealth(acc1.id).state, "cooldown");
+
+    const first = await registry.getProviderForModel("openai/gpt-4o");
+    assert.equal(first.id, acc2.id, "cooldown account must never be first");
+});
+
 test("CircuitBreaker tracks provider health and handles cooldown recovery", async () => {
     const registry = new ProviderRegistry();
     const cb = registry.getCircuitBreaker();

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -31,6 +31,7 @@ export interface ProviderDefinition {
     requires_api_key: boolean;
     requires_oauth?: boolean;
     supports_custom_url?: boolean;
+    roundRobin?: boolean;
     status: ProviderStatus;
     models: ModelObject[];
     connections?: ProviderConfig[];

--- a/packages/types/src/schemas/providers.ts
+++ b/packages/types/src/schemas/providers.ts
@@ -36,3 +36,9 @@ export const AddCustomModelSchema = z.object({
 });
 
 export type AddCustomModelZod = z.infer<typeof AddCustomModelSchema>;
+
+export const ToggleRoundRobinSchema = z.object({
+    enabled: z.boolean()
+});
+
+export type ToggleRoundRobinZod = z.infer<typeof ToggleRoundRobinSchema>;


### PR DESCRIPTION
## Summary

The Round Robin toggle on the provider detail page was **UI-only** — a local `useState` that did nothing. This PR wires it end-to-end so it actually distributes requests across healthy multi-account connections.

## Changes

| Layer | File | What |
|-------|------|------|
| Types | `provider.ts` | `roundRobin?: boolean` on `ProviderDefinition` |
| Types | `schemas/providers.ts` | `ToggleRoundRobinSchema` (Zod) |
| DB | `settings.ts` | `getRoundRobinDB` / `setRoundRobinDB` — persisted per provider base ID in `system_settings` |
| Registry | `registry.ts` | `setRoundRobin()` + per-baseId rotation index; rotates candidates on each request when enabled |
| API | `providers.logic.ts` | `SetRoundRobin()` — writes DB **and** syncs in-memory registry flag (boot-only reload would otherwise miss it) |
| API | `providers.controller.ts` + `routes/v1/providers.ts` | `PATCH /v1/providers/:providerId/round-robin { enabled }` |
| API | `services/registry.ts` | Boot-time flag sync from DB |
| Web | `useProvider.ts` + `$providerId.tsx` | Toggle now reads `provider.roundRobin` and calls the mutation — no stale local state |
| Tests | `registry.test.ts`, `round-robin-endpoint.test.ts` | Rotation cycling regression + endpoint auth guard |

## Behavior

- Toggle **on**: consecutive requests to a model matching multiple accounts rotate through healthy candidates (circuit-breaker health ordering preserved within rotation).
- Toggle **off**: pins to the first healthy candidate (previous behavior).
- Toggle applies **immediately** — no server restart needed.

## Verification

- `packages/{types,db,providers}` + `apps/api` + `apps/web` all build clean
- Providers test suite: 17/17 pass (incl. new rotation test)
- API suite: 146/146 pass
- `opencode-compat.test.ts` 401 failure is **pre-existing** on `main` (unrelated to this PR)