### PR TITLE
fix(db): enable TLS for Postgres (Heroku)

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -73,7 +73,9 @@ async function getPool(): Promise<PgPool> {
         connectionString: process.env.DATABASE_URL,
         max: 10,
         idleTimeoutMillis: 30_000,
-        connectionTimeoutMillis: 10_000
+        connectionTimeoutMillis: 10_000,
+        // Heroku Postgres requires TLS; self-signed cert → rejectUnauthorized: false
+        ssl: { rejectUnauthorized: false }
     });
     return pgPool;
 }


### PR DESCRIPTION
### Summary

Enable TLS for Postgres connection on Heroku.

### Changes
- `packages/db/src/client.ts`: add `ssl: { rejectUnauthorized: false }` to pg Pool config when `DATABASE_URL` is set (Heroku requires TLS)

### Verification
Single-file change, minimal surface.