### PR TITLE
fix(db): enable TLS for Postgres (Heroku - SSL required)

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -73,7 +73,9 @@ async function getPool(): Promise<PgPool> {
         connectionString: process.env.DATABASE_URL,
         max: 10,
         idleTimeoutMillis: 30_000,
-        connectionTimeoutMillis: 10_000
+        connectionTimeoutMillis: 10_000,
+        // Heroku Postgres requires TLS; self-signed cert → rejectUnauthorized: false
+        ssl: { rejectUnauthorized: false }
     });
     return pgPool;
 }


### PR DESCRIPTION
Heroku Postgres rejects plaintext connections. Without `ssl: { rejectUnauthorized: false }`, the pg Pool fails to connect and the app crashes on boot.

This is a Heroku-only fix — self-hosted Postgres without SSL is unaffected (ssl config is simply ignored by pg when the server doesn't support TLS).