### PR TITLE
fix(multimodal): add vision support to antigravity and opencode adapter

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -34,6 +34,7 @@
     "devDependencies": {
         "@srouter/constants": "workspace:*",
         "@srouter/db": "workspace:*",
+        "@srouter/pricing": "workspace:*",
         "@srouter/types": "workspace:*",
         "@types/node": "^26.1.1",
         "tsup": "^8.5.1",

--- a/apps/cli/src/adapters/opencode.ts
+++ b/apps/cli/src/adapters/opencode.ts
@@ -5,8 +5,59 @@ import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.j
 import { ConfigStore, defaultStore } from "../lib/configStore.js";
 import { getOpenCodeConfigPath, isExecutableInPath } from "../lib/platform.js";
 import { fetchAvailableModels } from "../lib/srouterClient.js";
+import { getModelMetadata } from "@srouter/pricing";
+
+export interface OpenCodeModelConfig {
+    id?: string;
+    name: string;
+    attachment?: boolean;
+    modalities?: {
+        input?: string[];
+        output?: string[];
+    };
+}
+
+function createOpenCodeModelConfig(id: string, name?: string): OpenCodeModelConfig {
+    const displayName = name || formatModelDisplayName(id);
+    const config: OpenCodeModelConfig = {
+        id,
+        name: displayName
+    };
+
+    // Check metadata from @srouter/pricing (pricing.jsonc / models.jsonc)
+    const meta = getModelMetadata(id);
+    if (meta?.modalities?.input?.includes("image") || meta?.attachment) {
+        config.attachment = true;
+        config.modalities = {
+            input: meta.modalities?.input || ["text", "image"],
+            output: meta.modalities?.output || ["text"]
+        };
+    } else {
+        // Heuristic fallback for known multimodal model families
+        const lower = id.toLowerCase();
+        const isKnownVision =
+            lower.includes("gemini") ||
+            lower.includes("vision") ||
+            lower.includes("gpt-4o") ||
+            lower.includes("claude-3") ||
+            lower.includes("claude-sonnet") ||
+            lower.includes("claude-opus") ||
+            lower.includes("pixtral");
+
+        if (isKnownVision) {
+            config.attachment = true;
+            config.modalities = {
+                input: ["text", "image"],
+                output: ["text"]
+            };
+        }
+    }
+
+    return config;
+}
 
 export const DEFAULT_SROUTER_MODELS: Array<{ id: string; name: string }> = [
+
     { id: "anthropic/claude-3-7-sonnet", name: "Claude 3.7 Sonnet (Anthropic)" },
     { id: "claude-3-7-sonnet", name: "Claude 3.7 Sonnet" },
     { id: "anthropic/claude-3-5-sonnet", name: "Claude 3.5 Sonnet (Anthropic)" },
@@ -206,20 +257,24 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
         const existingSrouter = data.provider.srouter || {};
         const existingModels = existingSrouter.models || {};
 
-        const modelsMap: Record<string, { id?: string; name: string }> = {};
+        const modelsMap: Record<string, OpenCodeModelConfig> = {};
 
         // 1. Seed with default catalog
         for (const m of DEFAULT_SROUTER_MODELS) {
-            modelsMap[m.id] = {
-                id: m.id,
-                name: m.name
-            };
+            modelsMap[m.id] = createOpenCodeModelConfig(m.id, m.name);
         }
 
-        // 2. Retain existing models from user config
+        // 2. Retain existing models from user config (enriching with vision/capabilities if missing)
         for (const [key, val] of Object.entries(existingModels)) {
             if (val && typeof val === "object") {
-                modelsMap[key] = val as { id?: string; name: string };
+                const existingVal = val as OpenCodeModelConfig;
+                const fresh = createOpenCodeModelConfig(key, existingVal.name);
+                modelsMap[key] = {
+                    ...fresh,
+                    ...existingVal,
+                    ...(fresh.attachment !== undefined && { attachment: fresh.attachment }),
+                    ...(fresh.modalities !== undefined && { modalities: fresh.modalities })
+                };
             }
         }
 
@@ -235,10 +290,7 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
                 const cleanId = rawId.startsWith("srouter/")
                     ? rawId.replace(/^srouter\//, "")
                     : rawId;
-                modelsMap[cleanId] = {
-                    id: cleanId,
-                    name: formatModelDisplayName(cleanId)
-                };
+                modelsMap[cleanId] = createOpenCodeModelConfig(cleanId);
             }
         } catch {
             // Silently fall back to default catalog
@@ -250,10 +302,10 @@ export class OpenCodeAdapter extends AbstractToolAdapter {
             ? rawModel.replace(/^srouter\//, "")
             : rawModel;
 
-        modelsMap[cleanModelId] = {
-            id: cleanModelId,
-            name: modelsMap[cleanModelId]?.name || formatModelDisplayName(cleanModelId)
-        };
+        modelsMap[cleanModelId] = createOpenCodeModelConfig(
+            cleanModelId,
+            modelsMap[cleanModelId]?.name
+        );
 
         data.provider.srouter = {
             name: "SRouter",

--- a/apps/cli/tests/opencodeAdapter.test.ts
+++ b/apps/cli/tests/opencodeAdapter.test.ts
@@ -55,10 +55,17 @@ test("OpenCodeAdapter - link and unlink lifecycle", async () => {
         const models = savedConfig.provider.srouter.models;
         assert.ok(models["claude-3-7-sonnet"]);
         assert.equal(models["claude-3-7-sonnet"].name, "Claude 3.7 Sonnet");
+        assert.equal(models["claude-3-7-sonnet"].attachment, true);
+        assert.deepEqual(models["claude-3-7-sonnet"].modalities, {
+            input: ["text", "image", "pdf"],
+            output: ["text"]
+        });
         assert.ok(models["antigravity/gemini-2.5-pro"]);
         assert.equal(models["antigravity/gemini-2.5-pro"].name, "Gemini 2.5 Pro (Antigravity)");
+        assert.equal(models["antigravity/gemini-2.5-pro"].attachment, true);
         assert.ok(models["openai_codex/gpt-4o"]);
         assert.equal(models["openai_codex/gpt-4o"].name, "GPT-4o (OpenAI Codex)");
+        assert.equal(models["openai_codex/gpt-4o"].attachment, true);
         assert.ok(models["nemotron-3.5-lightning-free"]);
         assert.equal(models["nemotron-3.5-lightning-free"].name, "Nemotron 3.5 Lightning Free");
 

--- a/packages/executors/src/antigravity.ts
+++ b/packages/executors/src/antigravity.ts
@@ -14,6 +14,7 @@ import {
     ANTIGRAVITY_IDE_USER_AGENT,
     accumulateChunks,
     buildAntigravityContents,
+    buildAntigravityContentsAsync,
     buildAntigravityEnvelope,
     buildAntigravityTools,
     createGeminiStreamState,
@@ -185,17 +186,17 @@ export class AntigravityExecutor implements AIProvider {
     /**
      * Build the Antigravity request envelope + sanitized request body.
      */
-    private buildRequest(
+    private async buildRequest(
         model: string,
         req: ChatCompletionRequest,
         stream: boolean,
         enabledCreditTypes?: string[]
-    ): { url: string; body: Record<string, unknown> } {
+    ): Promise<{ url: string; body: Record<string, unknown> }> {
         const cleanBaseUrl = this.getAntigravityBaseUrl();
         const modelName = parseAntigravityModelName(model);
 
         // Build contents (with tool support, prompt stripping, zero-width stripping, trailing turn stripping)
-        const contents = buildAntigravityContents(req);
+        const contents = await buildAntigravityContentsAsync(req);
 
         // ─── Image generation: different request structure ───
         if (isImageModel(modelName)) {
@@ -399,7 +400,7 @@ export class AntigravityExecutor implements AIProvider {
         req: ChatCompletionRequest,
         enabledCreditTypes?: string[]
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
-        const { url, body } = this.buildRequest(model, req, true, enabledCreditTypes);
+        const { url, body } = await this.buildRequest(model, req, true, enabledCreditTypes);
         const streamUrl = url.includes("?") ? url : `${url}?alt=sse`;
         const res = await fetchWithRetry(streamUrl, body, this.getHeaders());
 

--- a/packages/pricing/src/pricing.ts
+++ b/packages/pricing/src/pricing.ts
@@ -1,6 +1,6 @@
-import { loadPricingData } from "./parser.js";
+import { loadModelsDevData, loadPricingData } from "./parser.js";
 import { findCanonicalModelKey, normalizeModelName } from "./matcher.js";
-import type { ModelPrice, PricingDataset } from "./types.js";
+import type { ModelPrice, ModelsDevModel, PricingDataset } from "./types.js";
 
 export * from "./types.js";
 export * from "./parser.js";
@@ -81,6 +81,54 @@ export function getPricingForModel(_provider: string | undefined, model: string)
     }
 
     return DEFAULT_PRICING;
+}
+
+let cachedModelsDevData: Record<string, ModelsDevModel> | undefined;
+
+/**
+ * Retrieves comprehensive metadata (modalities, limits, capabilities) for a model
+ * by resolving aliases and canonical keys from pricing.jsonc / models.jsonc.
+ */
+export function getModelMetadata(modelId: string): ModelsDevModel | undefined {
+    if (!modelId) return undefined;
+    if (!cachedModelsDevData) {
+        try {
+            cachedModelsDevData = loadModelsDevData();
+        } catch {
+            cachedModelsDevData = {};
+        }
+    }
+
+    const data = cachedModelsDevData;
+
+    // 1. Direct key match
+    if (data[modelId]) {
+        return data[modelId];
+    }
+
+    // 2. Canonical / Normalized match using pricing aliases and catalog
+    const canonical =
+        findCanonicalModelKey(modelId, MODEL_PRICING, MODEL_ALIASES) ||
+        normalizeModelName(modelId, MODEL_ALIASES);
+
+    if (canonical && data[canonical]) {
+        return data[canonical];
+    }
+
+    // 3. Search modelsDevData by suffix or id match
+    const targetSuffix = `/${canonical}`;
+    for (const [key, item] of Object.entries(data)) {
+        if (
+            key === canonical ||
+            key.endsWith(targetSuffix) ||
+            item.id === canonical ||
+            item.id.endsWith(targetSuffix)
+        ) {
+            return item;
+        }
+    }
+
+    return undefined;
 }
 
 /**

--- a/packages/translator/src/antigravity.ts
+++ b/packages/translator/src/antigravity.ts
@@ -63,10 +63,37 @@ export function parseGeminiModelName(rawModel: string): string {
 }
 
 export function buildGeminiContents(req: ChatCompletionRequest): GeminiContent[] {
-    return req.messages.map((m) => ({
-        role: m.role === "assistant" ? "model" : "user",
-        parts: [{ text: typeof m.content === "string" ? m.content : JSON.stringify(m.content) }]
-    }));
+    return req.messages.map((m) => {
+        const parts: GeminiContentPart[] = [];
+        if (typeof m.content === "string") {
+            parts.push({ text: m.content });
+        } else if (Array.isArray(m.content)) {
+            for (const part of m.content) {
+                if (part.type === "text" && part.text) {
+                    parts.push({ text: part.text });
+                } else if (part.type === "image_url" && part.image_url?.url) {
+                    const match = part.image_url.url.match(/^data:([^;]+);base64,(.+)$/);
+                    if (match && match[1] && match[2]) {
+                        parts.push({
+                            inlineData: {
+                                mimeType: match[1],
+                                data: match[2]
+                            }
+                        });
+                    }
+                }
+            }
+        } else if (m.content !== null && m.content !== undefined) {
+            parts.push({ text: String(m.content) });
+        }
+        if (parts.length === 0) {
+            parts.push({ text: "..." });
+        }
+        return {
+            role: m.role === "assistant" ? "model" : "user",
+            parts
+        };
+    });
 }
 
 export function buildGeminiBody(
@@ -1006,6 +1033,194 @@ export function parseAntigravityModelName(rawModel: string): string {
     return model;
 }
 
+// Fetch remote image and convert to inlineData (base64)
+async function resolveImageInlineData(url: string): Promise<GeminiInlineData | null> {
+    const match = url.match(/^data:([^;]+);base64,(.+)$/);
+    if (match && match[1] && match[2]) {
+        return {
+            mimeType: match[1],
+            data: match[2]
+        };
+    }
+    if (/^https?:\/\//i.test(url)) {
+        try {
+            const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+            if (!res.ok) return null;
+            const contentType = res.headers.get("content-type") || "image/png";
+            const buffer = Buffer.from(await res.arrayBuffer());
+            return {
+                mimeType: contentType.split(";")[0]?.trim() || "image/png",
+                data: buffer.toString("base64")
+            };
+        } catch {
+            return null;
+        }
+    }
+    return null;
+}
+
+/**
+ * Build Antigravity Gemini contents from ChatCompletionRequest messages, mapping tools.
+ */
+export async function buildAntigravityContentsAsync(req: ChatCompletionRequest): Promise<GeminiContent[]> {
+    const rawContents: GeminiContent[] = [];
+
+    // Map tool_call_id to function name
+    const toolCallNameMap = new Map<string, string>();
+    for (const msg of req.messages) {
+        if (Array.isArray(msg.tool_calls)) {
+            for (const tc of msg.tool_calls) {
+                if (tc.id && tc.function?.name) {
+                    toolCallNameMap.set(tc.id, tc.function.name);
+                }
+            }
+        }
+    }
+
+    for (const m of req.messages) {
+        const role = m.role === "assistant" ? "model" : "user";
+        const parts: GeminiContentPart[] = [];
+
+        if (m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+            let text = typeof m.content === "string" ? m.content.trim() : "";
+            if (text) {
+                text = stripCompetitiveAgentPrompts(stripZeroWidth(text));
+                if (text) parts.push({ text });
+            }
+
+            for (const tc of m.tool_calls) {
+                let args: JSONObject = {};
+                try {
+                    args = stripZeroWidth(JSON.parse(tc.function.arguments || "{}") as JSONObject);
+                } catch {
+                    args = { raw: tc.function.arguments || "" };
+                }
+                const name = sanitizeFunctionName(tc.function.name);
+                const rawTc = tc as unknown as Record<string, unknown>;
+                const rawMsg = m as unknown as Record<string, unknown>;
+                const thoughtSignature =
+                    (rawTc.thoughtSignature as string) ||
+                    (rawTc.thought_signature as string) ||
+                    (rawMsg.thoughtSignature as string) ||
+                    (rawMsg.thought_signature as string) ||
+                    "skip_thought_signature_validator";
+
+                parts.push({
+                    functionCall: { name, args },
+                    thoughtSignature
+                });
+            }
+        } else if (
+            m.role === "assistant" &&
+            (m as unknown as Record<string, unknown>).function_call &&
+            (!Array.isArray(m.tool_calls) || m.tool_calls.length === 0)
+        ) {
+            const rawM = m as unknown as Record<string, unknown>;
+            const legacyFunctionCall = rawM.function_call as {
+                name?: string;
+                arguments?: string;
+                thoughtSignature?: string;
+                thought_signature?: string;
+            };
+            let text = typeof m.content === "string" ? m.content.trim() : "";
+            if (text) {
+                text = stripCompetitiveAgentPrompts(stripZeroWidth(text));
+                if (text) parts.push({ text });
+            }
+            let args: JSONObject = {};
+            try {
+                args = stripZeroWidth(
+                    JSON.parse(legacyFunctionCall.arguments || "{}") as JSONObject
+                );
+            } catch {
+                args = { raw: legacyFunctionCall.arguments || "" };
+            }
+            const name = sanitizeFunctionName(legacyFunctionCall.name || "");
+            const thoughtSignature =
+                legacyFunctionCall.thoughtSignature ||
+                legacyFunctionCall.thought_signature ||
+                (rawM.thoughtSignature as string) ||
+                (rawM.thought_signature as string) ||
+                "skip_thought_signature_validator";
+
+            parts.push({
+                functionCall: { name, args },
+                thoughtSignature
+            });
+        } else if (m.role === "tool") {
+            const rawName =
+                (m.tool_call_id ? toolCallNameMap.get(m.tool_call_id) : undefined) ||
+                m.name ||
+                m.tool_call_id ||
+                "function";
+            const name = sanitizeFunctionName(rawName);
+
+            let responseObj: JSONObject;
+            try {
+                const parsed =
+                    typeof m.content === "string"
+                        ? (JSON.parse(m.content) as JSONObject)
+                        : (m.content as JSONValue);
+                if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                    responseObj = stripZeroWidth(parsed as JSONObject);
+                } else {
+                    responseObj = { output: (parsed as JSONValue) ?? "" };
+                }
+            } catch {
+                responseObj = { output: typeof m.content === "string" ? m.content : "" };
+            }
+
+            parts.push({
+                functionResponse: {
+                    name,
+                    response: responseObj
+                }
+            });
+        } else {
+            if (typeof m.content === "string") {
+                let text = stripCompetitiveAgentPrompts(stripZeroWidth(m.content));
+                if (text) parts.push({ text });
+            } else if (Array.isArray(m.content)) {
+                for (const part of m.content) {
+                    if (part.type === "text" && part.text) {
+                        const text = stripCompetitiveAgentPrompts(stripZeroWidth(part.text));
+                        if (text) parts.push({ text });
+                    } else if (part.type === "image_url" && part.image_url?.url) {
+                        const inline = await resolveImageInlineData(part.image_url.url);
+                        if (inline) {
+                            parts.push({ inlineData: inline });
+                        }
+                    }
+                }
+            } else if (m.content !== null && m.content !== undefined) {
+                const text = stripCompetitiveAgentPrompts(stripZeroWidth(String(m.content)));
+                if (text) parts.push({ text });
+            }
+        }
+
+        if (parts.length === 0) parts.push({ text: "..." });
+        rawContents.push({ role, parts });
+    }
+
+    // Merge adjacent contents of the same role
+    const contents: GeminiContent[] = [];
+    for (const c of rawContents) {
+        if (!Array.isArray(c.parts) || c.parts.length === 0) continue;
+        if (contents.length > 0 && contents[contents.length - 1]?.role === c.role) {
+            contents[contents.length - 1]?.parts.push(...c.parts);
+        } else {
+            contents.push(c);
+        }
+    }
+
+    if (contents.length === 0) {
+        contents.push({ role: "user", parts: [{ text: "..." }] });
+    }
+
+    // Strip trailing assistant / model turn
+    return stripTrailingAssistantTurn(contents);
+}
+
 /**
  * Build Antigravity Gemini contents from ChatCompletionRequest messages, mapping tools.
  */
@@ -1124,14 +1339,38 @@ export function buildAntigravityContents(req: ChatCompletionRequest): GeminiCont
                 }
             });
         } else {
-            let text =
-                typeof m.content === "string"
-                    ? m.content
-                    : Array.isArray(m.content)
-                      ? m.content.map((c) => (c.type === "text" ? c.text || "" : "")).join("\n")
-                      : String(m.content ?? "");
-            text = stripCompetitiveAgentPrompts(stripZeroWidth(text));
-            if (text) parts.push({ text });
+            if (typeof m.content === "string") {
+                let text = stripCompetitiveAgentPrompts(stripZeroWidth(m.content));
+                if (text) parts.push({ text });
+            } else if (Array.isArray(m.content)) {
+                for (const part of m.content) {
+                    if (part.type === "text" && part.text) {
+                        const text = stripCompetitiveAgentPrompts(stripZeroWidth(part.text));
+                        if (text) parts.push({ text });
+                    } else if (part.type === "image_url" && part.image_url?.url) {
+                        const url = part.image_url.url;
+                        const match = url.match(/^data:([^;]+);base64,(.+)$/);
+                        if (match && match[1] && match[2]) {
+                            parts.push({
+                                inlineData: {
+                                    mimeType: match[1],
+                                    data: match[2]
+                                }
+                            });
+                        } else if (/^https?:\/\//i.test(url)) {
+                            // Upstream Gemini API requires inlineData base64 for images
+                            // If it's a web URL, we can note the URL or let the executor fetch if needed,
+                            // but in Antigravity/Gemini native API, remote URLs are passed via fileData or inlineData
+                            parts.push({
+                                text: `[Image: ${url}]`
+                            });
+                        }
+                    }
+                }
+            } else if (m.content !== null && m.content !== undefined) {
+                const text = stripCompetitiveAgentPrompts(stripZeroWidth(String(m.content)));
+                if (text) parts.push({ text });
+            }
         }
 
         if (parts.length === 0) parts.push({ text: "..." });

--- a/packages/translator/tests/antigravity.test.ts
+++ b/packages/translator/tests/antigravity.test.ts
@@ -298,6 +298,36 @@ test("buildAntigravityContents preserves existing thoughtSignature", () => {
     assert.equal(modelPart.thoughtSignature, "real_encrypted_signature_blob");
 });
 
+test("buildAntigravityContents converts base64 image_url to inlineData", () => {
+    const req: ChatCompletionRequest = {
+        model: "antigravity/gemini-3.8-flash-high",
+        messages: [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "Look at this screenshot" },
+                    {
+                        type: "image_url",
+                        image_url: {
+                            url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                        }
+                    }
+                ]
+            }
+        ]
+    };
+
+    const contents = buildAntigravityContents(req);
+    assert.equal(contents.length, 1);
+    assert.equal(contents[0]?.role, "user");
+    assert.equal(contents[0]?.parts.length, 2);
+    assert.equal(contents[0]?.parts[0]?.text, "Look at this screenshot");
+    assert.deepEqual(contents[0]?.parts[1]?.inlineData, {
+        mimeType: "image/png",
+        data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    });
+});
+
 test("geminiStreamToOpenAIChunks propagates thoughtSignature in tool calls", () => {
     const state = createGeminiStreamState("gemini-3.7-flash-high");
     const rawChunk = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       '@srouter/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@srouter/pricing':
+        specifier: workspace:*
+        version: link:../../packages/pricing
       '@srouter/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
## Summary
- **Antigravity Multimodal Support (`packages/translator` & `packages/executors`)**:
  - Adds support for parsing and translating OpenAI-formatted `image_url` parts (both base64 data URIs and remote HTTP/HTTPS URLs) into Gemini `inlineData` parts.
  - Automatically fetches remote images and encodes them to base64 inline data for upstream Gemini calls.
  - Preserves function call and thought signatures while handling image parts properly.
- **Model Metadata & Capabilities Resolution (`@srouter/pricing`)**:
  - Introduces `getModelMetadata(modelId)` helper in `@srouter/pricing` that queries models.dev dataset (`models.jsonc`) using aliases and canonical keys from `pricing.jsonc`.
  - Exposes model capabilities including `attachment`, `modalities` (`input`/`output`), and context/token limits.
- **OpenCode Adapter Auto-Configuration (`@srouter/cli`)**:
  - Automatically configures `attachment: true` and `modalities: { input: ["text", "image"], output: ["text"] }` in `opencode.jsonc` when linking vision-capable models (e.g., Gemini, Claude, GPT-4o).
  - Fixes OpenCode TUI rejecting clipboard image paste with `"Model ini tidak mendukung input gambar/clipboard"`.

## Verification
- Unit tests pass across touched packages:
  - `@srouter/pricing`: `pnpm test` passed (8/8).
  - `@srouter/cli`: `pnpm test` passed (17/17).
  - `@srouter/translator`: `pnpm test` passed (32/32).
- Live verification against local SRouter instance:
  - Base64 inline PNG successfully recognized and described by `antigravity/gemini-3.8-flash-high`.
  - Remote image URL successfully fetched, parsed, and described by `antigravity/gemini-3.8-flash-high`.
