### PR TITLE
fix(db): isolate test databases from production database

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
         "build": "tsup",
         "clean": "rm -rf dist",
         "start": "node dist/index.js",
-        "test": "tsx --test --test-concurrency=1 tests/**/*.test.ts"
+        "test": "NODE_ENV=test tsx --test --test-concurrency=1 --import ./tests/setup.ts tests/**/*.test.ts"
     },
     "dependencies": {
         "@hono/node-server": "^2.1.0",

--- a/apps/api/tests/analytics.test.ts
+++ b/apps/api/tests/analytics.test.ts
@@ -20,13 +20,14 @@ afterEach(async () => {
 /**
  * Seeds `rows` into the 1h analytics window at a deterministic `created_at`
  * inside a fresh minute-bucket. Uses raw SQL so the timestamp is controlled —
- * `logRequestDB` forces `created_at = Date.now()`, which can collide with live
- * traffic in a shared dev DB. Skips backward in 1-min steps until it finds an
- * empty bucket, so the exact token sums asserted below are hermetic.
+ * `logRequestDB` forces `created_at = Date.now()`, which can collide with
+ * other tests sharing this isolated test database (see tests/setup.ts).
+ * Skips backward in 1-min steps until it finds an empty bucket, so the
+ * exact token sums asserted below are hermetic.
  */
 async function seedIntoEmptyBucket(rows: Array<Omit<RequestLogEntry, "id" | "createdAt">>) {
-    // Clear all existing logs so we always find an empty bucket (avoids flaky
-    // race with other tests that share the same global DB).
+    // Clear test-database logs so we always find an empty bucket (avoids flaky
+    // race with other tests that share the same isolated test DB).
     await db.prepare("DELETE FROM request_logs").run();
 
     const BucketSizeMs = 60_000;

--- a/apps/api/tests/setup.ts
+++ b/apps/api/tests/setup.ts
@@ -1,0 +1,53 @@
+/**
+ * Test loader — runs BEFORE any test file via `tsx --test --import ./tests/setup.ts`.
+ *
+ * Redirects the database to an isolated temp file per test process so tests
+ * NEVER touch the production database (`~/.srouter/srouter.db`). A previous
+ * run wiped all production API keys because tests shared that file.
+ *
+ * Standalone on purpose (node builtins only): importing `@srouter/db` here
+ * would open the production connection before the redirect happens.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const PROD_DB_PATH = path.join(os.homedir(), ".srouter", "srouter.db");
+
+function isProductionPath(p: string): boolean {
+    return path.resolve(p) === path.resolve(PROD_DB_PATH);
+}
+
+// Respect an explicit non-production override (e.g. CI-provided temp DB).
+const current = process.env.DATABASE_PATH;
+if (!current || isProductionPath(current)) {
+    const dir = path.join(os.tmpdir(), "srouter-test");
+    fs.mkdirSync(dir, { recursive: true });
+    // Per-process file: each `tsx --test` worker gets its own database.
+    const testDb = path.join(dir, `test-${process.pid}.db`);
+    // Fresh slate on (unlikely) pid reuse.
+    for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+        try {
+            fs.rmSync(`${testDb}${suffix}`, { force: true });
+        } catch {
+            // Ignore cleanup errors for files that may not exist.
+        }
+    }
+    process.env.DATABASE_PATH = testDb;
+    process.on("exit", () => {
+        for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+            try {
+                fs.rmSync(`${testDb}${suffix}`, { force: true });
+            } catch {
+                // Best-effort temp cleanup only.
+            }
+        }
+    });
+}
+
+// Tests run against local SQLite — never a production Postgres.
+if (process.env.DATABASE_URL) {
+    delete process.env.DATABASE_URL;
+}
+
+process.env.NODE_ENV ??= "test";

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -24,7 +24,7 @@
     "scripts": {
         "build": "tsup",
         "clean": "rm -rf dist",
-        "test": "tsx --test tests/**/*.test.ts"
+        "test": "NODE_ENV=test tsx --test --import ./tests/setup.ts tests/**/*.test.ts"
     },
     "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/apps/cli/src/commands/migrate.ts
+++ b/apps/cli/src/commands/migrate.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import * as p from "@clack/prompts";
 import { DatabaseSync } from "node:sqlite";
-import { DEFAULT_DB_PATH, initDatabase, LEGACY_DB_LOCATIONS, SROUTER_DIR } from "@srouter/db";
+import { getDatabasePath, initDatabase, LEGACY_DB_LOCATIONS } from "@srouter/db";
 import { formatError, formatInfo, formatSuccess, formatWarning, pc } from "../lib/ui.js";
 
 type SqliteValue = string | number | bigint | Uint8Array | null;
@@ -214,8 +214,16 @@ export interface MigrateCommandOptions {
     action?: "copy" | "merge" | "backup_and_replace";
 }
 
-const TargetDbPath = DEFAULT_DB_PATH;
-const BackupDir = path.join(SROUTER_DIR, "backups");
+/** Resolved lazily (not at import) so tests can redirect via `DATABASE_PATH`
+ * to an isolated file instead of the production database. */
+function getTargetDbPath(): string {
+    return getDatabasePath();
+}
+
+/** Backups live next to the target database (isolated automatically in tests). */
+function getBackupDir(targetDbPath: string): string {
+    return path.join(path.dirname(targetDbPath), "backups");
+}
 
 const NineRouterDbLocations = [
     path.join(os.homedir(), ".9router", "srouter.db"),
@@ -234,14 +242,14 @@ function fileKb(filePath: string): string {
     return `${(fs.statSync(filePath).size / 1024).toFixed(2)} KB`;
 }
 
-function ensureDirs(): void {
-    fs.mkdirSync(SROUTER_DIR, { recursive: true, mode: 0o700 });
-    fs.mkdirSync(BackupDir, { recursive: true, mode: 0o755 });
+function ensureDirs(targetDbPath: string): void {
+    fs.mkdirSync(path.dirname(targetDbPath), { recursive: true, mode: 0o700 });
+    fs.mkdirSync(getBackupDir(targetDbPath), { recursive: true, mode: 0o755 });
 }
 
-function backupDb(source: string, label: string): string {
+function backupDb(source: string, label: string, targetDbPath: string): string {
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const backupPath = path.join(BackupDir, `${label}-backup-${timestamp}.db`);
+    const backupPath = path.join(getBackupDir(targetDbPath), `${label}-backup-${timestamp}.db`);
     fs.copyFileSync(source, backupPath);
     p.log.step(`Backed up to ${pc.dim(backupPath)}`);
     return backupPath;
@@ -327,9 +335,10 @@ function findDatabase(candidates: string[], label: string): string | null {
 
 async function migrateDb(options: MigrateCommandOptions): Promise<void> {
     p.intro("SRouter Database Migration");
+    const targetDbPath = getTargetDbPath();
 
-    if (fs.existsSync(TargetDbPath)) {
-        p.log.warn(`Database already exists at ${TargetDbPath} (${fileKb(TargetDbPath)})`);
+    if (fs.existsSync(targetDbPath)) {
+        p.log.warn(`Database already exists at ${targetDbPath} (${fileKb(targetDbPath)})`);
         p.outro("No migration needed — already using the new location.");
         return;
     }
@@ -342,13 +351,13 @@ async function migrateDb(options: MigrateCommandOptions): Promise<void> {
     if (!source) {
         p.log.error("No existing database found.");
         p.outro(
-            `Start SRouter and a fresh database will be created at ${TargetDbPath}, ` +
+            `Start SRouter and a fresh database will be created at ${targetDbPath}, ` +
                 "or pass --source /path/to/srouter.db."
         );
         return;
     }
 
-    ensureDirs();
+    ensureDirs(targetDbPath);
     const proceed =
         options.yes || (await p.confirm({ message: `Migrate database from ${source}?` })) === true;
 
@@ -358,10 +367,10 @@ async function migrateDb(options: MigrateCommandOptions): Promise<void> {
     }
 
     try {
-        backupDb(source, "srouter");
-        fs.copyFileSync(source, TargetDbPath);
-        fs.chmodSync(TargetDbPath, 0o600);
-        p.log.success(`Database moved to ${TargetDbPath}`);
+        backupDb(source, "srouter", targetDbPath);
+        fs.copyFileSync(source, targetDbPath);
+        fs.chmodSync(targetDbPath, 0o600);
+        p.log.success(`Database moved to ${targetDbPath}`);
         p.outro("Restart SRouter to use the migrated database.");
     } catch (error) {
         p.log.error(formatError(`Migration failed: ${(error as Error).message}`));
@@ -432,14 +441,15 @@ async function migrateNineRouter(options: MigrateCommandOptions): Promise<void> 
         return;
     }
 
-    const existingTarget = fs.existsSync(TargetDbPath);
+    const targetDbPath = getTargetDbPath();
+    const existingTarget = fs.existsSync(targetDbPath);
     let action: "copy" | "merge" | "backup_and_replace" = options.action ?? "copy";
 
     if (existingTarget && !options.action) {
         if (options.yes) {
             action = "merge";
         } else {
-            p.log.warn(`Existing SRouter database found at ${TargetDbPath} (${fileKb(TargetDbPath)})`);
+            p.log.warn(`Existing SRouter database found at ${targetDbPath} (${fileKb(targetDbPath)})`);
             const choice = await p.select({
                 message: "How should the existing SRouter database be handled?",
                 options: [
@@ -465,12 +475,12 @@ async function migrateNineRouter(options: MigrateCommandOptions): Promise<void> 
         return;
     }
 
-    ensureDirs();
-    const sourceBackup = backupDb(source, "9router");
+    ensureDirs(targetDbPath);
+    const sourceBackup = backupDb(source, "9router", targetDbPath);
 
     let targetBackup: string | null = null;
     if (action === "backup_and_replace") {
-        targetBackup = backupDb(TargetDbPath, "srouter");
+        targetBackup = backupDb(targetDbPath, "srouter", targetDbPath);
     }
 
     const s = p.spinner();
@@ -478,7 +488,7 @@ async function migrateNineRouter(options: MigrateCommandOptions): Promise<void> 
         s.start("Preparing target database");
         await initDatabase();
 
-        const targetDb = new DatabaseSync(TargetDbPath);
+        const targetDb = new DatabaseSync(targetDbPath);
         targetDb.exec("PRAGMA foreign_keys = OFF;");
 
         let inserted = 0;
@@ -581,7 +591,7 @@ async function migrateNineRouter(options: MigrateCommandOptions): Promise<void> 
                 `Rows/Items inserted: ${inserted}`,
                 `Rows/Items skipped: ${skipped}`,
                 `Source: ${source}`,
-                `Target: ${TargetDbPath}`
+                `Target: ${targetDbPath}`
             ].join("\n")
         );
 

--- a/apps/cli/tests/migrate.test.ts
+++ b/apps/cli/tests/migrate.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { DatabaseSync } from "node:sqlite";
+import { getDatabasePath } from "@srouter/db";
 import { migrateCommand } from "../src/commands/migrate.js";
 
 test("9Router database migration imports SQLite tables safely", async () => {
@@ -36,7 +37,8 @@ test("9Router database migration imports SQLite tables safely", async () => {
         yes: true
     });
 
-    const targetDbPath = path.join(os.homedir(), ".srouter", "srouter.db");
+    // Isolated test database (redirected by tests/setup.ts) — never production.
+    const targetDbPath = getDatabasePath();
     assert.equal(fs.existsSync(targetDbPath), true);
 
     const targetDb = new DatabaseSync(targetDbPath);
@@ -107,7 +109,8 @@ test("9Router JSON backup export imports providers, apiKeys and customModels saf
         yes: true
     });
 
-    const targetDbPath = path.join(os.homedir(), ".srouter", "srouter.db");
+    // Isolated test database (redirected by tests/setup.ts) — never production.
+    const targetDbPath = getDatabasePath();
     const targetDb = new DatabaseSync(targetDbPath);
 
     const provider1 = targetDb.prepare("SELECT * FROM providers WHERE id = ?").get("conn-123") as Record<string, unknown>;

--- a/apps/cli/tests/setup.ts
+++ b/apps/cli/tests/setup.ts
@@ -1,0 +1,53 @@
+/**
+ * Test loader — runs BEFORE any test file via `tsx --test --import ./tests/setup.ts`.
+ *
+ * Redirects the database to an isolated temp file per test process so tests
+ * NEVER touch the production database (`~/.srouter/srouter.db`). A previous
+ * `migrate` test run wiped production API keys because it targeted that file.
+ *
+ * Standalone on purpose (node builtins only): importing `@srouter/db` here
+ * would open the production connection before the redirect happens.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const PROD_DB_PATH = path.join(os.homedir(), ".srouter", "srouter.db");
+
+function isProductionPath(p: string): boolean {
+    return path.resolve(p) === path.resolve(PROD_DB_PATH);
+}
+
+// Respect an explicit non-production override (e.g. CI-provided temp DB).
+const current = process.env.DATABASE_PATH;
+if (!current || isProductionPath(current)) {
+    const dir = path.join(os.tmpdir(), "srouter-test");
+    fs.mkdirSync(dir, { recursive: true });
+    // Per-process file: each `tsx --test` worker gets its own database.
+    const testDb = path.join(dir, `test-${process.pid}.db`);
+    // Fresh slate on (unlikely) pid reuse.
+    for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+        try {
+            fs.rmSync(`${testDb}${suffix}`, { force: true });
+        } catch {
+            // Ignore cleanup errors for files that may not exist.
+        }
+    }
+    process.env.DATABASE_PATH = testDb;
+    process.on("exit", () => {
+        for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+            try {
+                fs.rmSync(`${testDb}${suffix}`, { force: true });
+            } catch {
+                // Best-effort temp cleanup only.
+            }
+        }
+    });
+}
+
+// Tests run against local SQLite — never a production Postgres.
+if (process.env.DATABASE_URL) {
+    delete process.env.DATABASE_URL;
+}
+
+process.env.NODE_ENV ??= "test";

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,33 +1,16 @@
-import path from "node:path";
-import fs from "node:fs";
-import os from "node:os";
 import { sqliteDb } from "./sqlite.js";
 import { type DbClient, type DbResult, getDbClient } from "./client.js";
 
-/** Directory holding the SRouter database (and backups) in the user's home directory. */
-export const SROUTER_DIR = path.join(os.homedir(), ".srouter");
-
-/** Default database location: ~/.srouter/srouter.db */
-export const DEFAULT_DB_PATH = path.join(SROUTER_DIR, "srouter.db");
-
-/** Legacy database locations checked for backward compatibility (relative to cwd). */
-export const LEGACY_DB_LOCATIONS = [
-    path.resolve(process.cwd(), "apps/api/srouter.db"),
-    path.resolve(process.cwd(), "srouter.db")
-];
-
-export function getDatabasePath(): string {
-    // Allow explicit override via DATABASE_PATH environment variable
-    if (process.env.DATABASE_PATH) return process.env.DATABASE_PATH;
-
-    // Fallback for legacy installations (keep existing for backward compatibility)
-    for (const legacyPath of LEGACY_DB_LOCATIONS) {
-        if (fs.existsSync(legacyPath)) return legacyPath;
-    }
-
-    // Return new default path and create directory if needed
-    return DEFAULT_DB_PATH;
-}
+// Single source of truth for database locations lives in sqlite.ts
+// (re-exported here so existing `@srouter/db` importers keep working).
+export {
+    SROUTER_DIR,
+    DEFAULT_DB_PATH,
+    LEGACY_DB_LOCATIONS,
+    getDatabasePath,
+    getOpenDatabasePath,
+    closeSqliteDb
+} from "./sqlite.js";
 
 // ─────────────────────────────────────────────────────────────
 // Compat wrapper — mirrors the node:sqlite statement API but is

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -15,7 +15,10 @@ export const LEGACY_DB_LOCATIONS = [
     path.resolve(process.cwd(), "srouter.db")
 ];
 
-function getDatabasePath(): string {
+/** Resolve the SQLite file path. Reads `DATABASE_PATH` lazily so test
+ * loaders (`--import tests/setup.ts`) can redirect to an isolated file
+ * before the first query opens a connection. */
+export function getDatabasePath(): string {
     // Allow explicit override via DATABASE_PATH environment variable
     if (process.env.DATABASE_PATH) return process.env.DATABASE_PATH;
 
@@ -28,41 +31,103 @@ function getDatabasePath(): string {
     return DEFAULT_DB_PATH;
 }
 
-const dbPath = getDatabasePath();
-
-// Ensure parent folder exists if path contains subdirectories
-const dbDir = path.dirname(dbPath);
-if (!fs.existsSync(dbDir)) {
-    fs.mkdirSync(dbDir, { recursive: true });
-}
-
-export const sqliteDb = new DatabaseSync(dbPath);
-
-// Wait up to 5s instead of failing immediately when another connection
-// (e.g. a parallel test process or the CLI) holds the write lock.
-sqliteDb.exec("PRAGMA busy_timeout = 5000;");
-
-// Enable WAL mode for high performance concurrency.
-// Retry briefly — concurrent processes initializing on the same DB file
-// (CI runs app test suites in parallel) can transiently hold the lock.
-function execWithRetry(sql: string, attempts = 5): void {
-    for (let i = 0; i < attempts; i++) {
-        try {
-            sqliteDb.exec(sql);
-            return;
-        } catch (error) {
-            const code = (error as { code?: string }).code;
-            if (code === "SQLITE_BUSY" && i < attempts - 1) {
-                Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200 * (i + 1));
-                continue;
-            }
-            throw error;
-        }
+/**
+ * Fail fast when a test process accidentally targets the production
+ * database. Test runners must redirect via `DATABASE_PATH`
+ * (see `apps/api/tests/setup.ts`); wiping `~/.srouter/srouter.db`
+ * from a test run deleted real API keys before this guard existed.
+ */
+function assertNotProductionDatabaseInTests(dbPath: string): void {
+    if (process.env.NODE_ENV !== "test") return;
+    if (path.resolve(dbPath) === path.resolve(DEFAULT_DB_PATH)) {
+        throw new Error(
+            "Refusing to open the production database (DATABASE_PATH points at " +
+                `${DEFAULT_DB_PATH}) while NODE_ENV=test. ` +
+                "Run tests through `pnpm test` so tests/setup.ts redirects " +
+                "to an isolated temp database."
+        );
     }
 }
 
-execWithRetry("PRAGMA journal_mode = WAL;");
-execWithRetry("PRAGMA foreign_keys = ON;");
-execWithRetry("PRAGMA synchronous = NORMAL;");
-execWithRetry("PRAGMA temp_store = MEMORY;");
-execWithRetry("PRAGMA cache_size = -20000;");
+function openDatabase(dbPath: string): DatabaseSync {
+    assertNotProductionDatabaseInTests(dbPath);
+
+    // Ensure parent folder exists if path contains subdirectories
+    const dbDir = path.dirname(dbPath);
+    if (!fs.existsSync(dbDir)) {
+        fs.mkdirSync(dbDir, { recursive: true });
+    }
+
+    const db = new DatabaseSync(dbPath);
+
+    // Wait up to 5s instead of failing immediately when another connection
+    // (e.g. a parallel test process or the CLI) holds the write lock.
+    db.exec("PRAGMA busy_timeout = 5000;");
+
+    // Enable WAL mode for high performance concurrency.
+    // Retry briefly — concurrent processes initializing on the same DB file
+    // (CI runs app test suites in parallel) can transiently hold the lock.
+    for (let i = 0; i < 5; i++) {
+        try {
+            db.exec("PRAGMA journal_mode = WAL;");
+            break;
+        } catch (error) {
+            const code = (error as { code?: string }).code;
+            if (code !== "SQLITE_BUSY" || i === 4) throw error;
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200 * (i + 1));
+        }
+    }
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec("PRAGMA synchronous = NORMAL;");
+    db.exec("PRAGMA temp_store = MEMORY;");
+    db.exec("PRAGMA cache_size = -20000;");
+    return db;
+}
+
+// Lazy singleton: the connection opens on first use (not at import),
+// so `DATABASE_PATH` set by a test loader always wins over the default.
+// Re-opens when the path changes (e.g. tests redirecting mid-process).
+let _sqliteDb: DatabaseSync | null = null;
+let _sqliteDbPath: string | null = null;
+
+function getSqliteDbInstance(): DatabaseSync {
+    const dbPath = getDatabasePath();
+    if (!_sqliteDb || _sqliteDbPath !== path.resolve(dbPath)) {
+        try {
+            _sqliteDb?.close();
+        } catch {
+            // Ignore close errors on a stale handle.
+        }
+        _sqliteDb = openDatabase(dbPath);
+        _sqliteDbPath = path.resolve(dbPath);
+    }
+    return _sqliteDb;
+}
+
+/**
+ * Shared SQLite connection. Lazily opened on first property access —
+ * behaves like the previous eager `DatabaseSync` export.
+ */
+export const sqliteDb: DatabaseSync = new Proxy({} as DatabaseSync, {
+    get(_target, prop) {
+        const instance = getSqliteDbInstance() as unknown as Record<PropertyKey, unknown>;
+        const value = instance[prop];
+        return typeof value === "function" ? (value as () => unknown).bind(instance) : value;
+    }
+});
+
+/** Currently opened database file, if any (for diagnostics/tests). */
+export function getOpenDatabasePath(): string | null {
+    return _sqliteDbPath;
+}
+
+/** Close the shared connection (test teardown / path switching). */
+export function closeSqliteDb(): void {
+    try {
+        _sqliteDb?.close();
+    } catch {
+        // Ignore close errors on a stale handle.
+    }
+    _sqliteDb = null;
+    _sqliteDbPath = null;
+}


### PR DESCRIPTION
Fixes #109.

Test runners shared `~/.srouter/srouter.db` with production. This caused real data loss: `analytics.test.ts` ran a bare `DELETE FROM request_logs`, and the CLI `migrate.test.ts` merged fake rows over real `api_keys`/`providers`.

## Changes
- `apps/api/tests/setup.ts` + `apps/cli/tests/setup.ts` (new): `--import` loader redirecting each test process to its own temp DB (`/tmp/srouter-test/test-<pid>.db`), auto-cleaned on exit. Wired into both `pnpm test` scripts with `NODE_ENV=test`.
- `packages/db/src/sqlite.ts`: lazy singleton (opens on first use, so test-time `DATABASE_PATH` is honored) + fail-fast guard refusing the production path under `NODE_ENV=test`.
- `packages/db/src/db.ts`: path constants re-exported from `sqlite.ts` (single source of truth).
- `apps/cli/src/commands/migrate.ts`: target DB resolved via `getDatabasePath()` instead of hardcoded prod path; backups live next to the target.
- `apps/cli/tests/migrate.test.ts`, `apps/api/tests/analytics.test.ts`: run against the isolated DB (destructive statements now contained).

## Verification
- `packages/db` + `apps/cli` build clean.
- Full API suite: 151/151 pass; CLI migrate tests pass.
- Production `~/.srouter/srouter.db` byte-identical before/after test runs.