### PR TITLE
feat(keys): add allowed_models restriction for virtual API keys

### DIFF
--- a/apps/api/src/controllers/keys.controller.ts
+++ b/apps/api/src/controllers/keys.controller.ts
@@ -22,7 +22,8 @@ export class KeysController {
             const created = createAPIKeyDB({
                 name: parsed.data.name.trim(),
                 rateLimit: parsed.data.rateLimit ?? 0,
-                quotaLimit: parsed.data.quotaLimit ?? 0
+                quotaLimit: parsed.data.quotaLimit ?? 0,
+                allowed_models: parsed.data.allowed_models ?? null
             });
             return Ok(c, created, 201);
         } catch (error) {

--- a/apps/api/src/controllers/messages.controller.ts
+++ b/apps/api/src/controllers/messages.controller.ts
@@ -8,6 +8,7 @@ import {
 import { AnthropicMessageRequestSchema, type AnthropicMessageRequest } from "@srouter/types";
 import { ChatLogic } from "@/logic/chat.logic.js";
 import { AnthropicErr, FormatAnthropicErrorPayload, Ok } from "@/utils/response.js";
+import { GetApiKeyRow, IsModelAllowed } from "@/middleware/ModelAccess.js";
 
 export class MessagesController {
     public static async CreateMessage(c: Context): Promise<Response> {
@@ -23,6 +24,17 @@ export class MessagesController {
         }
 
         const body = parsed.data as AnthropicMessageRequest;
+
+        const AllowedModels = GetApiKeyRow(c)?.allowed_models;
+        if (!IsModelAllowed(AllowedModels, body.model)) {
+            return AnthropicErr(
+                c,
+                `Model '${body.model}' is not allowed for this API key`,
+                403,
+                "permission_error"
+            );
+        }
+
         const OpenAIReq = AnthropicToOpenAIRequest(body);
         const isThinkingEnabled = Boolean(body.thinking?.type === "enabled");
 

--- a/apps/api/src/controllers/models.controller.ts
+++ b/apps/api/src/controllers/models.controller.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { ModelListResponse } from "@srouter/types";
 import { ModelsLogic } from "@/logic/models.logic.js";
 import { Err, Ok } from "@/utils/response.js";
+import { GetApiKeyRow, IsModelAllowed } from "@/middleware/ModelAccess.js";
 
 const MODEL_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
 
@@ -18,9 +19,15 @@ export class ModelsController {
         }
 
         const Models = await ModelsLogic.GetAllModels(undefined, ExplicitRefresh);
+        const AllowedModels = GetApiKeyRow(c)?.allowed_models;
+        const VisibleModels =
+            AllowedModels && AllowedModels.length > 0
+                ? Models.filter((Model) => IsModelAllowed(AllowedModels, Model.id))
+                : Models;
+
         const ResponseData: ModelListResponse = {
             object: "list",
-            data: Models
+            data: VisibleModels
         };
         c.header("Cache-Control", MODEL_CACHE_CONTROL);
         return Ok(c, ResponseData);
@@ -30,6 +37,13 @@ export class ModelsController {
         const RawModelId = c.req.param("model") || c.req.param("*");
         const ModelId = RawModelId ? decodeURIComponent(RawModelId) : undefined;
         if (!ModelId) return Err(c, "Model ID parameter is required", 400);
+
+        const AllowedModels = GetApiKeyRow(c)?.allowed_models;
+        if (!IsModelAllowed(AllowedModels, ModelId)) {
+            return Err(c, `Model '${ModelId}' is not allowed for this API key`, 403, {
+                code: "model_not_allowed"
+            });
+        }
 
         const RefreshParam = c.req.query("refresh") || c.req.query("force");
         const ForceRefresh = RefreshParam === "true" || RefreshParam === "1";

--- a/apps/api/src/middleware/ModelAccess.ts
+++ b/apps/api/src/middleware/ModelAccess.ts
@@ -1,0 +1,44 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { DBAPIKey } from "@srouter/types";
+import { Err } from "@/utils/response.js";
+
+function NormalizeModelId(model: string): string {
+    return model.replace(/^srouter\//, "");
+}
+
+export function IsModelAllowed(
+    allowedModels: string[] | null | undefined,
+    model: string
+): boolean {
+    if (!allowedModels || allowedModels.length === 0) return true;
+
+    const Requested = NormalizeModelId(model);
+    return allowedModels.some((allowed) => {
+        const Allowed = NormalizeModelId(allowed);
+        return Allowed === Requested || allowed === model;
+    });
+}
+
+export function GetApiKeyRow(c: Context): DBAPIKey | undefined {
+    return c.get("apiKeyRow") as DBAPIKey | undefined;
+}
+
+export function EnforceModelAccess(): MiddlewareHandler {
+    return async (c, next) => {
+        const ApiKeyRow = GetApiKeyRow(c);
+        const AllowedModels = ApiKeyRow?.allowed_models;
+
+        if (AllowedModels && AllowedModels.length > 0) {
+            const Body = c.req.valid("json" as never) as { model?: string } | undefined;
+            const Model = Body?.model;
+
+            if (Model && !IsModelAllowed(AllowedModels, Model)) {
+                return Err(c, `Model '${Model}' is not allowed for this API key`, 403, {
+                    code: "model_not_allowed"
+                });
+            }
+        }
+
+        return await next();
+    };
+}

--- a/apps/api/src/routes/v1/chat.ts
+++ b/apps/api/src/routes/v1/chat.ts
@@ -3,6 +3,7 @@ import { ChatCompletionRequestSchema } from "@srouter/types";
 import { ChatController } from "@/controllers/chat.controller.js";
 import { ValidateJson } from "@/middleware/Validation.js";
 import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
+import { EnforceModelAccess } from "@/middleware/ModelAccess.js";
 
 export const ChatRouter = new Hono();
 
@@ -10,11 +11,13 @@ ChatRouter.post(
     "/chat/completions",
     ApiKeyAuth,
     ValidateJson(ChatCompletionRequestSchema),
+    EnforceModelAccess(),
     ChatController.CreateCompletion
 );
 ChatRouter.post(
     "/chat/completion",
     ApiKeyAuth,
     ValidateJson(ChatCompletionRequestSchema),
+    EnforceModelAccess(),
     ChatController.CreateCompletion
 );

--- a/apps/api/tests/api-keys-allowed-models.test.ts
+++ b/apps/api/tests/api-keys-allowed-models.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createAPIKeyDB, deleteAPIKeyDB, getAPIKeyByKeyDB } from "@srouter/db";
+import { IsModelAllowed } from "@/middleware/ModelAccess.js";
+
+const createdIds: string[] = [];
+
+afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+        deleteAPIKeyDB(id);
+    }
+});
+
+test("createAPIKeyDB persists allowed_models and round-trips via lookup", () => {
+    const created = createAPIKeyDB({
+        name: "Restricted Key",
+        allowed_models: ["gpt-4o", "claude-3-5-sonnet-20241022"]
+    });
+    createdIds.push(created.id);
+
+    assert.deepEqual(created.allowed_models, ["gpt-4o", "claude-3-5-sonnet-20241022"]);
+
+    const lookup = getAPIKeyByKeyDB(created.key);
+    assert.ok(lookup);
+    assert.deepEqual(lookup?.allowed_models, ["gpt-4o", "claude-3-5-sonnet-20241022"]);
+});
+
+test("createAPIKeyDB normalizes empty allowed_models to null (unrestricted)", () => {
+    const created = createAPIKeyDB({
+        name: "Open Key",
+        allowed_models: []
+    });
+    createdIds.push(created.id);
+
+    assert.equal(created.allowed_models, null);
+
+    const lookup = getAPIKeyByKeyDB(created.key);
+    assert.equal(lookup?.allowed_models, null);
+});
+
+test("createAPIKeyDB defaults allowed_models to null when omitted", () => {
+    const created = createAPIKeyDB({ name: "Default Key" });
+    createdIds.push(created.id);
+
+    assert.equal(created.allowed_models, null);
+});
+
+test("IsModelAllowed permits any model when list is null or empty", () => {
+    assert.equal(IsModelAllowed(null, "gpt-4o"), true);
+    assert.equal(IsModelAllowed([], "gpt-4o"), true);
+    assert.equal(IsModelAllowed(undefined, "gpt-4o"), true);
+});
+
+test("IsModelAllowed enforces allow-list membership", () => {
+    const Allowed = ["gpt-4o", "claude-3-5-sonnet-20241022"];
+    assert.equal(IsModelAllowed(Allowed, "gpt-4o"), true);
+    assert.equal(IsModelAllowed(Allowed, "gpt-4o-mini"), false);
+    assert.equal(IsModelAllowed(Allowed, "claude-3-5-sonnet-20241022"), true);
+});
+
+test("IsModelAllowed ignores srouter/ prefix when matching", () => {
+    assert.equal(IsModelAllowed(["gpt-4o"], "srouter/gpt-4o"), true);
+    assert.equal(IsModelAllowed(["srouter/gpt-4o"], "gpt-4o"), true);
+});

--- a/apps/web/src/components/keys/CreateKeyDialog.tsx
+++ b/apps/web/src/components/keys/CreateKeyDialog.tsx
@@ -1,4 +1,8 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Check, Search, X } from "lucide-react";
+import type { ModelListResponse } from "@srouter/types";
+import { api } from "@/lib/api";
 import {
     Dialog,
     DialogContent,
@@ -14,13 +18,52 @@ type CreateKeyDialogProps = {
     open: boolean;
     creating: boolean;
     onOpenChange: (open: boolean) => void;
-    onSubmit: (data: { name: string; rateLimit?: number; quotaLimit?: number }) => Promise<void>;
+    onSubmit: (data: {
+        name: string;
+        rateLimit?: number;
+        quotaLimit?: number;
+        allowed_models?: string[] | null;
+    }) => Promise<void>;
 };
+
+type ModelScope = "all" | "restricted";
 
 export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: CreateKeyDialogProps) {
     const [name, setName] = useState("");
     const [rateLimit, setRateLimit] = useState("");
     const [quotaLimit, setQuotaLimit] = useState("");
+    const [modelScope, setModelScope] = useState<ModelScope>("all");
+    const [selectedModels, setSelectedModels] = useState<string[]>([]);
+    const [modelSearch, setModelSearch] = useState("");
+
+    const { data: modelsData, isPending: modelsPending } = useQuery({
+        queryKey: ["models"],
+        queryFn: () => api.get<ModelListResponse>("/v1/models"),
+        enabled: open && modelScope === "restricted"
+    });
+
+    const models = useMemo(() => modelsData?.data ?? [], [modelsData]);
+
+    const filteredModels = useMemo(() => {
+        const query = modelSearch.trim().toLowerCase();
+        if (!query) return models;
+        return models.filter((m) => m.id.toLowerCase().includes(query));
+    }, [models, modelSearch]);
+
+    const resetForm = () => {
+        setName("");
+        setRateLimit("");
+        setQuotaLimit("");
+        setModelScope("all");
+        setSelectedModels([]);
+        setModelSearch("");
+    };
+
+    const toggleModel = (modelId: string) => {
+        setSelectedModels((prev) =>
+            prev.includes(modelId) ? prev.filter((id) => id !== modelId) : [...prev, modelId]
+        );
+    };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -29,16 +72,17 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
 
         const rateNum = rateLimit.trim() ? parseInt(rateLimit, 10) : undefined;
         const quotaNum = quotaLimit.trim() ? parseInt(quotaLimit, 10) : undefined;
+        const allowedModels =
+            modelScope === "restricted" && selectedModels.length > 0 ? selectedModels : null;
 
         await onSubmit({
             name: trimmedName,
             rateLimit: Number.isFinite(rateNum) && (rateNum ?? 0) > 0 ? rateNum : undefined,
-            quotaLimit: Number.isFinite(quotaNum) && (quotaNum ?? 0) > 0 ? quotaNum : undefined
+            quotaLimit: Number.isFinite(quotaNum) && (quotaNum ?? 0) > 0 ? quotaNum : undefined,
+            allowed_models: allowedModels
         });
 
-        setName("");
-        setRateLimit("");
-        setQuotaLimit("");
+        resetForm();
     };
 
     return (
@@ -128,6 +172,114 @@ export function CreateKeyDialog({ open, creating, onOpenChange, onSubmit }: Crea
                                 Optional max lifetime tokens
                             </p>
                         </div>
+                    </div>
+
+                    {/* Allowed Models Scope */}
+                    <div className="space-y-2 pt-1">
+                        <label className="block text-xs font-medium text-foreground">
+                            Allowed models
+                        </label>
+                        <div className="grid grid-cols-2 gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setModelScope("all")}
+                                className={`rounded-md border px-3 py-2 text-left text-xs transition-colors cursor-pointer ${
+                                    modelScope === "all"
+                                        ? "border-primary bg-primary/10 text-foreground font-semibold"
+                                        : "border-input bg-background text-muted-foreground hover:text-foreground"
+                                }`}
+                            >
+                                All models
+                                <span className="block text-[10px] font-normal opacity-70">
+                                    Unrestricted access
+                                </span>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setModelScope("restricted")}
+                                className={`rounded-md border px-3 py-2 text-left text-xs transition-colors cursor-pointer ${
+                                    modelScope === "restricted"
+                                        ? "border-primary bg-primary/10 text-foreground font-semibold"
+                                        : "border-input bg-background text-muted-foreground hover:text-foreground"
+                                }`}
+                            >
+                                Specific models
+                                <span className="block text-[10px] font-normal opacity-70">
+                                    Restrict to a subset
+                                </span>
+                            </button>
+                        </div>
+
+                        {modelScope === "restricted" && (
+                            <div className="space-y-2 rounded-md border border-border/70 bg-background/50 p-2.5">
+                                <div className="relative">
+                                    <Search className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                                    <Input
+                                        type="text"
+                                        value={modelSearch}
+                                        onChange={(e) => setModelSearch(e.target.value)}
+                                        placeholder="Search models…"
+                                        className="h-8 pl-8 pr-7 font-mono text-xs rounded-md bg-background"
+                                    />
+                                    {modelSearch && (
+                                        <button
+                                            type="button"
+                                            onClick={() => setModelSearch("")}
+                                            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-xs p-0.5 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                                            aria-label="Clear search"
+                                        >
+                                            <X className="size-3" />
+                                        </button>
+                                    )}
+                                </div>
+
+                                <div className="max-h-44 overflow-y-auto rounded-md">
+                                    {modelsPending ? (
+                                        <p className="py-4 text-center text-[11px] text-muted-foreground">
+                                            Loading models…
+                                        </p>
+                                    ) : filteredModels.length === 0 ? (
+                                        <p className="py-4 text-center text-[11px] text-muted-foreground">
+                                            No models matched your search.
+                                        </p>
+                                    ) : (
+                                        <ul className="space-y-0.5">
+                                            {filteredModels.map((model) => {
+                                                const isSelected = selectedModels.includes(
+                                                    model.id
+                                                );
+                                                return (
+                                                    <li key={model.id}>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => toggleModel(model.id)}
+                                                            className={`flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left font-mono text-[11px] transition-colors cursor-pointer ${
+                                                                isSelected
+                                                                    ? "bg-primary/10 text-foreground"
+                                                                    : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+                                                            }`}
+                                                        >
+                                                            <span className="truncate">
+                                                                {model.id}
+                                                            </span>
+                                                            {isSelected && (
+                                                                <Check className="size-3.5 shrink-0 text-primary" />
+                                                            )}
+                                                        </button>
+                                                    </li>
+                                                );
+                                            })}
+                                        </ul>
+                                    )}
+                                </div>
+
+                                <p className="text-[11px] text-muted-foreground">
+                                    {selectedModels.length > 0
+                                        ? `${selectedModels.length} model${selectedModels.length === 1 ? "" : "s"} selected`
+                                        : "Select at least one model, or the key stays unrestricted."}
+                                </p>
+                            </div>
+                        )}
                     </div>
 
                     <DialogFooter className="pt-3 gap-2">

--- a/apps/web/src/components/keys/KeySecretModal.tsx
+++ b/apps/web/src/components/keys/KeySecretModal.tsx
@@ -88,6 +88,27 @@ export function KeySecretModal({ newKey, onClose }: KeySecretModalProps) {
                             </Button>
                         </div>
                     </div>
+                    {newKey.allowed_models && newKey.allowed_models.length > 0 ? (
+                        <div className="space-y-1.5">
+                            <span className="block text-xs font-medium text-foreground">
+                                Allowed models
+                            </span>
+                            <div className="flex flex-wrap gap-1.5">
+                                {newKey.allowed_models.map((model) => (
+                                    <span
+                                        key={model}
+                                        className="inline-flex items-center rounded-full border border-border/60 bg-secondary/40 px-2 py-0.5 font-mono text-[10px] text-foreground"
+                                    >
+                                        {model}
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    ) : (
+                        <p className="text-[11px] text-muted-foreground">
+                            This key can access all models.
+                        </p>
+                    )}
                 </div>
 
                 <DialogFooter className="pt-2">

--- a/apps/web/src/components/keys/KeyTable.tsx
+++ b/apps/web/src/components/keys/KeyTable.tsx
@@ -182,6 +182,7 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                 <th className="py-2.5 px-4 text-right font-semibold">
                                     Token Quota
                                 </th>
+                                <th className="py-2.5 px-4 font-semibold">Models</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">Usage</th>
                                 <th className="py-2.5 px-4 text-center font-semibold">Status</th>
                                 <th className="py-2.5 px-4 text-right font-semibold">Created</th>
@@ -270,6 +271,23 @@ export function KeyTable({ keys, deletingId, onCreateClick, onDeleteClick }: Key
                                             ) : (
                                                 <span className="text-muted-foreground/60">
                                                     Unlimited
+                                                </span>
+                                            )}
+                                        </td>
+
+                                        {/* Allowed Models Scope */}
+                                        <td className="py-3 px-4">
+                                            {k.allowed_models && k.allowed_models.length > 0 ? (
+                                                <span
+                                                    className="inline-flex items-center rounded-full border border-border/60 bg-secondary/40 px-2 py-0.5 font-mono text-[10px] font-medium text-foreground cursor-default"
+                                                    title={k.allowed_models.join("\n")}
+                                                >
+                                                    {k.allowed_models.length} model
+                                                    {k.allowed_models.length === 1 ? "" : "s"}
+                                                </span>
+                                            ) : (
+                                                <span className="font-mono text-[10px] text-muted-foreground/60">
+                                                    All
                                                 </span>
                                             )}
                                         </td>

--- a/apps/web/src/hooks/useKeys.ts
+++ b/apps/web/src/hooks/useKeys.ts
@@ -27,7 +27,12 @@ export function useKeys() {
     }, [fetchKeys]);
 
     const createKey = useCallback(
-        async (data: { name: string; rateLimit?: number; quotaLimit?: number }) => {
+        async (data: {
+            name: string;
+            rateLimit?: number;
+            quotaLimit?: number;
+            allowed_models?: string[] | null;
+        }) => {
             if (!data.name.trim()) {
                 toast.error("Key name is required");
                 return null;

--- a/apps/web/src/routes/keys.tsx
+++ b/apps/web/src/routes/keys.tsx
@@ -39,6 +39,7 @@ function KeysPage() {
         name: string;
         rateLimit?: number;
         quotaLimit?: number;
+        allowed_models?: string[] | null;
     }) => {
         const res = await createKey(data);
         if (res) {

--- a/packages/db/src/apiKeys.ts
+++ b/packages/db/src/apiKeys.ts
@@ -11,7 +11,19 @@ interface APIKeyRow {
     rate_limit: number;
     quota_limit: number;
     usage_tokens: number;
+    allowed_models: string | null;
     created_at: number;
+}
+
+function ParseAllowedModels(value: string | null): string[] | null {
+    if (!value) return null;
+    try {
+        const Parsed: unknown = JSON.parse(value);
+        if (Array.isArray(Parsed) && Parsed.every((item) => typeof item === "string")) {
+            return Parsed.length > 0 ? (Parsed as string[]) : null;
+        }
+    } catch {}
+    return null;
 }
 
 export function getAllAPIKeysDB(): DBAPIKey[] {
@@ -39,6 +51,7 @@ function mapAPIKeyRow(row: APIKeyRow): DBAPIKey {
         rateLimit: row.rate_limit,
         quotaLimit: row.quota_limit,
         usageTokens: row.usage_tokens,
+        allowed_models: ParseAllowedModels(row.allowed_models),
         createdAt: row.created_at
     };
 }
@@ -47,18 +60,30 @@ export function createAPIKeyDB(data: {
     name: string;
     rateLimit?: number;
     quotaLimit?: number;
+    allowed_models?: string[] | null;
 }): DBAPIKey {
     const Id = generateId("key");
     const RandomHex = randomUUID().replace(/-/g, "").slice(0, 16);
     const Key = `sr-live-${RandomHex}`;
     const CreatedAt = Date.now();
+    const AllowedModels =
+        data.allowed_models && data.allowed_models.length > 0 ? data.allowed_models : null;
+    const AllowedModelsJson = AllowedModels ? JSON.stringify(AllowedModels) : null;
 
     const Query = db.prepare(`
-        INSERT INTO api_keys (id, key, name, enabled, rate_limit, quota_limit, usage_tokens, created_at)
-        VALUES (?, ?, ?, 1, ?, ?, 0, ?)
+        INSERT INTO api_keys (id, key, name, enabled, rate_limit, quota_limit, usage_tokens, allowed_models, created_at)
+        VALUES (?, ?, ?, 1, ?, ?, 0, ?, ?)
     `);
 
-    Query.run(Id, Key, data.name, data.rateLimit ?? 0, data.quotaLimit ?? 0, CreatedAt);
+    Query.run(
+        Id,
+        Key,
+        data.name,
+        data.rateLimit ?? 0,
+        data.quotaLimit ?? 0,
+        AllowedModelsJson,
+        CreatedAt
+    );
 
     return {
         id: Id,
@@ -68,6 +93,7 @@ export function createAPIKeyDB(data: {
         rateLimit: data.rateLimit ?? 0,
         quotaLimit: data.quotaLimit ?? 0,
         usageTokens: 0,
+        allowed_models: AllowedModels,
         createdAt: CreatedAt
     };
 }

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -133,9 +133,12 @@ export function initDatabase(): void {
             rate_limit INTEGER DEFAULT 0,
             quota_limit INTEGER DEFAULT 0,
             usage_tokens INTEGER DEFAULT 0,
+            allowed_models TEXT,
             created_at INTEGER NOT NULL
         );
     `);
+
+    ensureColumns("api_keys", [{ name: "allowed_models", definition: "allowed_models TEXT" }]);
 
     // 3. Table for Request Logs & Token Analytics
     db.exec(`

--- a/packages/types/src/apiKeys.ts
+++ b/packages/types/src/apiKeys.ts
@@ -6,5 +6,6 @@ export interface DBAPIKey {
     rateLimit: number;
     quotaLimit: number;
     usageTokens: number;
+    allowed_models?: string[] | null;
     createdAt: number;
 }

--- a/packages/types/src/schemas/apiKeys.ts
+++ b/packages/types/src/schemas/apiKeys.ts
@@ -7,7 +7,8 @@ export const CreateAPIKeySchema = z.object({
         })
         .min(1, "Field 'name' cannot be empty"),
     rateLimit: z.number().int().nonnegative().optional(),
-    quotaLimit: z.number().int().nonnegative().optional()
+    quotaLimit: z.number().int().nonnegative().optional(),
+    allowed_models: z.array(z.string().min(1)).nullable().optional()
 });
 
 export type CreateAPIKeyZod = z.infer<typeof CreateAPIKeySchema>;


### PR DESCRIPTION
### Summary

Add `allowed_models` field to virtual API keys — restrict which models a key can access.

### Changes
- `packages/types/src/schemas/apiKeys.ts`: add `allowed_models` (string[] | null)
- `packages/types/src/apiKeys.ts`: sync interface
- API key CRUD: accept/validate/strip `allowed_models`
- `middleware/ModelAccess.ts`: enforce allowlist on chat/messages routes
- Web UI: model selector UI for API key creation/edit
- Tests for allowlist enforcement

### Verification
15 files changed, 379 insertions, 13 deletions.