### PR TITLE
feat(api): support SROUTER_PUBLIC_URL for single-port OAuth on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,6 @@
 # Heroku process — single web dyno runs the unified API + dashboard server.
 # DATABASE_URL (Postgres) is injected by the Heroku Postgres add-on; when unset
 # the server falls back to the local SQLite database at DATABASE_PATH.
+# Set SROUTER_PUBLIC_URL=https://<app>.herokuapp.com to expose OAuth callback
+# routes on the main $PORT listener (Heroku only routes $PORT).
 web: node apps/api/dist/index.js

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -89,13 +89,18 @@ Provider authentication and OAuth callbacks are also mounted under the `/v1` API
 
 The app reads these gateway-level environment variables:
 
-| Variable        | Default         | Description             |
-| --------------- | --------------- | ----------------------- |
-| `PORT`          | `3000`          | HTTP server port        |
-| `OAUTH_PORT`    | `1455`          | OAuth callback listener |
-| `DATABASE_PATH` | `srouter.db`    | SQLite database path    |
-| `NODE_ENV`      | `development`   | Runtime environment     |
-| `WEB_DIST_PATH` | `apps/web/dist` | Built dashboard path    |
+| Variable            | Default         | Description                                                            |
+| ------------------- | --------------- | ---------------------------------------------------------------------- |
+| `PORT`              | `3000`          | HTTP server port                                                       |
+| `OAUTH_PORT`        | `1455`          | Local OAuth callback listener (skipped when `SROUTER_PUBLIC_URL` set)  |
+| `SROUTER_PUBLIC_URL`| —               | Public origin (e.g. `https://app.herokuapp.com`); rewrites OAuth callback URLs to `/v1/auth/.../callback` on the main server |
+| `DATABASE_PATH`     | `srouter.db`    | SQLite database path                                                   |
+| `NODE_ENV`          | `development`   | Runtime environment                                                    |
+| `WEB_DIST_PATH`     | `apps/web/dist` | Built dashboard path                                                   |
+
+When `SROUTER_PUBLIC_URL` is configured the local `OAUTH_PORT` listener is
+not bound — callback routes are served by the main listener, so the gateway
+runs on platforms that expose only one port (Heroku).
 
 For local development, the repository root `.env.example` can be copied to `.env`.
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,6 +23,7 @@ import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry, startProviderRegistry } from "@/services/registry.js";
 import { bootstrapAdminAccountFromEnv } from "@/services/adminAuth.js";
 import { autostartTunnelIfEnabled } from "@/services/cloudflareTunnel.js";
+import { GetPublicUrlBase } from "@/utils/callbackUrl.js";
 import { adminAuthStore, initDatabase, isPostgres } from "@srouter/db";
 
 import { HTTPException } from "hono/http-exception";
@@ -207,22 +208,27 @@ async function boot(): Promise<void> {
         }
     );
 
-    // Secondary listener on Port 1455 for OAuth callbacks and local Anthropic proxy
-    try {
-        serve(
-            {
-                fetch: oauthApp.fetch,
-                port: oauthPort,
-                hostname: oauthHost
-            },
-            (info) => {
-                console.log(
-                    `🔑 OAuth Callback Server running at http://${info.address}:${info.port}/auth/callback & /auth/antigravity/callback & /auth/claude/callback`
-                );
-            }
-        );
-    } catch (err) {
-        console.warn(`Could not start OAuth server on port ${oauthPort}:`, err);
+    // Secondary listener on Port 1455 for OAuth callbacks and local Anthropic proxy.
+    // When SROUTER_PUBLIC_URL is set (Heroku/public deploys) the OAuth callback
+    // routes already live on the main server, so binding an extra port would
+    // fail on platforms that expose only $PORT.
+    if (!GetPublicUrlBase()) {
+        try {
+            serve(
+                {
+                    fetch: oauthApp.fetch,
+                    port: oauthPort,
+                    hostname: oauthHost
+                },
+                (info) => {
+                    console.log(
+                        `🔑 OAuth Callback Server running at http://${info.address}:${info.port}/auth/callback & /auth/antigravity/callback & /auth/claude/callback`
+                    );
+                }
+            );
+        } catch (err) {
+            console.warn(`Could not start OAuth server on port ${oauthPort}:`, err);
+        }
     }
 
     // Start background OAuth token refresh sweeper

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -24,6 +24,7 @@ import {
     type TokenImportParams
 } from "@srouter/types";
 import { AuthHandlers } from "@/services/authHandlers.js";
+import { ResolveCallbackUrl } from "@/utils/callbackUrl.js";
 
 export type { OAuthLoginParams, OAuthLoginResult, TokenImportParams } from "@srouter/types";
 
@@ -38,7 +39,8 @@ function ResolveClientId(handler: AuthProviderHandler, params: OAuthLoginParams)
 }
 
 function ResolveRedirectUri(handler: AuthProviderHandler, params: OAuthLoginParams): string {
-    return params.redirectUri || handler.defaultRedirectUri || "";
+    const redirectUri = params.redirectUri || handler.defaultRedirectUri || "";
+    return redirectUri ? ResolveCallbackUrl(redirectUri) : "";
 }
 
 function ExtractEmailFromToken(token?: string): string | undefined {

--- a/apps/api/src/utils/callbackUrl.ts
+++ b/apps/api/src/utils/callbackUrl.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve the externally reachable base URL for OAuth callback redirects.
+ *
+ * Local development uses the dedicated OAuth listener on 127.0.0.1:1455, so
+ * redirect URIs stay `http://localhost:1455/...`. When the gateway runs behind
+ * a public origin (Heroku, VPS, tunnel) set SROUTER_PUBLIC_URL (e.g.
+ * `https://srouter.example.com`) so authorize URLs point back at the main
+ * server (`/v1/auth/.../callback`), where the callback routes already live.
+ */
+export function GetPublicUrlBase(): string | undefined {
+    const value = process.env.SROUTER_PUBLIC_URL?.trim();
+    return value ? value.replace(/\/+$/, "") : undefined;
+}
+
+/**
+ * Rewrites a localhost/127.0.0.1 OAuth redirect URI to the public origin when
+ * SROUTER_PUBLIC_URL is configured. Non-local URIs (user-supplied custom
+ * callbacks) pass through untouched.
+ */
+export function ResolveCallbackUrl(redirectUri: string): string {
+    const publicBase = GetPublicUrlBase();
+    if (!publicBase) return redirectUri;
+
+    try {
+        const url = new URL(redirectUri);
+        const isLocalhost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+        if (isLocalhost) {
+            return `${publicBase}/v1${url.pathname}`;
+        }
+    } catch {
+        // Malformed URI: leave as-is and let the caller surface the error.
+    }
+
+    return redirectUri;
+}

--- a/apps/api/src/utils/callbackUrl.ts
+++ b/apps/api/src/utils/callbackUrl.ts
@@ -25,7 +25,9 @@ export function ResolveCallbackUrl(redirectUri: string): string {
         const url = new URL(redirectUri);
         const isLocalhost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
         if (isLocalhost) {
-            return `${publicBase}/v1${url.pathname}`;
+            // Already a main-server /v1 path — don't double-prefix.
+            const path = url.pathname.startsWith("/v1") ? url.pathname : `/v1${url.pathname}`;
+            return `${publicBase}${path}`;
         }
     } catch {
         // Malformed URI: leave as-is and let the caller surface the error.

--- a/apps/api/tests/antigravity-provider.test.ts
+++ b/apps/api/tests/antigravity-provider.test.ts
@@ -5,6 +5,9 @@ import type { AIProvider } from "@srouter/types";
 import { registry } from "../src/services/registry.js";
 import { AuthLogic } from "../src/logic/auth.logic.js";
 
+// CI has no SROUTER_PUBLIC_URL, so redirect URIs resolve to the local listener.
+const LOCAL_REDIRECT_ANTIGRAVITY = "http://localhost:1455/auth/antigravity/callback";
+
 const createdIds: string[] = [];
 
 afterEach(async () => {
@@ -47,5 +50,5 @@ test("initiateAntigravityOAuth generates valid Antigravity authorization paramet
     assert.ok(authorizeUrl.includes("code_challenge_method=S256"));
     assert.ok(authorizeUrl.includes(`state=${encodeURIComponent(state)}`));
     assert.ok(codeVerifier.length > 0);
-    assert.equal(redirectUri, "http://localhost:1455/auth/antigravity/callback");
+    assert.equal(redirectUri, LOCAL_REDIRECT_ANTIGRAVITY);
 });

--- a/apps/api/tests/auth-providers.test.ts
+++ b/apps/api/tests/auth-providers.test.ts
@@ -121,6 +121,11 @@ test("ResolveCallbackUrl rewrites localhost to SROUTER_PUBLIC_URL and passes cus
             ResolveCallbackUrl("https://myapp.example.com/cb"),
             "https://myapp.example.com/cb"
         );
+        // A localhost URI already on the main /v1 path must not double up.
+        assert.equal(
+            ResolveCallbackUrl("http://localhost:3000/v1/auth/callback"),
+            "https://srouter.example.com/v1/auth/callback"
+        );
         assert.equal(GetPublicUrlBase(), "https://srouter.example.com");
     } finally {
         if (original === undefined) {

--- a/apps/api/tests/auth-providers.test.ts
+++ b/apps/api/tests/auth-providers.test.ts
@@ -6,6 +6,12 @@ import { registry } from "../src/services/registry.js";
 import { AuthLogic } from "../src/logic/auth.logic.js";
 import { AuthHandlers } from "../src/services/authHandlers.js";
 import type { AuthProviderHandler } from "@srouter/types";
+import { GetPublicUrlBase, ResolveCallbackUrl } from "../src/utils/callbackUrl.js";
+
+// CI has no SROUTER_PUBLIC_URL, so redirect URIs resolve to the local
+// listener (127.0.0.1:1455) exactly as the handlers default.
+const LOCAL_REDIRECT = "http://localhost:1455/auth/callback";
+const LOCAL_REDIRECT_ANTIGRAVITY = "http://localhost:1455/auth/antigravity/callback";
 
 const createdIds: string[] = [];
 
@@ -63,7 +69,7 @@ test("generic logic (initiatePKCEFor) produces an authorizeUrl with expected sta
     assert.ok(authorizeUrl.includes("code_challenge_method=S256"));
     assert.ok(authorizeUrl.includes(`state=${encodeURIComponent(state)}`));
     assert.ok(codeVerifier.length > 0);
-    assert.equal(redirectUri, "http://localhost:1455/auth/callback");
+    assert.equal(redirectUri, LOCAL_REDIRECT);
 });
 
 test("auth provider handlers carry preserved per-provider messages", async () => {
@@ -96,4 +102,41 @@ test("processTokenImport registers a live executor in the registry", async () =>
     const instance = registry.getProvider(config.id) as AIProvider | undefined;
     assert.ok(instance, "expected a registered executor");
     assert.equal(instance.id, config.id);
+});
+
+test("ResolveCallbackUrl rewrites localhost to SROUTER_PUBLIC_URL and passes custom URIs through", () => {
+    const original = process.env.SROUTER_PUBLIC_URL;
+    try {
+        process.env.SROUTER_PUBLIC_URL = "https://srouter.example.com/";
+        assert.equal(
+            ResolveCallbackUrl("http://localhost:1455/auth/callback"),
+            "https://srouter.example.com/v1/auth/callback"
+        );
+        assert.equal(
+            ResolveCallbackUrl("http://127.0.0.1:1455/auth/antigravity/callback"),
+            "https://srouter.example.com/v1/auth/antigravity/callback"
+        );
+        // User-supplied custom callback must pass through untouched.
+        assert.equal(
+            ResolveCallbackUrl("https://myapp.example.com/cb"),
+            "https://myapp.example.com/cb"
+        );
+        assert.equal(GetPublicUrlBase(), "https://srouter.example.com");
+    } finally {
+        if (original === undefined) {
+            delete process.env.SROUTER_PUBLIC_URL;
+        } else {
+            process.env.SROUTER_PUBLIC_URL = original;
+        }
+    }
+});
+
+test("ResolveCallbackUrl is a no-op without SROUTER_PUBLIC_URL", () => {
+    const original = process.env.SROUTER_PUBLIC_URL;
+    try {
+        delete process.env.SROUTER_PUBLIC_URL;
+        assert.equal(ResolveCallbackUrl("http://localhost:1455/auth/callback"), LOCAL_REDIRECT);
+    } finally {
+        if (original !== undefined) process.env.SROUTER_PUBLIC_URL = original;
+    }
 });


### PR DESCRIPTION
## Summary

Support running the gateway on single-port platforms (Heroku) for OAuth callbacks.

## Problem

Heroku only exposes `$PORT`. The current OAuth flow binds a secondary listener on `OAUTH_PORT` (1455) for callback routes, which can't be reached externally on Heroku. This also blocks running Anthropic's local proxy flow when a public URL is configured.

## Changes

- New `apps/api/src/utils/callbackUrl.ts`: `GetPublicUrlBase()` + `ResolveCallbackUrl()` helpers.
- When `SROUTER_PUBLIC_URL` is set:
  - The secondary `OAUTH_PORT` listener is skipped — callback routes are already served on the main listener.
  - OAuth `redirect_uri` values are rewritten to `<SROUTER_PUBLIC_URL>/v1/auth/.../callback` so the provider redirects back to the public origin.
- Updated `apps/api/README.md` env table + `Procfile` comment documenting `SROUTER_PUBLIC_URL`.
- Tests updated for the new callback URL resolution.

## Env

```
SROUTER_PUBLIC_URL=https://<app>.herokuapp.com
```
