### PR TITLE
fix(api): restore tool call interception logic and missing imports in ChatLogic

### DIFF
--- a/apps/api/src/logic/chat.logic.ts
+++ b/apps/api/src/logic/chat.logic.ts
@@ -18,9 +18,15 @@ import type {
 } from "@srouter/types";
 import { registry } from "@/services/registry.js";
 import { ensureFreshToken } from "@/services/tokenRefresh.js";
-import { executeInterceptedSearch } from "@/services/toolInterceptor.js";
+import { executeInterceptedSearch, shouldInterceptToolCall } from "@/services/toolInterceptor.js";
 
 const MAX_INTERCEPT_DEPTH = 3;
+
+interface AssembledStreamingToolCall {
+    id: string;
+    name: string;
+    arguments: string;
+}
 
 interface CandidateModel {
     model: string;
@@ -307,6 +313,11 @@ export class ChatLogic {
                 await ensureFreshToken(providerId);
                 const generator = registry.chatCompletionStream(currentReq);
 
+                const bufferedChunks: ChatCompletionChunk[] = [];
+                const toolCallsMap = new Map<number, AssembledStreamingToolCall>();
+                let hasToolCalls = false;
+                let assistantContent = "";
+
                 for await (const chunk of generator) {
                     if (!yieldedAny) {
                         yieldedAny = true;
@@ -320,6 +331,94 @@ export class ChatLogic {
                         usage = chunk.usage;
                     }
 
+                    const choice = chunk.choices?.[0];
+                    const delta = choice?.delta;
+
+                    if (delta?.content) {
+                        assistantContent += delta.content;
+                    }
+
+                    if (Array.isArray(delta?.tool_calls) && delta.tool_calls.length > 0) {
+                        hasToolCalls = true;
+                        for (const tc of delta.tool_calls) {
+                            const idx = tc.index ?? toolCallsMap.size;
+                            const existing = toolCallsMap.get(idx) || {
+                                id: tc.id || `call_${Date.now()}_${idx}`,
+                                name: tc.function?.name || "",
+                                arguments: ""
+                            };
+                            if (tc.id) existing.id = tc.id;
+                            if (tc.function?.name) existing.name = tc.function.name;
+                            if (tc.function?.arguments) existing.arguments += tc.function.arguments;
+                            toolCallsMap.set(idx, existing);
+                        }
+                    }
+
+                    if (hasToolCalls) {
+                        bufferedChunks.push(chunk);
+                    } else {
+                        yield chunk;
+                    }
+                }
+
+                const assembledToolCalls = Array.from(toolCallsMap.values());
+                const hasInterceptableCall =
+                    depth < MAX_INTERCEPT_DEPTH &&
+                    assembledToolCalls.some((tc) =>
+                        shouldInterceptToolCall(tc.name, effectiveBody.tools)
+                    );
+
+                if (hasInterceptableCall) {
+                    const assistantToolCalls: ToolCall[] = assembledToolCalls.map((tc) => ({
+                        id: tc.id,
+                        type: "function",
+                        function: {
+                            name: tc.name,
+                            arguments: tc.arguments
+                        }
+                    }));
+
+                    const assistantMessage: ChatMessage = {
+                        role: "assistant",
+                        content: assistantContent || null,
+                        tool_calls: assistantToolCalls
+                    };
+
+                    const updatedMessages: ChatMessage[] = [
+                        ...effectiveBody.messages,
+                        assistantMessage
+                    ];
+
+                    for (const tc of assembledToolCalls) {
+                        if (shouldInterceptToolCall(tc.name, effectiveBody.tools)) {
+                            const { toolCallId, result } = await executeInterceptedSearch({
+                                id: tc.id,
+                                function: { name: tc.name, arguments: tc.arguments }
+                            });
+                            updatedMessages.push({
+                                role: "tool",
+                                tool_call_id: toolCallId,
+                                content: JSON.stringify(result)
+                            });
+                        }
+                    }
+
+                    const followUpRequest: ChatCompletionRequest = {
+                        ...currentReq,
+                        messages: updatedMessages
+                    };
+                    yield* this.ProcessStreamingCompletion(
+                        followUpRequest,
+                        startTime,
+                        depth + 1,
+                        apiKeyId,
+                        ipAddress,
+                        userAgent
+                    );
+                    return;
+                }
+
+                for (const chunk of bufferedChunks) {
                     yield chunk;
                 }
 


### PR DESCRIPTION
## Summary
Restore `shouldInterceptToolCall` import and streaming tool-call interception handling in `ChatLogic.ProcessStreamingCompletion`.

## Problem
In PR #104 (`fix(api): stream SSE chunks immediately without buffering`), removing the tool call chunk buffering in `ProcessStreamingCompletion` inadvertently removed the streaming tool-call interception flow (`executeInterceptedSearch`), while also breaking `ProcessNonStreamingCompletion` because `shouldInterceptToolCall` was removed from the imports. This broke CI with:
- `ReferenceError: shouldInterceptToolCall is not defined`
- Failing unit test `ChatLogic intercepts streaming web_search and yields final answer stream to client`

## Fix
- Re-import `shouldInterceptToolCall` from `@/services/toolInterceptor.js`.
- Keep tool-call interception buffer specifically for tool calls (when `delta.tool_calls` is present) so tool interception works seamlessly in streaming while regular content text chunks stream through immediately.
