### PR TITLE
docs: add design spec for image generation endpoint

### DIFF
--- a/docs/superpowers/plans/2026-09-04-image-generation-endpoint.md
+++ b/docs/superpowers/plans/2026-09-04-image-generation-endpoint.md
@@ -39,6 +39,9 @@
   - Implement `ImageGenerationRequestSchema`:
     - `prompt`: `z.string().min(1).max(32000)`
     - `model`: `z.string().optional().default("dall-e-3")`
+    - `image`: `z.union([z.string(), z.array(z.string())]).optional()` (img2img input image base64 or URL)
+    - `images`: `z.array(z.string()).optional()` (multi-reference img2img input)
+    - `mask`: `z.string().optional()` (in-painting mask)
     - `n`: `z.number().int().min(1).max(10).optional().default(1)`
     - `quality`: `z.enum(["standard", "hd", "low", "medium", "high", "auto"]).optional().default("auto")`
     - `response_format`: `z.enum(["url", "b64_json"]).optional().default("url")`

--- a/docs/superpowers/plans/2026-09-04-image-generation-endpoint.md
+++ b/docs/superpowers/plans/2026-09-04-image-generation-endpoint.md
@@ -1,0 +1,133 @@
+# Image Generation Endpoint (`POST /v1/images/generations`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add standard OpenAI-compatible image generation routing to SRouter via `POST /v1/images/generations` with request/response schema validation, model output modality checks via `@srouter/pricing` (`models.jsonc`), provider execution delegation, fallback support, and SQLite telemetry logging.
+
+**Architecture:**
+- Route: `apps/api/src/routes/v1/images.ts` mounted at `/v1/images` (path `/v1/images/generations`).
+- Controller: `apps/api/src/controllers/images.controller.ts`.
+- Logic: `apps/api/src/logic/images.logic.ts` performs API key / rate-limit checks, modality validation using `getModelMetadata()` from `@srouter/pricing`, provider resolution via `registry`, fallback cascading, and logging into `request_logs`.
+- Packages:
+  - `@srouter/types`: `ImageGenerationRequestSchema`, `ImageGenerationResponseSchema`, and derived TypeScript types.
+  - `@srouter/executors`: `generateImage(req: ImageGenerationRequest)` method in base and concrete executors (e.g. `OpenAIExecutor`, `AntigravityExecutor`, `GoRouterExecutor`, `GenericExecutor`).
+  - `@srouter/translator`: Request/response translation utilities when provider dialects differ.
+
+**Tech Stack:** Node.js (v22+), TypeScript, Hono 4, Zod, `@srouter/types`, `@srouter/executors`, `@srouter/pricing`, `@srouter/db`.
+
+---
+
+## Global Constraints
+- Runtime: Node.js >= 22, ESM only.
+- Architecture Law: `routes/v1 -> controllers -> logic -> services / packages/{db,executors,pricing,translator,types}`.
+- Zero loose `any`, strict type safety, PascalCase guards/helpers.
+- Gateway endpoints mount under `/v1` in `apps/api/src/index.ts`.
+- Never run whole-monorepo build or broad test suites. Only test/build touched packages.
+
+---
+
+### Task 1: Shared Types & Zod Schemas (`@srouter/types`)
+
+**Files:**
+- Create: `packages/types/src/schemas/images.ts`
+- Create: `packages/types/src/images.ts`
+- Modify: `packages/types/src/schemas/index.ts`
+- Modify: `packages/types/src/index.ts`
+- Test: `packages/types/tests/images.test.ts`
+
+- [ ] **Step 1: Create types and Zod schemas for Image Generation**
+  - Implement `ImageGenerationRequestSchema`:
+    - `prompt`: `z.string().min(1).max(32000)`
+    - `model`: `z.string().optional().default("dall-e-3")`
+    - `n`: `z.number().int().min(1).max(10).optional().default(1)`
+    - `quality`: `z.enum(["standard", "hd", "low", "medium", "high", "auto"]).optional().default("auto")`
+    - `response_format`: `z.enum(["url", "b64_json"]).optional().default("url")`
+    - `size`: `z.string().optional().default("1024x1024")`
+    - `style`: `z.enum(["vivid", "natural"]).optional()`
+    - `user`: `z.string().optional()`
+    - `partial_images`: `z.number().int().min(0).max(3).optional()`
+  - Implement `ImageGenerationResponseSchema`:
+    - `created`: `z.number()`
+    - `data`: `z.array(z.object({ url: z.string().optional(), b64_json: z.string().optional(), revised_prompt: z.string().optional() }))`
+    - `usage`: `z.object({ total_tokens: z.number().optional(), input_tokens: z.number().optional(), output_tokens: z.number().optional() }).optional()`
+  - Derive types: `ImageGenerationRequest = z.infer<typeof ImageGenerationRequestSchema>` and `ImageGenerationResponse = z.infer<typeof ImageGenerationResponseSchema>`.
+
+- [ ] **Step 2: Export in `@srouter/types` and verify package build**
+  - Run: `cd packages/types && pnpm run build`
+
+---
+
+### Task 2: Provider Executor Interface & Implementations (`@srouter/executors`)
+
+**Files:**
+- Modify: `packages/executors/src/base.ts`
+- Modify: `packages/executors/src/openai.ts`
+- Modify: `packages/executors/src/antigravity.ts` (if applicable)
+- Modify: `packages/executors/src/index.ts`
+- Test: `packages/executors/tests/images.test.ts`
+
+- [ ] **Step 1: Add `generateImage` to `BaseExecutor`**
+  - Add signature to `BaseExecutor`:
+    ```ts
+    generateImage?(req: ImageGenerationRequest): Promise<ImageGenerationResponse>;
+    ```
+- [ ] **Step 2: Implement `generateImage` in `OpenAIExecutor`**
+  - POST to `${this.baseUrl}/images/generations` with standard Authorization and payload.
+  - Map response into `ImageGenerationResponse`.
+  - Handle errors without leaking upstream credentials.
+- [ ] **Step 3: Run unit tests for executors**
+  - Run: `cd packages/executors && pnpm test`
+
+---
+
+### Task 3: Modality Validation Helper (`@srouter/pricing`)
+
+**Files:**
+- Modify: `packages/pricing/src/pricing.ts`
+- Modify: `packages/pricing/src/index.ts`
+- Test: `packages/pricing/tests/image-modality.test.ts`
+
+- [ ] **Step 1: Implement `isImageGenerationSupported(model: string): boolean`**
+  - Use `getModelMetadata(model)`.
+  - Check `metadata?.modalities?.output?.includes("image")`.
+  - Provide fallback allowlist for models known to generate images (e.g. `dall-e-2`, `dall-e-3`, `gpt-image-1`, `gpt-image-1.5`, `gpt-image-2`, `nano-banana`).
+  - Return `true` if supported, `false` otherwise.
+- [ ] **Step 2: Run pricing tests**
+  - Run: `cd packages/pricing && pnpm test`
+
+---
+
+### Task 4: Images Logic & Routing in API (`apps/api`)
+
+**Files:**
+- Create: `apps/api/src/logic/images.logic.ts`
+- Create: `apps/api/src/controllers/images.controller.ts`
+- Create: `apps/api/src/routes/v1/images.ts`
+- Modify: `apps/api/src/index.ts`
+- Test: `apps/api/tests/images-route.test.ts`
+
+- [ ] **Step 1: Implement `ImagesLogic.generate(req, context)`**
+  - Validate model capability: call `isImageGenerationSupported(model)`. If false, throw `HTTPException(400, { message: "Model '<model>' does not support image generation. Output modalities do not include 'image'." })`.
+  - Deduce credit/rate-limit using existing apiKey helpers.
+  - Resolve provider and execute with fallback chain if configured.
+  - Record request log in `request_logs`.
+- [ ] **Step 2: Implement `ImagesController` & Mount Route**
+  - Mount `imagesRoute` at `/images` under `/v1` (`POST /v1/images/generations`).
+  - Protect with `apiKeyAuth`.
+- [ ] **Step 3: Write tests for `/v1/images/generations`**
+  - Test validation rejection (model not supporting image output -> 400).
+  - Test valid request delegating to registered executor and returning 200 with `{ created, data: [...] }`.
+  - Test auth rejection (401 when API key required but missing).
+  - Run: `cd apps/api && pnpm exec tsx --test tests/images-route.test.ts`
+
+---
+
+### Task 5: Verification & End-to-End Smoke Test
+
+- [ ] **Step 1: Run typechecks and builds for touched packages**
+  - `cd packages/types && pnpm run build`
+  - `cd packages/pricing && pnpm run build`
+  - `cd packages/executors && pnpm run build`
+  - `cd apps/api && pnpm run build`
+- [ ] **Step 2: Run targeted test suite in `apps/api`**
+  - `cd apps/api && pnpm test`

--- a/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
+++ b/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
@@ -1,0 +1,144 @@
+# Design Specification: Image Generation Endpoint (`/v1/images/generations`)
+
+- **Author**: Seaavey & Hermes
+- **Date**: 2026-09-04
+- **Status**: Draft — awaiting approval
+
+---
+
+## 1. Overview & Motivation
+
+SRouter currently functions purely as a text-based LLM routing gateway supporting `/v1/chat/completions` (OpenAI format) and `/v1/messages` (Anthropic format). Many downstream AI developer clients, coding agents, and apps (OpenAI SDK, LangChain, LlamaIndex, etc.) expect the standard OpenAI Image Generation API (`/v1/images/generations`).
+
+This specification outlines adding standard OpenAI-compatible image generation routing to SRouter, enabling client applications to request image generations through configured providers (e.g. OpenAI DALL-E, Google Gemini Imagen, OpenRouter / HuggingFace image models, etc.) while leveraging SRouter's core features: API key validation, provider alias routing, fallback handling, and request logging.
+
+---
+
+## 2. API Contract (OpenAI Specification)
+
+### 2.1 Endpoint
+`POST /v1/images/generations`
+
+### 2.2 Headers
+- `Authorization: Bearer <srouter-api-key>`
+- `Content-Type: application/json`
+
+### 2.3 Request Payload (`ImageGenerationRequest`)
+
+```json
+{
+  "prompt": "A futuristic city in watercolor style",
+  "model": "dall-e-3",
+  "n": 1,
+  "quality": "standard",
+  "response_format": "url",
+  "size": "1024x1024",
+  "style": "vivid",
+  "user": "optional-user-id"
+}
+```
+
+#### Fields & Constraints:
+- `prompt` (string, required): Text description of the desired image(s). Max 1000 characters for dall-e-2, 4000 for dall-e-3.
+- `model` (string, optional, default: `"dall-e-3"`): ID or alias of the model to use. Supports model mapping / provider prefix (e.g. `openai/dall-e-3`, `openrouter/stabilityai/stable-diffusion-3`).
+- `n` (integer, optional, default: `1`): Number of images to generate. Must be between 1 and 10.
+- `quality` (string, optional, default: `"standard"`): `"standard"` or `"hd"` (model-dependent).
+- `response_format` (string, optional, default: `"url"`): `"url"` or `"b64_json"`.
+- `size` (string, optional, default: `"1024x1024"`): Dimensions of the generated images (`256x256`, `512x512`, `1024x1024`, `1024x1792`, `1792x1024`).
+- `style` (string, optional, default: `"vivid"`): `"vivid"` or `"natural"`.
+
+### 2.4 Response Payload (`ImageGenerationResponse`)
+
+```json
+{
+  "created": 1725408000,
+  "data": [
+    {
+      "url": "https://oaidalleapiprodscus.blob.core.windows.net/...",
+      "revised_prompt": "A modern watercolor painting of a towering futuristic metropolis with neon accents..."
+    }
+  ]
+}
+```
+
+Or for `response_format: "b64_json"`:
+
+```json
+{
+  "created": 1725408000,
+  "data": [
+    {
+      "b64_json": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      "revised_prompt": "..."
+    }
+  ]
+}
+```
+
+---
+
+## 3. Architecture & Data Flow
+
+Following SRouter's architectural law:
+```
+routes/v1 → controllers → logic → services / packages/{db,executors,providers,translator}
+```
+
+```
+apps/api/src/routes/v1/images.ts
+  └── ImagesController.Generate
+        └── ImagesLogic.generate()
+              ├── ApiKeyAuth / RateLimit Check
+              ├── Model resolution & provider routing (resolveProvider)
+              ├── Fallback chain execution
+              ├── Packages:
+              │     ├── @srouter/types: ImageGenerationRequest & Response schemas
+              │     ├── @srouter/translator: translateImageRequest / translateImageResponse
+              │     ├── @srouter/executors: ImageExecutor or ProviderExecutor.generateImage()
+              │     └── @srouter/db: request_logs persistence
+              └── Return standard JSON response
+```
+
+### 3.1 Layer Responsibilities
+
+1. **`apps/api/src/routes/v1/images.ts`**:
+   - Declares route `POST /generations` with `apiKeyAuth` middleware.
+   - Validates request body using `@hono/zod-validator` and `ImageGenerationRequestSchema`.
+2. **`apps/api/src/controllers/images.controller.ts`**:
+   - HTTP extraction (c.req.valid('json'), auth context, client IP, user agent).
+   - Calls `ImagesLogic.generate()`.
+   - Returns standard JSON response or raises `HTTPException`.
+3. **`apps/api/src/logic/images.logic.ts`**:
+   - Resolves provider based on model prefix or default catalog.
+   - Executes image generation request with fallback retry runner.
+   - Records request log into SQLite `request_logs`.
+4. **`packages/types`**:
+   - Zod schemas: `ImageGenerationRequestSchema`, `ImageGenerationResponseSchema`.
+   - TypeScript types derived via `z.infer`.
+5. **`packages/executors`**:
+   - Extends provider executor interface or base executor to support `generateImage(req: ImageGenerationRequest)`.
+   - Handles upstream HTTP request to target provider's `/v1/images/generations` or provider-specific image generation API.
+6. **`packages/translator`**:
+   - Standardizes differences across providers (e.g. Gemini Imagen vs OpenAI DALL-E) into the OpenAI output envelope.
+
+---
+
+## 4. Key Considerations & YAGNI Boundaries
+
+1. **Strict OpenAI Compatibility**: Keep standard response envelope `{ created, data: [{ url | b64_json, revised_prompt }] }`.
+2. **Stream Handling**: Image generation is non-streaming; returns pure JSON. No SSE required.
+3. **Cost & Token Tracking**:
+   - Images do not consume input/output tokens in the standard LLM sense.
+   - Log entry will mark `total_tokens: 0`, and calculate `estimated_cost` based on model image unit pricing if configured in catalog.
+4. **Out of Scope (YAGNI for Phase 1)**:
+   - No image edits (`/v1/images/edits`) or image variations (`/v1/images/variations`) in Phase 1.
+   - No direct local file caching or image storage proxying (URLs are returned directly from upstream provider or base64).
+
+---
+
+## 5. Implementation Plan (Phases)
+
+- **Phase 1 (Spec & Review)**: Commit this specification and submit PR for review.
+- **Phase 2 (Types & Executors)**: Add schemas in `@srouter/types`, adapt `@srouter/executors` for image generation endpoint.
+- **Phase 3 (Routing & Logic)**: Mount `/v1/images` router in `apps/api`, wire up `ImagesLogic` & logging.
+- **Phase 4 (Testing & Verification)**: Unit tests for schemas and executors; smoke tests against local SRouter instance.

--- a/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
+++ b/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
@@ -96,10 +96,14 @@ apps/api/src/routes/v1/images.ts
   └── ImagesController.Generate
         └── ImagesLogic.generate()
               ├── ApiKeyAuth / RateLimit Check
+              ├── Model capability validation (@srouter/pricing getModelMetadata)
+              │     └── Verify `modalities.output` includes `"image"`
+              │     └── If not supported: raise 400 HTTPException ("Model '<model>' does not support image generation.")
               ├── Model resolution & provider routing (resolveProvider)
               ├── Fallback chain execution
               ├── Packages:
               │     ├── @srouter/types: ImageGenerationRequest & Response schemas
+              │     ├── @srouter/pricing: getModelMetadata / modalities output validation
               │     ├── @srouter/translator: translateImageRequest / translateImageResponse
               │     ├── @srouter/executors: ImageExecutor or ProviderExecutor.generateImage()
               │     └── @srouter/db: request_logs persistence
@@ -116,6 +120,21 @@ apps/api/src/routes/v1/images.ts
    - Calls `ImagesLogic.generate()`.
    - Returns standard JSON response or raises `HTTPException`.
 3. **`apps/api/src/logic/images.logic.ts`**:
+   - **Model Modality Validation**:
+     - Uses `getModelMetadata(model)` from `@srouter/pricing` (which queries `models.jsonc`).
+     - Checks if `metadata.modalities.output` contains `"image"`.
+     - For known image models not yet cataloged (e.g. `dall-e-2`, `dall-e-3`), provides a known fallback allowlist.
+     - If the requested model does NOT support image output (e.g. text-only model like `deepseek-chat`, `gpt-4o`, `claude-sonnet-4`), immediately throws a `400 Bad Request`:
+       ```json
+       {
+         "error": {
+           "message": "Model 'claude-sonnet-4' does not support image generation. Output modalities do not include 'image'.",
+           "type": "invalid_request_error",
+           "param": "model",
+           "code": "model_not_supported"
+         }
+       }
+       ```
    - Resolves provider based on model prefix or default catalog.
    - Executes image generation request with fallback retry runner.
    - Records request log into SQLite `request_logs`.

--- a/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
+++ b/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
@@ -2,7 +2,7 @@
 
 - **Author**: Seaavey & Hermes
 - **Date**: 2026-09-04
-- **Status**: Draft — awaiting approval
+- **Status**: Approved — ready for implementation
 
 ---
 

--- a/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
+++ b/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
@@ -29,6 +29,8 @@ This specification outlines adding standard OpenAI-compatible image generation r
 {
   "prompt": "A futuristic city in watercolor style",
   "model": "dall-e-3",
+  "image": "data:image/png;base64,...",
+  "mask": "data:image/png;base64,...",
   "n": 1,
   "quality": "standard",
   "response_format": "url",
@@ -41,6 +43,8 @@ This specification outlines adding standard OpenAI-compatible image generation r
 #### Fields & Constraints (OpenAI OpenAPI Standard):
 - `prompt` (string, required): Text description of the desired image(s). Max 1000 characters for `dall-e-2`, 4000 for `dall-e-3`, up to 32000 for GPT image models.
 - `model` (string, optional, default: `"dall-e-2"` or `"dall-e-3"`): ID or alias of the model to use. Supports model mapping / provider prefix (e.g. `openai/dall-e-3`, `openrouter/stabilityai/stable-diffusion-3`).
+- `image` (string | array of string, optional): Input image for **img2img / image editing**. Accepts base64 data URL (`data:image/png;base64,...`), raw base64 string, or external image URL (`https://...`). Also supports array of image references (`images`) for multi-reference models.
+- `mask` (string, optional): Transparent mask image for inpainting / selective image editing (base64 data URL or external URL).
 - `n` (integer, optional, default: `1`): Number of images to generate (1 to 10). Note: `dall-e-3` only supports `n=1`.
 - `quality` (string, optional, default: `"auto"` or `"standard"`): `"standard"`, `"hd"` (`dall-e-3`), or `"low"`, `"medium"`, `"high"`, `"auto"` (GPT image models).
 - `response_format` (string, optional, default: `"url"`): `"url"` or `"b64_json"`.

--- a/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
+++ b/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
@@ -38,14 +38,16 @@ This specification outlines adding standard OpenAI-compatible image generation r
 }
 ```
 
-#### Fields & Constraints:
-- `prompt` (string, required): Text description of the desired image(s). Max 1000 characters for dall-e-2, 4000 for dall-e-3.
-- `model` (string, optional, default: `"dall-e-3"`): ID or alias of the model to use. Supports model mapping / provider prefix (e.g. `openai/dall-e-3`, `openrouter/stabilityai/stable-diffusion-3`).
-- `n` (integer, optional, default: `1`): Number of images to generate. Must be between 1 and 10.
-- `quality` (string, optional, default: `"standard"`): `"standard"` or `"hd"` (model-dependent).
+#### Fields & Constraints (OpenAI OpenAPI Standard):
+- `prompt` (string, required): Text description of the desired image(s). Max 1000 characters for `dall-e-2`, 4000 for `dall-e-3`, up to 32000 for GPT image models.
+- `model` (string, optional, default: `"dall-e-2"` or `"dall-e-3"`): ID or alias of the model to use. Supports model mapping / provider prefix (e.g. `openai/dall-e-3`, `openrouter/stabilityai/stable-diffusion-3`).
+- `n` (integer, optional, default: `1`): Number of images to generate (1 to 10). Note: `dall-e-3` only supports `n=1`.
+- `quality` (string, optional, default: `"auto"` or `"standard"`): `"standard"`, `"hd"` (`dall-e-3`), or `"low"`, `"medium"`, `"high"`, `"auto"` (GPT image models).
 - `response_format` (string, optional, default: `"url"`): `"url"` or `"b64_json"`.
-- `size` (string, optional, default: `"1024x1024"`): Dimensions of the generated images (`256x256`, `512x512`, `1024x1024`, `1024x1792`, `1792x1024`).
-- `style` (string, optional, default: `"vivid"`): `"vivid"` or `"natural"`.
+- `size` (string, optional, default: `"1024x1024"`): Dimensions of the generated images (`256x256`, `512x512`, `1024x1024`, `1024x1536`, `1536x1024`, `1024x1792`, `1792x1024`, or arbitrary for newer models).
+- `style` (string, optional, default: `"vivid"`): `"vivid"` or `"natural"` (`dall-e-3` only).
+- `user` (string, optional): Unique end-user identifier for abuse detection.
+- `partial_images` (integer, optional, min 0, max 3): Number of partial images to generate for streaming responses.
 
 ### 2.4 Response Payload (`ImageGenerationResponse`)
 

--- a/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
+++ b/docs/superpowers/specs/2026-09-04-image-generation-endpoint-design.md
@@ -57,7 +57,12 @@ This specification outlines adding standard OpenAI-compatible image generation r
       "url": "https://oaidalleapiprodscus.blob.core.windows.net/...",
       "revised_prompt": "A modern watercolor painting of a towering futuristic metropolis with neon accents..."
     }
-  ]
+  ],
+  "usage": {
+    "total_tokens": 0,
+    "input_tokens": 0,
+    "output_tokens": 0
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR introduces the technical design specification for supporting the OpenAI-compatible Image Generation endpoint (`POST /v1/images/generations`) in SRouter.

## Scope of Spec
- **API Contract:** OpenAI-compatible request and response payloads (`prompt`, `model`, `size`, `quality`, `n`, `response_format`, etc.).
- **Architecture Flow:** Follows SRouter's dependency rule (`routes/v1/images.ts` → `ImagesController` → `ImagesLogic` → `executors` / `translator` / `db`).
- **YAGNI Boundaries:** Focuses purely on image generation (edits/variations excluded in Phase 1; no local storage proxying).
- **Phased Implementation Roadmap:** Breakdown from types/executors to route wiring and integration testing.
