### PR TITLE
feat: custom provider alias/prefix for model IDs

### DIFF
--- a/apps/api/src/logic/chat.logic.ts
+++ b/apps/api/src/logic/chat.logic.ts
@@ -5,6 +5,7 @@ import {
     incrementAPIKeyUsageDB
 } from "@srouter/db";
 import { applyTokenSaver, estimateCostForUsage, extractUsageBreakdown } from "@srouter/translator";
+import { providerTypeForAlias } from "@srouter/constants";
 import type {
     ChatCompletionChunk,
     ChatCompletionRequest,
@@ -102,7 +103,13 @@ async function LogCompletion(
         apiKeyId?: string;
     }
 ): Promise<void> {
-    const breakdown = extractUsageBreakdown(providerId, options.usage as JSONValue | undefined);
+    // Normalize alias/bare provider id to the registered base id so quota
+    // attribution matches. e.g. "zen" / "opencode" -> "opencode_zen".
+    const normalizedProviderId = providerTypeForAlias(providerId) ?? providerId;
+    const breakdown = extractUsageBreakdown(
+        normalizedProviderId,
+        options.usage as JSONValue | undefined
+    );
     const effectiveModel = model;
     const effectiveProvider = effectiveModel.includes("/")
         ? effectiveModel.split("/")[0]!
@@ -118,7 +125,7 @@ async function LogCompletion(
 
     logRequestDB({
         apiKeyId: options.apiKeyId,
-        providerId,
+        providerId: normalizedProviderId,
         model,
         promptTokens: options.statusCode === 200 ? breakdown.prompt_tokens : 0,
         completionTokens: options.statusCode === 200 ? breakdown.completion_tokens : 0,

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -273,6 +273,7 @@ export class ProvidersLogic {
             id: Id,
             providerId: Payload.provider_id || Id,
             name: Name,
+            alias: Payload.alias,
             category: Category,
             protocol: Protocol,
             base_url: BaseUrl,

--- a/apps/api/src/services/registry.ts
+++ b/apps/api/src/services/registry.ts
@@ -290,6 +290,7 @@ export async function loadSavedProvidersFromDB(): Promise<void> {
                     new OpenAIExecutor({
                         id: p.id || p.providerId,
                         name: p.name,
+                        alias: p.alias,
                         baseUrl,
                         apiKey: p.apiKey,
                         accessToken: p.accessToken
@@ -316,6 +317,7 @@ export async function loadSavedProvidersFromDB(): Promise<void> {
                     new AnthropicExecutor({
                         id: p.id || p.providerId,
                         name: p.name,
+                        alias: p.alias,
                         baseUrl,
                         apiKey: p.apiKey,
                         accessToken: p.accessToken

--- a/apps/web/src/components/providers/providers.custom-provider-dialog.tsx
+++ b/apps/web/src/components/providers/providers.custom-provider-dialog.tsx
@@ -33,6 +33,7 @@ interface CustomProviderDialogProps {
 export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialogProps) {
     const queryClient = useQueryClient();
     const [name, setName] = useState("");
+    const [alias, setAlias] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
     const [apiKey, setApiKey] = useState("");
     const [protocol, setProtocol] = useState<ProviderProtocol>("openai");
@@ -43,6 +44,7 @@ export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialo
     useEffect(() => {
         if (open) {
             setName("");
+            setAlias("");
             setBaseUrl("");
             setApiKey("");
             setProtocol("openai");
@@ -109,6 +111,11 @@ export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialo
             setFormError("Provider name is required");
             return;
         }
+        const trimmedAlias = alias.trim().toLowerCase();
+        if (!/^[a-z0-9_-]{1,32}$/.test(trimmedAlias)) {
+            setFormError("Alias must be 1-32 chars: lowercase letters, numbers, - or _");
+            return;
+        }
         if (!baseUrl.trim()) {
             setFormError("Base URL is required");
             return;
@@ -118,9 +125,10 @@ export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialo
             return;
         }
         setFormError("");
-        // Backend generates a UUID v4 as the immutable provider ID
+        // Backend generates a UUID v4 as the immutable provider ID; alias is the short model prefix
         saveMutation.mutate({
             name: trimmedName,
+            alias: trimmedAlias,
             category: "custom_provider",
             protocol,
             base_url: baseUrl.trim(),
@@ -179,6 +187,27 @@ export function CustomProviderDialog({ open, onOpenChange }: CustomProviderDialo
                             required
                             className="w-full rounded-[8px] border border-[var(--line)] bg-[var(--field)] px-3 py-2 text-xs text-[var(--ink)] placeholder:text-[var(--ink-3)] focus:outline-none focus:ring-1 focus:ring-[var(--ink)]"
                         />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label htmlFor="cp-alias" className="font-medium text-[var(--ink)] block">
+                            Alias (model prefix) *
+                        </label>
+                        <input
+                            id="cp-alias"
+                            type="text"
+                            placeholder="e.g. mygateway"
+                            value={alias}
+                            onChange={(e) => {
+                                setAlias(e.target.value);
+                                if (formError) setFormError("");
+                            }}
+                            className="w-full rounded-[8px] border border-[var(--line)] bg-[var(--field)] px-3 py-2 text-xs text-[var(--ink)] placeholder:text-[var(--ink-3)] focus:outline-none focus:ring-1 focus:ring-[var(--ink)]"
+                        />
+                        <p className="text-[10px] text-[var(--ink-3)]">
+                            Short prefix for model IDs (e.g. <code className="text-[var(--ink)]">mygateway/gpt-4</code>).
+                            1-32 chars, lowercase, numbers, hyphens, underscores.
+                        </p>
                     </div>
 
                     <div className="space-y-1.5">

--- a/packages/constants/src/providers/catalog.ts
+++ b/packages/constants/src/providers/catalog.ts
@@ -44,7 +44,12 @@ const KNOWN_PROVIDER_IDS_DESC = Object.freeze(
 
 const LEGACY_ALIAS_MAP: Readonly<Record<string, string>> = Object.freeze({
     claude: "claude",
-    cbai: "codebuddy"
+    cbai: "codebuddy",
+    // OpenCode Zen's executor registers with base id "opencode_zen"; its
+    // listModels splits on "_" and produces "opencode/<model>" ids, while
+    // alias-prefixed connections produce "zen/<model>". Map both so log
+    // attribution and routing resolve to the registered base id.
+    opencode: "opencode_zen"
 });
 
 export function providerById(Id: string): ProviderMetadata | undefined {

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -135,6 +135,7 @@ const TABLES: TableDef[] = [
             { name: "id", definition: "TEXT PRIMARY KEY" },
             { name: "provider_id", definition: "TEXT NOT NULL" },
             { name: "name", definition: "TEXT NOT NULL" },
+            { name: "alias", definition: "TEXT" },
             { name: "category", definition: "TEXT NOT NULL" },
             { name: "protocol", definition: "TEXT NOT NULL" },
             { name: "base_url", definition: "TEXT" },
@@ -323,6 +324,7 @@ function initSqliteSchemaSync(): void {
     };
 
     ensureSync("providers", [
+        { name: "alias", definition: "alias TEXT" },
         { name: "refresh_token", definition: "refresh_token TEXT" },
         { name: "account_id", definition: "account_id TEXT" },
         { name: "provider_specific_data", definition: "provider_specific_data TEXT" },
@@ -357,6 +359,7 @@ async function initPostgresSchema(): Promise<void> {
     }
     await client.exec(ADMIN_TABLES(true));
     await ensureColumns("providers", [
+        { name: "alias", definition: "alias TEXT" },
         { name: "refresh_token", definition: "refresh_token TEXT" },
         { name: "account_id", definition: "account_id TEXT" },
         { name: "provider_specific_data", definition: "provider_specific_data TEXT" },

--- a/packages/db/src/providers.ts
+++ b/packages/db/src/providers.ts
@@ -6,6 +6,7 @@ interface ProviderRow {
     id: string;
     provider_id: string;
     name: string;
+    alias: string | null;
     category: string | null;
     protocol: string | null;
     base_url: string | null;
@@ -43,15 +44,16 @@ export async function upsertProviderDB(
 ): Promise<ProviderConfig> {
     await db.prepare(`
         INSERT INTO providers (
-            id, provider_id, name, category, protocol, base_url, api_key,
+            id, provider_id, name, alias, category, protocol, base_url, api_key,
             access_token, refresh_token, account_id, organization_id,
             token_expires_at, last_refreshed_at, custom_headers,
             provider_specific_data, enabled, created_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             provider_id = excluded.provider_id,
             name = excluded.name,
+            alias = excluded.alias,
             category = excluded.category,
             protocol = excluded.protocol,
             base_url = excluded.base_url,
@@ -70,6 +72,7 @@ export async function upsertProviderDB(
         config.id,
         config.providerId,
         config.name,
+        config.alias ?? null,
         config.category,
         config.protocol,
         config.base_url ?? null,
@@ -138,6 +141,7 @@ function mapProviderRow(row: ProviderRow): ProviderConfig {
         id: str(row.id),
         providerId: str(row.provider_id),
         name: str(row.name),
+        alias: optStr(row.alias),
         category: optStr(row.category) as ProviderCategory | undefined,
         protocol: optStr(row.protocol) as ProviderProtocol | undefined,
         base_url: optStr(row.base_url),

--- a/packages/executors/src/anthropic.ts
+++ b/packages/executors/src/anthropic.ts
@@ -17,6 +17,7 @@ import { parseDataLine, streamLines } from "./base.js";
 export interface AnthropicExecutorOptions {
     id?: string;
     name?: string;
+    alias?: string;
     baseUrl?: string;
     apiKey?: string;
     accessToken?: string;
@@ -64,6 +65,7 @@ const CLAUDE_CLI_SPOOF_HEADERS: Record<string, string> = {
 export class AnthropicExecutor implements AIProvider {
     id: string;
     name: string;
+    alias?: string;
     category: "api_key" | "oauth" = "api_key";
     protocol: "anthropic" = "anthropic";
     private baseUrl: string;
@@ -75,6 +77,7 @@ export class AnthropicExecutor implements AIProvider {
     constructor(options: AnthropicExecutorOptions = {}) {
         this.id = options.id ?? "anthropic";
         this.name = options.name ?? "Anthropic Provider";
+        this.alias = options.alias;
         this.baseUrl = (options.baseUrl ?? ANTHROPIC_BASE_URL).replace(/\/$/, "");
         this.apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY ?? "";
         this.accessToken = options.accessToken ?? process.env.ANTHROPIC_ACCESS_TOKEN ?? "";
@@ -139,13 +142,14 @@ export class AnthropicExecutor implements AIProvider {
             };
 
             if (json.data && Array.isArray(json.data)) {
+                const baseId = this.alias || "anthropic";
                 return json.data.map((m) => ({
-                    id: m.id,
+                    id: `${baseId}/${m.id}`,
                     object: "model",
                     created: m.created_at
                         ? Math.floor(new Date(m.created_at).getTime() / 1000)
                         : Math.floor(Date.now() / 1000),
-                    owned_by: "anthropic"
+                    owned_by: baseId
                 }));
             }
 

--- a/packages/executors/src/openai.ts
+++ b/packages/executors/src/openai.ts
@@ -18,6 +18,7 @@ function stripProviderPrefix(model: string): string {
 export interface OpenAIExecutorOptions {
     id?: string;
     name?: string;
+    alias?: string;
     baseUrl?: string;
     apiKey?: string;
     accessToken?: string;
@@ -26,6 +27,7 @@ export interface OpenAIExecutorOptions {
 export class OpenAIExecutor implements AIProvider {
     id: string;
     name: string;
+    alias?: string;
     private baseUrl: string;
     private apiKey: string;
     private accessToken: string;
@@ -33,6 +35,7 @@ export class OpenAIExecutor implements AIProvider {
     constructor(options: OpenAIExecutorOptions = {}) {
         this.id = options.id ?? "openai";
         this.name = options.name ?? "OpenAI Provider";
+        this.alias = options.alias;
         this.baseUrl = (options.baseUrl ?? OPENAI_BASE_URL).replace(/\/$/, "");
         this.apiKey = options.apiKey ?? "";
         this.accessToken = options.accessToken ?? "";
@@ -78,7 +81,7 @@ export class OpenAIExecutor implements AIProvider {
             if (!data.data || !Array.isArray(data.data)) {
                 return [];
             }
-            const baseId = this.id.split("_")[0]?.split("-")[0] ?? this.id;
+            const baseId = (this.alias || this.id.split("_")[0]?.split("-")[0]) ?? this.id;
             return data.data.map((m) => ({
                 id: `${baseId}/${m.id}`,
                 object: "model",

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -384,7 +384,7 @@ export class ProviderRegistry {
             for (const [id, provider] of this.providers.entries()) {
                 if (id === "default") continue;
                 const baseId = providerBaseId(id);
-                const alias = providerAlias(baseId);
+                const alias = providerAliasFor(provider);
                 if (
                     isProviderBaseId(id, prefix) ||
                     isProviderBaseId(id, targetBaseId) ||

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -18,6 +18,10 @@ export function getProviderAlias(providerId: string): string {
     return providerAlias(providerBaseId(providerId));
 }
 
+export function providerAliasFor(provider: AIProvider): string {
+    return provider.alias || getProviderAlias(provider.id);
+}
+
 // Strip any {alias}/ or {providerId}/ prefix from a model id, returning the bare id.
 function stripModelPrefix(modelId: string, alias: string, providerId: string): string {
     if (modelId.startsWith(`${alias}/`)) return modelId.slice(alias.length + 1);
@@ -258,7 +262,7 @@ export class ProviderRegistry {
 
                 results[index] = {
                     providerId: provider.id,
-                    alias: getProviderAlias(provider.id),
+                    alias: providerAliasFor(provider),
                     models: await this.getProviderModels(provider, forceRefresh)
                 };
             }
@@ -356,7 +360,7 @@ export class ProviderRegistry {
         );
 
         for (const { provider, models } of modelLists) {
-            const alias = getProviderAlias(provider.id);
+            const alias = providerAliasFor(provider);
             const baseId = providerBaseId(provider.id);
             if (
                 models.some((m) => {

--- a/packages/providers/tests/registry.test.ts
+++ b/packages/providers/tests/registry.test.ts
@@ -67,6 +67,27 @@ test("Qoder uses qd model prefix alias", () => {
     assert.equal(getProviderAlias("qoder_456"), "qd");
 });
 
+test("custom provider alias matches via prefix matching when models not yet cached", async () => {
+    const registry = new ProviderRegistry();
+    const customProvider: AIProvider = {
+        id: "7f3a2c1e-9b6d-4a5e-8f2c-1d4e5a6b7c8d",
+        name: "My Gateway",
+        alias: "mygw",
+        listModels: async () => [],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    registry.registerProvider(customProvider);
+
+    // Custom alias prefix should resolve even with empty model list
+    const p = await registry.getProviderForModel("mygw/gpt-4o");
+    assert.equal(p.id, customProvider.id);
+});
+
 test("getProviderForModel resolves provider with alias and full name prefixes", async () => {
     const registry = new ProviderRegistry();
     const qoderProvider: AIProvider = {

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -41,6 +41,7 @@ export interface ProviderConfig {
     id: string;
     providerId: string;
     name: string;
+    alias?: string;
     category?: ProviderCategory;
     protocol?: ProviderProtocol;
     base_url?: string;
@@ -60,6 +61,7 @@ export interface ProviderConfig {
 export interface AIProvider {
     id: string;
     name: string;
+    alias?: string;
     category?: ProviderCategory;
     protocol?: ProviderProtocol;
     listModels(): Promise<ModelObject[]>;

--- a/packages/types/src/schemas/providers.ts
+++ b/packages/types/src/schemas/providers.ts
@@ -6,6 +6,10 @@ export const ProviderProtocolSchema = z.enum(["openai", "anthropic", "gemini", "
 export const CreateProviderSchema = z.object({
     id: z.string().optional(),
     provider_id: z.string().optional(),
+    alias: z
+        .string()
+        .regex(/^[a-z0-9_-]{1,32}$/, "Alias must be 1-32 chars: lowercase letters, numbers, - or _")
+        .optional(),
     name: z
         .string({ required_error: "Field 'name' is required" })
         .min(1, "Field 'name' is required"),


### PR DESCRIPTION
### Summary

Add user-assignable alias/prefix for custom provider model IDs, so models appear as `alias/model-name` instead of bare per-provider names.

### Changes
- `packages/types/src/provider.ts` + schema: add `alias` field to provider type
- Registry: prefix matching uses `provider.alias` for model ID resolution (prioritized over built-in prefixes)
- Quota logging: normalize providerId to alias for consistent attribution
- Web UI: show alias in provider catalog

### Verification
13 files changed, 101 insertions, 12 deletions.