### PR TITLE
fix: Claude Code v2 compatibility — system role, adaptive thinking, unknown model warning

### DIFF
--- a/apps/api/src/controllers/messages.controller.ts
+++ b/apps/api/src/controllers/messages.controller.ts
@@ -48,7 +48,7 @@ export class MessagesController {
 
         const ApiKeyId = ApiKeyRow?.id;
         const OpenAIReq = AnthropicToOpenAIRequest(body);
-        const isThinkingEnabled = Boolean(body.thinking?.type === "enabled");
+        const isThinkingEnabled = body.thinking?.type !== "disabled";
 
         if (body.stream) {
             c.header("Content-Type", "text/event-stream");

--- a/apps/cli/src/adapters/claude.ts
+++ b/apps/cli/src/adapters/claude.ts
@@ -140,6 +140,8 @@ export class ClaudeAdapter extends AbstractToolAdapter {
         data.env.ANTHROPIC_DEFAULT_OPUS_MODEL = context.opusModel || defaultModel;
         data.env.ANTHROPIC_DEFAULT_SONNET_MODEL = context.sonnetModel || defaultModel;
         data.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = context.haikuModel || defaultModel;
+        // Suppress "not a model Claude Code recognizes" warning for unknown models
+        data.env.CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT = "1";
 
         // Clean out legacy SCODEX or old vendor keys if present
         if (data.env.ANTHROPIC_DEFAULT_FABLE_MODEL) {
@@ -213,6 +215,7 @@ export class ClaudeAdapter extends AbstractToolAdapter {
                 delete data.env.ANTHROPIC_DEFAULT_SONNET_MODEL;
                 delete data.env.ANTHROPIC_DEFAULT_HAIKU_MODEL;
                 delete data.env.ANTHROPIC_DEFAULT_FABLE_MODEL;
+                delete data.env.CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT;
             }
             await fs.writeFile(configPath, JSON.stringify(data, null, 2), "utf-8");
             return true;
@@ -234,7 +237,8 @@ export class ClaudeAdapter extends AbstractToolAdapter {
             ANTHROPIC_MODEL: defaultModel,
             ANTHROPIC_DEFAULT_OPUS_MODEL: context.opusModel || defaultModel,
             ANTHROPIC_DEFAULT_SONNET_MODEL: context.sonnetModel || defaultModel,
-            ANTHROPIC_DEFAULT_HAIKU_MODEL: context.haikuModel || defaultModel
+            ANTHROPIC_DEFAULT_HAIKU_MODEL: context.haikuModel || defaultModel,
+            CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT: "1"
         };
         return env;
     }

--- a/apps/cli/tests/claudeAdapter.test.ts
+++ b/apps/cli/tests/claudeAdapter.test.ts
@@ -112,6 +112,7 @@ test("ClaudeAdapter - link with tier models and getEnv", async () => {
         assert.equal(env.ANTHROPIC_DEFAULT_OPUS_MODEL, "claude-3-opus-20240229");
         assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, "claude-3-7-sonnet-20250219");
         assert.equal(env.ANTHROPIC_DEFAULT_HAIKU_MODEL, "claude-3-5-haiku-20241022");
+        assert.equal(env.CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT, "1");
 
         // Unlink manually without backup
         const unlinked = await adapter.unlink();
@@ -123,6 +124,10 @@ test("ClaudeAdapter - link with tier models and getEnv", async () => {
         assert.equal(unlinkedData.ANTHROPIC_DEFAULT_OPUS_MODEL, undefined);
         assert.equal(unlinkedData.ANTHROPIC_DEFAULT_SONNET_MODEL, undefined);
         assert.equal(unlinkedData.ANTHROPIC_DEFAULT_HAIKU_MODEL, undefined);
+        assert.equal(
+            unlinkedData.env?.CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT,
+            undefined
+        );
     } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/translator/tests/anthropic.test.ts
+++ b/packages/translator/tests/anthropic.test.ts
@@ -94,6 +94,30 @@ test("anthropicToOpenAIRequest maps system string, messages, and tools", () => {
     });
 });
 
+test("anthropicToOpenAIRequest maps inline system message role", () => {
+    const req: AnthropicMessageRequest = {
+        model: "claude-3-7-sonnet-20250219",
+        max_tokens: 4096,
+        messages: [
+            {
+                role: "system",
+                content: "You are a helpful coding assistant."
+            },
+            {
+                role: "user",
+                content: "Run test suite"
+            }
+        ]
+    };
+
+    const openAIReq = AnthropicToOpenAIRequest(req);
+    assert.equal(openAIReq.messages.length, 2);
+    assert.equal(openAIReq.messages[0]?.role, "system");
+    assert.equal(openAIReq.messages[0]?.content, "You are a helpful coding assistant.");
+    assert.equal(openAIReq.messages[1]?.role, "user");
+    assert.equal(openAIReq.messages[1]?.content, "Run test suite");
+});
+
 test("openAIToAnthropicResponse maps OpenAI response to Anthropic message format", () => {
     const openAIRes: ChatCompletionResponse = {
         id: "chatcmpl-test-123",

--- a/packages/types/src/anthropic.ts
+++ b/packages/types/src/anthropic.ts
@@ -56,7 +56,7 @@ export interface AnthropicMessageRequest {
         disable_parallel_tool_use?: boolean;
     };
     thinking?: {
-        type: "enabled" | "disabled";
+        type: "enabled" | "disabled" | "adaptive";
         budget_tokens?: number;
     };
 }

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -6,6 +6,6 @@ export type JSONObject = Record<string, JSONValue>;
 export type ChatRole = "system" | "user" | "assistant" | "tool" | "function" | "developer";
 export type ChatMessageRole = ChatRole;
 
-export type AnthropicRole = Extract<ChatRole, "user" | "assistant">;
+export type AnthropicRole = Extract<ChatRole, "user" | "assistant"> | "system";
 export type AssistantOrUserRole = Extract<ChatRole, "user" | "assistant">;
 export type CommandCodeRole = Extract<ChatRole, "user" | "assistant" | "tool">;

--- a/packages/types/src/schemas/anthropic.ts
+++ b/packages/types/src/schemas/anthropic.ts
@@ -26,7 +26,7 @@ export const AnthropicContentBlockSchema: z.ZodType<AnthropicContentBlock> = z.o
 });
 
 export const AnthropicMessageSchema = z.object({
-    role: z.enum(["user", "assistant"]),
+    role: z.enum(["user", "assistant", "system"]),
     content: z.union([z.string(), z.array(AnthropicContentBlockSchema).max(200)])
 });
 
@@ -77,7 +77,7 @@ export const AnthropicMessageRequestSchema = z.object({
         .optional(),
     thinking: z
         .object({
-            type: z.enum(["enabled", "disabled"]),
+            type: z.enum(["enabled", "disabled", "adaptive"]),
             budget_tokens: z.number().int().positive().max(1_000_000).optional()
         })
         .optional()


### PR DESCRIPTION
### Summary

Claude Code v2.1.251 breaks on SRouter's `/v1/messages` endpoint with two Zod validation errors, and shows a warning about unrecognized model context window.

### Changes

**Bugfix — inline system role**
- `AnthropicMessageSchema` role enum: `user | assistant` → `user | assistant | system`
- `AnthropicRole` type synced
- Claude Code v2 sends `role: "system"` inline in messages array (not as top-level `system` field)

**Bugfix — thinking.type "adaptive"**
- Zod schema and typed interface accept `"adaptive"` alongside `"enabled"` / `"disabled"`
- `messages.controller.ts`: `isThinkingEnabled` logic changed from `=== "enabled"` to `!== "disabled"` — so `adaptive` triggers thinking passthrough

**Enhancement — suppress unknown model warning**
- `srouter link` / `getEnv` now sets `CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT=1` in Claude Code settings env
- Properly cleaned on `unlink`

**Tests**
- New regression test: `anthropicToOpenAIRequest maps inline system message role`
- CLI adapter assertions for the new env var (link + unlink)

### Verification
- Translator: 31/31 pass
- Antigravity: 15/15 pass
- Claude adapter: 2/2 pass
- Build: types + translator ✅
- Deploy container: `/v1/messages` with system role → 200 OK
