### PR TITLE
refactor(api): modularize fallback policy and streamline oauth token types

### DIFF
--- a/.agents/skills/SRouter-Package/references/types.md
+++ b/.agents/skills/SRouter-Package/references/types.md
@@ -29,9 +29,12 @@ packages/types/src/
    - While schema and type identifiers are strictly `PascalCase`, all internal JSON/database object property keys MUST be pure `snake_case` (`base_url`, `api_key`, `rate_limit`, `quota_limit`, `usage_tokens`, `require_api_key`, `created_at`).
    - Match SQLite table columns 1:1 without case conversions.
 
-3. **Derived Types Only**:
+3. **Derived Types Only & Utility Types Reuse**:
    - Always derive types directly from schemas using `export type Foo = z.infer<typeof FooSchema>;`.
-   - Never write hand-crafted duplicate TypeScript interfaces.
+   - Never write hand-crafted duplicate TypeScript interfaces that mirror Zod schemas.
+   - Reuse existing types via TypeScript utility types (`Pick`, `Omit`, `Partial`) and Zod schema utilities (`.partial()`, `.pick()`, `.omit()`, `.extend()`) rather than re-declaring overlapping properties.
+   - For auth token structures (`OAuthTokens`, `TokenImportParams`, etc.), enforce pure `snake_case` property fields (`access_token`, `refresh_token`, `id_token`, `expires_in`, `account_id`) with zero camelCase duplicates or dual aliases.
+   - Zero `unknown` / `any` tolerance: use strict typed structures such as `JSONValue`, `JSONObject`, or `JSONSchemaValue` instead of `Record<string, unknown>`.
 
 4. **Validation at the Boundary**:
    - Schemas are consumed by Hono routes (`@hono/zod-validator`) in `apps/api` and form validators in `apps/web`.

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -59,7 +59,10 @@ function ExtractEmailFromToken(token?: string): string | undefined {
         if (typeof decoded.user_metadata?.email === "string") {
             return decoded.user_metadata.email;
         }
-        if (typeof decoded.preferred_username === "string" && decoded.preferred_username.includes("@")) {
+        if (
+            typeof decoded.preferred_username === "string" &&
+            decoded.preferred_username.includes("@")
+        ) {
             return decoded.preferred_username;
         }
         if (typeof decoded.unique_name === "string" && decoded.unique_name.includes("@")) {
@@ -76,7 +79,8 @@ function BuildAccountIdentity(
     now: number,
     tokens?: { accessToken?: string; idToken?: string }
 ): { accountId: string; accountName: string } {
-    const email = ExtractEmailFromToken(tokens?.idToken) || ExtractEmailFromToken(tokens?.accessToken);
+    const email =
+        ExtractEmailFromToken(tokens?.idToken) || ExtractEmailFromToken(tokens?.accessToken);
     const accountName = email || `${handler.displayName} (Account #${now.toString().slice(-4)})`;
     return {
         accountId: `${handler.idPrefix}_${now}`,
@@ -84,7 +88,10 @@ function BuildAccountIdentity(
     };
 }
 
-async function InitiatePKCEFor(handler: AuthProviderHandler, params: OAuthLoginParams): Promise<OAuthLoginResult> {
+async function InitiatePKCEFor(
+    handler: AuthProviderHandler,
+    params: OAuthLoginParams
+): Promise<OAuthLoginResult> {
     await CleanupExpiredSessions();
     const clientId = ResolveClientId(handler, params);
     const redirectUri = ResolveRedirectUri(handler, params);
@@ -137,10 +144,18 @@ async function ProcessOAuthCallbackFor(
         expiresIn: rawTokens.expiresIn
     };
 
+    const rawTokensRecord = rawTokens as unknown as Record<string, unknown>;
+    const idToken =
+        typeof rawTokensRecord.idToken === "string"
+            ? rawTokensRecord.idToken
+            : typeof rawTokensRecord.id_token === "string"
+              ? rawTokensRecord.id_token
+              : undefined;
+
     const timestamp = Date.now();
     const { accountId, accountName } = BuildAccountIdentity(handler, timestamp, {
         accessToken: tokens.accessToken,
-        idToken: (rawTokens as any).idToken || (rawTokens as any).id_token
+        idToken
     });
 
     const baseUrl = handler.baseUrl ? handler.baseUrl() : undefined;
@@ -184,9 +199,12 @@ async function ProcessTokenImportFor(
     const accountId = params.id || `${handler.idPrefix}_${timestamp}`;
     const token = params.access_token || params.accessToken || "";
     const refreshToken = params.refresh_token || params.refreshToken;
-    const email = ExtractEmailFromToken(token) || ExtractEmailFromToken(params.id_token || params.idToken);
+    const email =
+        ExtractEmailFromToken(token) || ExtractEmailFromToken(params.id_token || params.idToken);
     const providerName =
-        params.name || email || `${handler.displayName} (Account #${timestamp.toString().slice(-4)})`;
+        params.name ||
+        email ||
+        `${handler.displayName} (Account #${timestamp.toString().slice(-4)})`;
     const mapping = handler.mapImportTokens?.(params) ?? {
         accessToken: token,
         refreshToken: refreshToken,
@@ -508,7 +526,10 @@ export const AuthLogic = {
     processTokenImport: async (params: TokenImportParams): Promise<ProviderConfig> =>
         authProviderEntries.openai.importToken(params) as Promise<ProviderConfig>,
 
-    async initiateProviderOAuth(providerKey: string, params: OAuthLoginParams): Promise<OAuthLoginResult> {
+    async initiateProviderOAuth(
+        providerKey: string,
+        params: OAuthLoginParams
+    ): Promise<OAuthLoginResult> {
         const entry = authProviderEntries[providerKey];
         if (!entry?.initiate) throw new Error(`Unknown OAuth provider: ${providerKey}`);
         return entry.initiate(params) as Promise<OAuthLoginResult>;
@@ -524,7 +545,10 @@ export const AuthLogic = {
         return entry.callback(code, state);
     },
 
-    async processProviderTokenImport(providerKey: string, params: TokenImportParams): Promise<ProviderConfig> {
+    async processProviderTokenImport(
+        providerKey: string,
+        params: TokenImportParams
+    ): Promise<ProviderConfig> {
         const entry = authProviderEntries[providerKey];
         if (!entry) throw new Error(`Unknown auth provider: ${providerKey}`);
         return entry.importToken(params) as Promise<ProviderConfig>;

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -144,13 +144,7 @@ async function ProcessOAuthCallbackFor(
         expiresIn: rawTokens.expiresIn
     };
 
-    const rawTokensRecord = rawTokens as unknown as Record<string, unknown>;
-    const idToken =
-        typeof rawTokensRecord.idToken === "string"
-            ? rawTokensRecord.idToken
-            : typeof rawTokensRecord.id_token === "string"
-              ? rawTokensRecord.id_token
-              : undefined;
+    const idToken = rawTokens.idToken || rawTokens.id_token;
 
     const timestamp = Date.now();
     const { accountId, accountName } = BuildAccountIdentity(handler, timestamp, {

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -191,8 +191,8 @@ async function ProcessTokenImportFor(
 ): Promise<ProviderConfig> {
     const timestamp = Date.now();
     const accountId = params.id || `${handler.idPrefix}_${timestamp}`;
-    const token = params.accessToken || "";
-    const refreshToken = params.refreshToken;
+    const token = params.access_token || "";
+    const refreshToken = params.refresh_token;
     const email = ExtractEmailFromToken(token) || ExtractEmailFromToken(params.id_token);
     const providerName =
         params.name ||
@@ -201,9 +201,9 @@ async function ProcessTokenImportFor(
     const mapping = handler.mapImportTokens?.(params) ?? {
         accessToken: token,
         refreshToken: refreshToken,
-        accountId: params.accountId
+        accountId: params.account_id
     };
-    const baseUrl = params.baseUrl || handler.baseUrl?.();
+    const baseUrl = params.base_url || handler.baseUrl?.();
 
     const providerConfig = await upsertProviderDB({
         id: accountId,

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -144,7 +144,7 @@ async function ProcessOAuthCallbackFor(
         expiresIn: rawTokens.expiresIn
     };
 
-    const idToken = rawTokens.idToken || rawTokens.id_token;
+    const idToken = rawTokens.id_token;
 
     const timestamp = Date.now();
     const { accountId, accountName } = BuildAccountIdentity(handler, timestamp, {
@@ -191,10 +191,9 @@ async function ProcessTokenImportFor(
 ): Promise<ProviderConfig> {
     const timestamp = Date.now();
     const accountId = params.id || `${handler.idPrefix}_${timestamp}`;
-    const token = params.access_token || params.accessToken || "";
-    const refreshToken = params.refresh_token || params.refreshToken;
-    const email =
-        ExtractEmailFromToken(token) || ExtractEmailFromToken(params.id_token || params.idToken);
+    const token = params.accessToken || "";
+    const refreshToken = params.refreshToken;
+    const email = ExtractEmailFromToken(token) || ExtractEmailFromToken(params.id_token);
     const providerName =
         params.name ||
         email ||
@@ -202,9 +201,9 @@ async function ProcessTokenImportFor(
     const mapping = handler.mapImportTokens?.(params) ?? {
         accessToken: token,
         refreshToken: refreshToken,
-        accountId: params.account_id || params.accountId
+        accountId: params.accountId
     };
-    const baseUrl = params.base_url || params.baseUrl || handler.baseUrl?.();
+    const baseUrl = params.baseUrl || handler.baseUrl?.();
 
     const providerConfig = await upsertProviderDB({
         id: accountId,

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -139,9 +139,9 @@ async function ProcessOAuthCallbackFor(
 
     const rawTokens = await oAuthInstance.exchangeCodeForTokens!(code, session.codeVerifier || "");
     const tokens = handler.mapOAuthTokens?.(rawTokens) ?? {
-        accessToken: rawTokens.accessToken,
-        refreshToken: rawTokens.refreshToken,
-        expiresIn: rawTokens.expiresIn
+        accessToken: rawTokens.access_token,
+        refreshToken: rawTokens.refresh_token,
+        expiresIn: rawTokens.expires_in
     };
 
     const idToken = rawTokens.id_token;

--- a/apps/api/src/logic/chat.logic.ts
+++ b/apps/api/src/logic/chat.logic.ts
@@ -11,7 +11,6 @@ import type {
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatMessage,
-    FallbackRule,
     JSONValue,
     ToolCall,
     UsageInfo
@@ -19,6 +18,12 @@ import type {
 import { registry } from "@/services/registry.js";
 import { ensureFreshToken } from "@/services/tokenRefresh.js";
 import { executeInterceptedSearch, shouldInterceptToolCall } from "@/services/toolInterceptor.js";
+import {
+    type CandidateModel,
+    type ErrorWithStatus,
+    ExtractStatusCode,
+    ShouldTriggerFallback
+} from "./fallback.policy.js";
 
 const MAX_INTERCEPT_DEPTH = 3;
 
@@ -26,57 +31,6 @@ interface AssembledStreamingToolCall {
     id: string;
     name: string;
     arguments: string;
-}
-
-interface CandidateModel {
-    model: string;
-    rule?: FallbackRule;
-}
-
-interface ErrorWithStatus {
-    status?: number;
-    statusCode?: number;
-    message?: string;
-}
-
-function ExtractStatusCode(
-    err: Error | ErrorWithStatus | string | null | undefined
-): number | undefined {
-    if (!err) return undefined;
-    if (typeof err === "object") {
-        if ("status" in err && typeof err.status === "number") {
-            return err.status;
-        }
-        if ("statusCode" in err && typeof err.statusCode === "number") {
-            return err.statusCode;
-        }
-    }
-    const msg = typeof err === "string" ? err : err.message || String(err);
-    if (/no active provider connection|not found|unknown model|invalid model|no provider found/i.test(msg)) {
-        return 404;
-    }
-    const match = msg.match(/\b(400|401|402|403|404|408|409|422|429|500|502|503|504)\b/);
-    if (match) return parseInt(match[1]!, 10);
-    return undefined;
-}
-
-function ShouldTriggerFallback(
-    rule: FallbackRule,
-    err: Error | ErrorWithStatus | string | null | undefined
-): boolean {
-    if (!rule.enabled) return false;
-    if (!rule.triggerOnStatus || rule.triggerOnStatus.length === 0) return true;
-    const status = ExtractStatusCode(err);
-    if (status && rule.triggerOnStatus.includes(status)) return true;
-    const msg = typeof err === "string" ? err : err ? err.message || String(err) : "";
-    if (
-        /rate\s*limit|too\s+many\s+requests|quota|exhausted|capacity|high\s+traffic|overloaded|no active provider connection|not found|unknown model|invalid model|no provider found|insufficient tokens|insufficient_quota|billing_error/i.test(
-            msg
-        )
-    ) {
-        return true;
-    }
-    return status === undefined;
 }
 
 async function ResolveCandidates(originalModel: string): Promise<CandidateModel[]> {
@@ -108,8 +62,6 @@ async function LogCompletion(
         userAgent?: string;
     }
 ): Promise<void> {
-    // Normalize alias/bare provider id to the registered base id so quota
-    // attribution matches. e.g. "zen" / "opencode" -> "opencode_zen".
     const normalizedProviderId = providerTypeForAlias(providerId) ?? providerId;
     const breakdown = extractUsageBreakdown(
         normalizedProviderId,

--- a/apps/api/src/logic/fallback.policy.ts
+++ b/apps/api/src/logic/fallback.policy.ts
@@ -1,0 +1,56 @@
+import type { FallbackRule } from "@srouter/types";
+
+export interface CandidateModel {
+    model: string;
+    rule?: FallbackRule;
+}
+
+export interface ErrorWithStatus {
+    status?: number;
+    statusCode?: number;
+    message?: string;
+}
+
+export function ExtractStatusCode(
+    err: Error | ErrorWithStatus | string | null | undefined
+): number | undefined {
+    if (!err) return undefined;
+    if (typeof err === "object") {
+        if ("status" in err && typeof err.status === "number") {
+            return err.status;
+        }
+        if ("statusCode" in err && typeof err.statusCode === "number") {
+            return err.statusCode;
+        }
+    }
+    const msg = typeof err === "string" ? err : err.message || String(err);
+    if (
+        /no active provider connection|not found|unknown model|invalid model|no provider found/i.test(
+            msg
+        )
+    ) {
+        return 404;
+    }
+    const match = msg.match(/\b(400|401|402|403|404|408|409|422|429|500|502|503|504)\b/);
+    if (match) return parseInt(match[1]!, 10);
+    return undefined;
+}
+
+export function ShouldTriggerFallback(
+    rule: FallbackRule,
+    err: Error | ErrorWithStatus | string | null | undefined
+): boolean {
+    if (!rule.enabled) return false;
+    if (!rule.triggerOnStatus || rule.triggerOnStatus.length === 0) return true;
+    const status = ExtractStatusCode(err);
+    if (status && rule.triggerOnStatus.includes(status)) return true;
+    const msg = typeof err === "string" ? err : err ? err.message || String(err) : "";
+    if (
+        /rate\s*limit|too\s+many\s+requests|quota|exhausted|capacity|high\s+traffic|overloaded|no active provider connection|not found|unknown model|invalid model|no provider found|insufficient tokens|insufficient_quota|billing_error/i.test(
+            msg
+        )
+    ) {
+        return true;
+    }
+    return status === undefined;
+}

--- a/apps/api/src/logic/images.logic.ts
+++ b/apps/api/src/logic/images.logic.ts
@@ -12,44 +12,12 @@ import type {
 import { HTTPException } from "hono/http-exception";
 import { registry } from "@/services/registry.js";
 import { ensureFreshToken } from "@/services/tokenRefresh.js";
-
-interface CandidateModel {
-    model: string;
-    rule?: FallbackRule;
-}
-
-interface ErrorWithStatus {
-    status?: number;
-    statusCode?: number;
-    message?: string;
-}
-
-function ExtractStatusCode(
-    err: Error | ErrorWithStatus | string | null | undefined
-): number | undefined {
-    if (!err) return undefined;
-    if (typeof err === "object") {
-        if ("status" in err && typeof err.status === "number") {
-            return err.status;
-        }
-        if ("statusCode" in err && typeof err.statusCode === "number") {
-            return err.statusCode;
-        }
-    }
-    const msg = typeof err === "string" ? err : err.message || String(err);
-    if (/no active provider connection|not found|unknown model|invalid model|no provider found/i.test(msg)) {
-        return 404;
-    }
-    return undefined;
-}
-
-function ShouldTriggerFallback(rule: FallbackRule, error: Error | ErrorWithStatus | string): boolean {
-    const errorStatusCode = ExtractStatusCode(error);
-    if (!rule.triggerOnStatus || rule.triggerOnStatus.length === 0) {
-        return true;
-    }
-    return errorStatusCode !== undefined && rule.triggerOnStatus.includes(errorStatusCode);
-}
+import {
+    type CandidateModel,
+    type ErrorWithStatus,
+    ExtractStatusCode,
+    ShouldTriggerFallback
+} from "./fallback.policy.js";
 
 async function ResolveCandidates(model: string): Promise<CandidateModel[]> {
     const candidates: CandidateModel[] = [{ model }];

--- a/apps/api/src/services/authHandlers.ts
+++ b/apps/api/src/services/authHandlers.ts
@@ -54,10 +54,10 @@ const openaiCodex: AuthProviderHandler = {
         "OpenAI Codex Access Token registered and saved directly to SQLite database!",
     oauthClass: OpenAICodexOAuth,
     mapOAuthTokens: (tokens) => ({
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        accountId: tokens.accountId,
-        expiresIn: tokens.expiresIn
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        accountId: tokens.account_id,
+        expiresIn: tokens.expires_in
     }),
     mapImportTokens: (params) => ({
         accessToken: params.access_token,
@@ -82,9 +82,9 @@ const antigravity: AuthProviderHandler = {
         "Antigravity Access Token registered and saved directly to SQLite database!",
     oauthClass: AntigravityOAuth,
     mapOAuthTokens: (tokens) => ({
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        expiresIn: tokens.expiresIn
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        expiresIn: tokens.expires_in
     }),
     mapImportTokens: (params) => ({
         accessToken: params.access_token,
@@ -143,10 +143,10 @@ const claude: AuthProviderHandler = {
     tokenImportMessage: "Claude Code OAuth token registered and saved directly to SQLite database!",
     oauthClass: ClaudeOAuth,
     mapOAuthTokens: (tokens) => ({
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        organizationId: tokens.organizationId,
-        expiresIn: tokens.expiresIn
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        organizationId: tokens.organization_id,
+        expiresIn: tokens.expires_in
     }),
     mapImportTokens: (params) => ({
         accessToken: params.access_token,
@@ -167,10 +167,10 @@ const qoder: AuthProviderHandler = {
         "Qoder Access Token / PAT registered and saved directly to SQLite database!",
     oauthClass: QoderOAuth,
     mapOAuthTokens: (tokens) => ({
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        accountId: tokens.accountId,
-        expiresIn: tokens.expiresIn
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        accountId: tokens.account_id,
+        expiresIn: tokens.expires_in
     }),
     mapImportTokens: (params) => ({
         accessToken: params.access_token,
@@ -283,9 +283,9 @@ const codeBuddy: AuthProviderHandler = {
     tokenImportMessage: "CodeBuddy Access Token registered and saved directly to SQLite database!",
     oauthClass: CodeBuddyOAuth,
     mapOAuthTokens: (tokens) => ({
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        expiresIn: tokens.expiresIn
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        expiresIn: tokens.expires_in
     }),
     mapImportTokens: (params) => ({
         accessToken: params.access_token,

--- a/apps/api/src/services/authHandlers.ts
+++ b/apps/api/src/services/authHandlers.ts
@@ -337,7 +337,7 @@ const bai: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "B.AI API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken || params.access_token,
+        apiKey: params.accessToken,
         refreshToken: params.refreshToken,
         baseUrl: params.baseUrl
     }),

--- a/apps/api/src/services/authHandlers.ts
+++ b/apps/api/src/services/authHandlers.ts
@@ -60,9 +60,9 @@ const openaiCodex: AuthProviderHandler = {
         expiresIn: tokens.expiresIn
     }),
     mapImportTokens: (params) => ({
-        accessToken: params.accessToken,
-        refreshToken: params.refreshToken,
-        accountId: params.accountId
+        accessToken: params.access_token,
+        refreshToken: params.refresh_token,
+        accountId: params.account_id
     }),
     buildExecutor: ({ id, name, accessToken, refreshToken, accountId }) =>
         new CodexExecutor({ id, name, accessToken, refreshToken, accountId })
@@ -87,9 +87,9 @@ const antigravity: AuthProviderHandler = {
         expiresIn: tokens.expiresIn
     }),
     mapImportTokens: (params) => ({
-        accessToken: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        accessToken: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, accessToken, refreshToken }) =>
         new AntigravityExecutor({ id, name, baseUrl, accessToken, refreshToken })
@@ -105,9 +105,9 @@ const commandCode: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "Command Code API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new CommandCodeExecutor({ id, name, baseUrl, apiKey })
@@ -123,9 +123,9 @@ const anthropic: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "Anthropic API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new AnthropicExecutor({ id, name, baseUrl, apiKey })
@@ -149,8 +149,8 @@ const claude: AuthProviderHandler = {
         expiresIn: tokens.expiresIn
     }),
     mapImportTokens: (params) => ({
-        accessToken: params.accessToken,
-        refreshToken: params.refreshToken
+        accessToken: params.access_token,
+        refreshToken: params.refresh_token
     }),
     buildExecutor: ({ id, name, accessToken, refreshToken, organizationId }) =>
         new AnthropicExecutor({ id, name, accessToken, refreshToken, organizationId })
@@ -173,10 +173,10 @@ const qoder: AuthProviderHandler = {
         expiresIn: tokens.expiresIn
     }),
     mapImportTokens: (params) => ({
-        accessToken: params.accessToken,
-        refreshToken: params.refreshToken,
-        accountId: params.accountId,
-        baseUrl: params.baseUrl
+        accessToken: params.access_token,
+        refreshToken: params.refresh_token,
+        accountId: params.account_id,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey, accessToken, refreshToken }) =>
         new QoderExecutor({ id, name, baseUrl, apiKey, accessToken, refreshToken })
@@ -192,9 +192,9 @@ const goRouter: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "GoRouter API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new GoRouterExecutor({ id, name, baseUrl: baseUrl || GOROUTER_BASE_URL, apiKey })
@@ -210,9 +210,9 @@ const bluesMinds: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "BluesMinds API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new BluesMindsExecutor({ id, name, baseUrl: baseUrl || BLUESMINDS_BASE_URL, apiKey })
@@ -228,9 +228,9 @@ const seekAI: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "SeekAI API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new SeekAIExecutor({ id, name, baseUrl: baseUrl || SEEKAI_BASE_URL, apiKey })
@@ -246,9 +246,9 @@ const tabiToken: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "TabiToken API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new TabiTokenExecutor({ id, name, baseUrl: baseUrl || TABITOKEN_BASE_URL, apiKey })
@@ -264,9 +264,9 @@ const tokenRouter: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "TokenRouter API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new TokenRouterExecutor({ id, name, baseUrl: baseUrl || TOKENROUTER_BASE_URL, apiKey })
@@ -288,9 +288,9 @@ const codeBuddy: AuthProviderHandler = {
         expiresIn: tokens.expiresIn
     }),
     mapImportTokens: (params) => ({
-        accessToken: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        accessToken: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, accessToken, apiKey }) =>
         new CodeBuddyExecutor({
@@ -337,9 +337,9 @@ const bai: AuthProviderHandler = {
     oauthSuccessMessage: "",
     tokenImportMessage: "B.AI API Key registered and saved directly to SQLite database!",
     mapImportTokens: (params) => ({
-        apiKey: params.accessToken,
-        refreshToken: params.refreshToken,
-        baseUrl: params.baseUrl
+        apiKey: params.access_token,
+        refreshToken: params.refresh_token,
+        baseUrl: params.base_url
     }),
     buildExecutor: ({ id, name, baseUrl, apiKey }) =>
         new BAIExecutor({ id, name, baseUrl: baseUrl || BAI_BASE_URL, apiKey })

--- a/apps/api/tests/fallback-policy.test.ts
+++ b/apps/api/tests/fallback-policy.test.ts
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ExtractStatusCode, ShouldTriggerFallback } from "../src/logic/fallback.policy.js";
+import type { FallbackRule } from "@srouter/types";
+
+test("ExtractStatusCode extracts status from number, object, or string message", () => {
+    assert.equal(ExtractStatusCode(null), undefined);
+    assert.equal(ExtractStatusCode(undefined), undefined);
+    assert.equal(ExtractStatusCode({ status: 429 }), 429);
+    assert.equal(ExtractStatusCode({ statusCode: 503 }), 503);
+    assert.equal(ExtractStatusCode(new Error("Request failed with status code 404")), 404);
+    assert.equal(ExtractStatusCode("rate limit exceeded (429)"), 429);
+    assert.equal(ExtractStatusCode("no active provider connection for gemini"), 404);
+    assert.equal(ExtractStatusCode(new Error("generic connection drop")), undefined);
+});
+
+test("ShouldTriggerFallback adheres to rule settings and error conditions", () => {
+    const disabledRule: FallbackRule = {
+        id: "1",
+        originalModel: "gpt-4o",
+        targetModel: "claude-3-5-sonnet",
+        enabled: false,
+        priority: 1
+    };
+    assert.equal(ShouldTriggerFallback(disabledRule, new Error("429")), false);
+
+    const wildcardStatusRule: FallbackRule = {
+        id: "2",
+        originalModel: "gpt-4o",
+        targetModel: "claude-3-5-sonnet",
+        enabled: true,
+        priority: 1,
+        triggerOnStatus: []
+    };
+    assert.equal(ShouldTriggerFallback(wildcardStatusRule, new Error("anything")), true);
+
+    const specificStatusRule: FallbackRule = {
+        id: "3",
+        originalModel: "gpt-4o",
+        targetModel: "claude-3-5-sonnet",
+        enabled: true,
+        priority: 1,
+        triggerOnStatus: [429, 503]
+    };
+    assert.equal(ShouldTriggerFallback(specificStatusRule, { status: 429 }), true);
+    assert.equal(ShouldTriggerFallback(specificStatusRule, { status: 400 }), false);
+    assert.equal(ShouldTriggerFallback(specificStatusRule, new Error("quota exceeded")), true);
+    assert.equal(ShouldTriggerFallback(specificStatusRule, new Error("unknown unhandled")), true);
+});

--- a/packages/providers/src/oauth/antigravity.ts
+++ b/packages/providers/src/oauth/antigravity.ts
@@ -106,6 +106,7 @@ export class AntigravityOAuth {
             accessToken: data.access_token,
             refreshToken: data.refresh_token,
             idToken: data.id_token,
+            id_token: data.id_token,
             expiresIn: data.expires_in,
             tokenType: data.token_type ?? "Bearer"
         };

--- a/packages/providers/src/oauth/antigravity.ts
+++ b/packages/providers/src/oauth/antigravity.ts
@@ -103,12 +103,11 @@ export class AntigravityOAuth {
         };
 
         return {
-            accessToken: data.access_token,
-            refreshToken: data.refresh_token,
-            idToken: data.id_token,
+            access_token: data.access_token,
+            refresh_token: data.refresh_token,
             id_token: data.id_token,
-            expiresIn: data.expires_in,
-            tokenType: data.token_type ?? "Bearer"
+            expires_in: data.expires_in,
+            token_type: data.token_type ?? "Bearer"
         };
     }
 
@@ -147,10 +146,10 @@ export class AntigravityOAuth {
         };
 
         return {
-            accessToken: data.access_token,
-            refreshToken: data.refresh_token ?? refreshToken,
-            expiresIn: data.expires_in,
-            tokenType: data.token_type ?? "Bearer"
+            access_token: data.access_token,
+            refresh_token: data.refresh_token ?? refreshToken,
+            expires_in: data.expires_in,
+            token_type: data.token_type ?? "Bearer"
         };
     }
 }

--- a/packages/providers/src/oauth/base.ts
+++ b/packages/providers/src/oauth/base.ts
@@ -4,6 +4,7 @@ export interface OAuthTokenResponse {
     accessToken: string;
     refreshToken?: string;
     idToken?: string;
+    id_token?: string;
     expiresIn?: number;
     tokenType: string;
     /** Optional ChatGPT/OpenAI account identifier (for multi-account binding) */

--- a/packages/providers/src/oauth/base.ts
+++ b/packages/providers/src/oauth/base.ts
@@ -1,16 +1,13 @@
 import crypto from "node:crypto";
 
 export interface OAuthTokenResponse {
-    accessToken: string;
-    refreshToken?: string;
-    idToken?: string;
+    access_token: string;
+    refresh_token?: string;
     id_token?: string;
-    expiresIn?: number;
-    tokenType: string;
-    /** Optional ChatGPT/OpenAI account identifier (for multi-account binding) */
-    accountId?: string;
-    /** Optional organization id (e.g. Claude OAuth) */
-    organizationId?: string;
+    expires_in?: number;
+    token_type: string;
+    account_id?: string;
+    organization_id?: string;
 }
 
 export interface PKCEPair {

--- a/packages/providers/src/oauth/claude.ts
+++ b/packages/providers/src/oauth/claude.ts
@@ -109,6 +109,7 @@ export class ClaudeOAuth {
             accessToken: data.access_token,
             refreshToken: data.refresh_token,
             idToken: data.id_token,
+            id_token: data.id_token,
             expiresIn: data.expires_in,
             tokenType: data.token_type ?? "Bearer",
             organizationId: data.organization_id
@@ -148,8 +149,9 @@ export class ClaudeOAuth {
 
         return {
             accessToken: data.access_token,
-            refreshToken: data.refresh_token ?? refreshToken,
+            refreshToken: data.refresh_token,
             idToken: data.id_token,
+            id_token: data.id_token,
             expiresIn: data.expires_in,
             tokenType: data.token_type ?? "Bearer",
             organizationId: data.organization_id

--- a/packages/providers/src/oauth/claude.ts
+++ b/packages/providers/src/oauth/claude.ts
@@ -106,13 +106,12 @@ export class ClaudeOAuth {
         };
 
         return {
-            accessToken: data.access_token,
-            refreshToken: data.refresh_token,
-            idToken: data.id_token,
+            access_token: data.access_token,
+            refresh_token: data.refresh_token,
             id_token: data.id_token,
-            expiresIn: data.expires_in,
-            tokenType: data.token_type ?? "Bearer",
-            organizationId: data.organization_id
+            expires_in: data.expires_in,
+            token_type: data.token_type ?? "Bearer",
+            organization_id: data.organization_id
         };
     }
 
@@ -148,13 +147,12 @@ export class ClaudeOAuth {
         };
 
         return {
-            accessToken: data.access_token,
-            refreshToken: data.refresh_token,
-            idToken: data.id_token,
+            access_token: data.access_token,
+            refresh_token: data.refresh_token,
             id_token: data.id_token,
-            expiresIn: data.expires_in,
-            tokenType: data.token_type ?? "Bearer",
-            organizationId: data.organization_id
+            expires_in: data.expires_in,
+            token_type: data.token_type ?? "Bearer",
+            organization_id: data.organization_id
         };
     }
 }

--- a/packages/providers/src/oauth/codebuddy.ts
+++ b/packages/providers/src/oauth/codebuddy.ts
@@ -154,14 +154,14 @@ export class CodeBuddyOAuth {
     async exchangeCodeForTokens(code: string, _codeVerifier?: string): Promise<OAuthTokenResponse> {
         const poll = await this.pollToken(code);
         if (poll.status !== AuthPollStatus.OK || !poll.accessToken) {
-            throw new Error(poll.error || "CodeBuddy authorization is still pending or was denied");
+            throw new Error(`CodeBuddy token exchange failed: ${poll.error || "unknown"}`);
         }
 
         return {
-            accessToken: poll.accessToken,
-            refreshToken: poll.refreshToken,
-            expiresIn: poll.expiresIn,
-            tokenType: "Bearer"
+            access_token: poll.accessToken,
+            refresh_token: poll.refreshToken,
+            expires_in: poll.expiresIn,
+            token_type: "Bearer"
         };
     }
 
@@ -190,25 +190,25 @@ export class CodeBuddyOAuth {
                 };
                 if (data.code === 0 && data.data?.accessToken) {
                     return {
-                        accessToken: data.data.accessToken,
-                        refreshToken: data.data.refreshToken || refreshToken,
-                        expiresIn: data.data.expiresIn || 86400,
-                        tokenType: "Bearer"
+                        access_token: data.data.accessToken,
+                        refresh_token: data.data.refreshToken || refreshToken,
+                        expires_in: data.data.expiresIn || 86400,
+                        token_type: "Bearer"
                     };
                 }
             }
             if (this.refreshBearer) throw new Error("CodeBuddy token refresh failed");
         } catch (error) {
             if (this.refreshBearer) {
-                throw error instanceof Error ? error : new Error("CodeBuddy token refresh failed");
+                throw error;
             }
             // fallback to preserving refreshToken
         }
 
         return {
-            accessToken: refreshToken,
-            refreshToken,
-            tokenType: "Bearer"
+            access_token: refreshToken,
+            refresh_token: refreshToken,
+            token_type: "Bearer"
         };
     }
 }

--- a/packages/providers/src/oauth/openai.ts
+++ b/packages/providers/src/oauth/openai.ts
@@ -101,13 +101,12 @@ export class OpenAICodexOAuth {
         };
 
         return {
-            accessToken: data.access_token,
-            refreshToken: data.refresh_token,
-            idToken: data.id_token,
+            access_token: data.access_token,
+            refresh_token: data.refresh_token,
             id_token: data.id_token,
-            expiresIn: data.expires_in,
-            tokenType: data.token_type ?? "Bearer",
-            accountId:
+            expires_in: data.expires_in,
+            token_type: data.token_type ?? "Bearer",
+            account_id:
                 data.chatgpt_account_id ||
                 data.account_id ||
                 extractAccountIdFromIdToken(data.id_token)
@@ -143,10 +142,10 @@ export class OpenAICodexOAuth {
         };
 
         return {
-            accessToken: data.access_token,
-            refreshToken: data.refresh_token ?? refreshToken,
-            expiresIn: data.expires_in,
-            tokenType: data.token_type ?? "Bearer"
+            access_token: data.access_token,
+            refresh_token: data.refresh_token ?? refreshToken,
+            expires_in: data.expires_in,
+            token_type: data.token_type ?? "Bearer"
         };
     }
 }

--- a/packages/providers/src/oauth/openai.ts
+++ b/packages/providers/src/oauth/openai.ts
@@ -104,6 +104,7 @@ export class OpenAICodexOAuth {
             accessToken: data.access_token,
             refreshToken: data.refresh_token,
             idToken: data.id_token,
+            id_token: data.id_token,
             expiresIn: data.expires_in,
             tokenType: data.token_type ?? "Bearer",
             accountId:

--- a/packages/providers/src/oauth/qoder.ts
+++ b/packages/providers/src/oauth/qoder.ts
@@ -134,20 +134,20 @@ export class QoderOAuth {
         const userInfo = await this.fetchUserInfo(poll.accessToken);
 
         return {
-            accessToken: poll.accessToken,
-            refreshToken: poll.refreshToken,
-            expiresIn: poll.expiresIn,
-            tokenType: "Bearer",
-            accountId: poll.userId || userInfo.id
+            access_token: poll.accessToken,
+            refresh_token: poll.refreshToken,
+            expires_in: poll.expiresIn,
+            token_type: "Bearer",
+            account_id: poll.userId || userInfo.id
         };
     }
 
     async refreshTokens(refreshToken: string): Promise<OAuthTokenResponse> {
         // Upstream refresh returns 403 for device tokens; return existing token
         return {
-            accessToken: refreshToken,
-            refreshToken,
-            tokenType: "Bearer"
+            access_token: refreshToken,
+            refresh_token: refreshToken,
+            token_type: "Bearer"
         };
     }
 }

--- a/packages/types/src/anthropic.ts
+++ b/packages/types/src/anthropic.ts
@@ -1,4 +1,4 @@
-import type { AnthropicRole } from "./chat.js";
+import type { AnthropicRole, JSONObject, JSONValue } from "./chat.js";
 import type { ToolDefinition } from "./openai.js";
 
 export interface AnthropicContentBlock {
@@ -14,7 +14,7 @@ export interface AnthropicContentBlock {
     };
     id?: string;
     name?: string;
-    input?: Record<string, unknown>;
+    input?: JSONObject;
     tool_use_id?: string;
     content?: string | AnthropicContentBlock[];
     is_error?: boolean;
@@ -31,9 +31,9 @@ export interface AnthropicTool {
     description?: string;
     input_schema: {
         type?: "object" | string;
-        properties?: Record<string, unknown>;
+        properties?: Record<string, JSONValue>;
         required?: string[];
-        [key: string]: unknown;
+        [key: string]: JSONValue | undefined;
     };
     cache_control?: { type: "ephemeral" };
 }
@@ -43,7 +43,7 @@ export interface AnthropicMessageRequest {
     messages: AnthropicMessage[];
     system?: string | AnthropicContentBlock[];
     max_tokens: number;
-    metadata?: Record<string, unknown>;
+    metadata?: JSONObject;
     stop_sequences?: string[];
     stream?: boolean;
     temperature?: number;
@@ -102,7 +102,7 @@ export type AnthropicStreamEvent =
           content_block:
               | { type: "text"; text: string }
               | { type: "thinking"; thinking: string }
-              | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> };
+              | { type: "tool_use"; id: string; name: string; input: JSONObject };
       }
     | {
           type: "content_block_delta";

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,4 +1,4 @@
-import type { AIProvider, ProviderCategory, ProviderProtocol } from "./provider.js";
+import type { AIProvider, ProviderCategory, ProviderConfig, ProviderProtocol } from "./provider.js";
 
 export interface OAuthLoginParams {
     clientId?: string;
@@ -80,14 +80,12 @@ export interface OAuthClientClass {
     new (options?: OAuthClientOptions): OAuthClientInstance;
 }
 
-export interface ImportTokenMapping {
-    accessToken?: string;
-    refreshToken?: string;
-    accountId?: string;
-    organizationId?: string;
+export type ImportTokenMapping = Pick<
+    ProviderConfig,
+    "accessToken" | "refreshToken" | "accountId" | "organizationId" | "apiKey"
+> & {
     baseUrl?: string;
-    apiKey?: string;
-}
+};
 
 export interface AuthProviderHandler {
     providerId: string;

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -34,6 +34,8 @@ export interface OAuthTokens {
     accountId?: string;
     organizationId?: string;
     expiresIn?: number;
+    id_token?: string;
+    idToken?: string;
 }
 
 export type ExecutorFactory = (args: {

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -28,16 +28,20 @@ export interface OAuthTokens {
     id_token?: string;
 }
 
-export type ExecutorFactory = (args: {
-    id: string;
-    name: string;
-    accountId?: string;
-    organizationId?: string;
-    baseUrl?: string;
-    apiKey?: string;
-    accessToken?: string;
-    refreshToken?: string;
-}) => AIProvider;
+export type ExecutorFactory = (
+    args: Pick<
+        ProviderConfig,
+        | "id"
+        | "name"
+        | "accountId"
+        | "organizationId"
+        | "apiKey"
+        | "accessToken"
+        | "refreshToken"
+    > & {
+        baseUrl?: string;
+    }
+) => AIProvider;
 
 export interface OAuthClientOptions {
     clientId?: string;
@@ -88,13 +92,8 @@ export interface AuthProviderHandler {
     baseUrl?: () => string | undefined;
     oauthSuccessMessage: string;
     tokenImportMessage: string;
-    mapOAuthTokens?: (tokens: OAuthTokens) => {
-        accessToken: string;
-        refreshToken?: string;
-        accountId?: string;
-        organizationId?: string;
+    mapOAuthTokens?: (tokens: OAuthTokens) => ImportTokenMapping & {
         expiresIn?: number;
-        baseUrl?: string;
     };
     mapImportTokens?: (params: TokenImportParams) => ImportTokenMapping;
     buildExecutor: ExecutorFactory;

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,4 +1,5 @@
 import type { AIProvider, ProviderCategory, ProviderConfig, ProviderProtocol } from "./provider.js";
+import type { TokenImportBody } from "./schemas/auth.js";
 
 export interface OAuthLoginParams {
     clientId?: string;
@@ -13,15 +14,10 @@ export interface OAuthLoginResult {
     redirectUri: string;
 }
 
-export interface TokenImportParams {
+export type TokenImportParams = TokenImportBody & {
     id?: string;
-    accessToken?: string;
-    refreshToken?: string;
-    accountId?: string;
-    baseUrl?: string;
-    name?: string;
-    id_token?: string;
-}
+    account_id?: string;
+};
 
 export interface OAuthTokens {
     accessToken: string;

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -20,11 +20,11 @@ export type TokenImportParams = TokenImportBody & {
 };
 
 export interface OAuthTokens {
-    accessToken: string;
-    refreshToken?: string;
-    accountId?: string;
-    organizationId?: string;
-    expiresIn?: number;
+    access_token: string;
+    refresh_token?: string;
+    account_id?: string;
+    organization_id?: string;
+    expires_in?: number;
     id_token?: string;
 }
 

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -15,17 +15,12 @@ export interface OAuthLoginResult {
 
 export interface TokenImportParams {
     id?: string;
-    access_token?: string;
     accessToken?: string;
-    refresh_token?: string;
     refreshToken?: string;
-    account_id?: string;
     accountId?: string;
-    base_url?: string;
     baseUrl?: string;
     name?: string;
     id_token?: string;
-    idToken?: string;
 }
 
 export interface OAuthTokens {
@@ -35,7 +30,6 @@ export interface OAuthTokens {
     organizationId?: string;
     expiresIn?: number;
     id_token?: string;
-    idToken?: string;
 }
 
 export type ExecutorFactory = (args: {

--- a/packages/types/src/logs.ts
+++ b/packages/types/src/logs.ts
@@ -90,19 +90,20 @@ export interface AnalyticsBucket {
     cachedTokens: number;
 }
 
-export interface AnalyticsTopModel {
-    model: string;
-    totalRequests: number;
+export type AnalyticsTopModel = Pick<
+    UsageByModelRow,
+    "model" | "totalRequests" | "estCost"
+> & {
     totalTokens: number;
-    estCost: number;
-}
+};
 
-export interface AnalyticsTopAgent {
+export type AnalyticsTopAgent = Pick<
+    UsageSummary,
+    "totalRequests" | "totalTokens"
+> & {
     agent: string;
     rawUserAgent: string;
-    totalRequests: number;
-    totalTokens: number;
-}
+};
 
 export interface AnalyticsProviderSlice {
     providerId: string;

--- a/packages/types/src/openai.ts
+++ b/packages/types/src/openai.ts
@@ -1,4 +1,5 @@
 import type { ChatRole, JSONValue } from "./chat.js";
+import type { ModelListResponseZod, ModelObjectZod } from "./schemas/models.js";
 
 export type FinishReason = "stop" | "length" | "tool_calls" | "content_filter" | null;
 
@@ -138,16 +139,6 @@ export interface ChatCompletionChunk {
     usage?: UsageInfo;
 }
 
-export interface ModelObject {
-    id: string;
-    object: "model";
-    created?: number;
-    owned_by: string;
-    /** True when the entry was manually added by the user (custom_models table). */
-    custom?: boolean;
-}
+export type ModelObject = ModelObjectZod;
 
-export interface ModelListResponse {
-    object: "list";
-    data: ModelObject[];
-}
+export type ModelListResponse = ModelListResponseZod;

--- a/packages/types/src/quota.ts
+++ b/packages/types/src/quota.ts
@@ -1,3 +1,5 @@
+import type { ModelUsageSummaryRow } from "./logs.js";
+
 export interface LiveModelQuotaItem {
     name: string;
     used: number;
@@ -9,14 +11,12 @@ export interface LiveModelQuotaItem {
     status: "ok" | "warning" | "exhausted";
 }
 
-export interface ProviderUsageMetric {
-    model: string;
-    totalRequests: number;
-    totalTokens: number;
-    promptTokens: number;
-    completionTokens: number;
+export type ProviderUsageMetric = Pick<
+    ModelUsageSummaryRow,
+    "model" | "totalRequests" | "totalTokens" | "promptTokens" | "completionTokens"
+> & {
     lastUsedAt: string | null;
-}
+};
 
 export interface ProviderQuotaAccount {
     id: string;

--- a/packages/types/src/schemas/anthropic.ts
+++ b/packages/types/src/schemas/anthropic.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { AnthropicContentBlock } from "../anthropic.js";
+import { JSONSchemaValue } from "./chat.js";
 
 const AnthropicCacheControlSchema = z.object({ type: z.literal("ephemeral") });
 
@@ -18,7 +19,7 @@ export const AnthropicContentBlockSchema: z.ZodType<AnthropicContentBlock> = z.o
         .optional(),
     id: z.string().optional(),
     name: z.string().optional(),
-    input: z.record(z.unknown()).optional(),
+    input: z.record(JSONSchemaValue).optional(),
     tool_use_id: z.string().optional(),
     content: z.union([z.string(), z.lazy(() => z.array(AnthropicContentBlockSchema))]).optional(),
     is_error: z.boolean().optional(),
@@ -36,7 +37,7 @@ export const AnthropicToolSchema = z.object({
     input_schema: z
         .object({
             type: z.string().optional(),
-            properties: z.record(z.unknown()).optional(),
+            properties: z.record(JSONSchemaValue).optional(),
             required: z.array(z.string()).optional()
         })
         .passthrough(),
@@ -61,7 +62,7 @@ export const AnthropicMessageRequestSchema = z.object({
         .positive()
         .max(1_000_000, "Parameter 'max_tokens' exceeds the gateway maximum")
         .optional(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(JSONSchemaValue).optional(),
     stop_sequences: z.array(z.string().max(1000)).max(100).optional(),
     stream: z.boolean().optional(),
     temperature: z.number().min(0).max(1).optional(),

--- a/packages/types/src/schemas/apiKeys.ts
+++ b/packages/types/src/schemas/apiKeys.ts
@@ -31,14 +31,7 @@ export const CreateAPIKeySchema = z.object({
 
 export type CreateAPIKeyZod = z.infer<typeof CreateAPIKeySchema>;
 
-export const UpdateAPIKeySchema = z.object({
-    name: z.string().min(1, "Field 'name' cannot be empty").optional(),
-    enabled: z.boolean().optional(),
-    rate_limit: z.number().int().nonnegative().optional(),
-    quota_limit: z.number().int().nonnegative().optional(),
-    credit_limit: z.number().nonnegative().optional(),
-    allowed_models: z.array(z.string().min(1)).nullable().optional()
-});
+export const UpdateAPIKeySchema = CreateAPIKeySchema.partial();
 
 export type UpdateAPIKeyZod = z.infer<typeof UpdateAPIKeySchema>;
 

--- a/packages/types/src/schemas/auth.ts
+++ b/packages/types/src/schemas/auth.ts
@@ -29,7 +29,8 @@ export const TokenImportBodySchema = z
             .min(1, "Field 'access_token' is required"),
         refresh_token: z.string().optional(),
         base_url: z.string().url().optional(),
-        name: z.string().optional()
+        name: z.string().optional(),
+        id_token: z.string().optional()
     })
     .passthrough();
 

--- a/packages/types/src/schemas/providers.ts
+++ b/packages/types/src/schemas/providers.ts
@@ -25,10 +25,12 @@ export const CreateProviderSchema = z.object({
 
 export type CreateProviderZod = z.infer<typeof CreateProviderSchema>;
 
-export const VerifyProviderSchema = z.object({
-    protocol: ProviderProtocolSchema.optional().default("openai"),
-    base_url: z.string().url().optional(),
-    api_key: z.string().optional()
+export const VerifyProviderSchema = CreateProviderSchema.pick({
+    protocol: true,
+    base_url: true,
+    api_key: true
+}).extend({
+    protocol: ProviderProtocolSchema.optional().default("openai")
 });
 
 export type VerifyProviderZod = z.infer<typeof VerifyProviderSchema>;

--- a/packages/types/src/schemas/settings.ts
+++ b/packages/types/src/schemas/settings.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { JSONSchemaValue } from "./chat.js";
 
 export const UpdateSettingsSchema = z.object({
     require_api_key: z.boolean().optional(),
@@ -12,7 +13,7 @@ export const TokenSaverPreviewRequestSchema = z.object({
     text: z
         .string({ required_error: "Field 'text' is required and must be a string" })
         .min(1, "Field 'text' cannot be empty"),
-    settings: z.record(z.unknown()).optional()
+    settings: z.record(JSONSchemaValue).optional()
 });
 
 export type TokenSaverPreviewRequestZod = z.infer<typeof TokenSaverPreviewRequestSchema>;

--- a/packages/types/src/tokenSaver.ts
+++ b/packages/types/src/tokenSaver.ts
@@ -1,35 +1,5 @@
 import { z } from "zod";
 
-export interface CompressToolOutputSettings {
-    enabled: boolean;
-    compressGit: boolean;
-    compressGrep: boolean;
-    compressFileLists: boolean;
-    compressLogs: boolean;
-    stripAnsiAndWhitespace: boolean;
-    minCharacterThreshold: number;
-}
-
-export interface LazySeniorDevSettings {
-    enabled: boolean;
-    mode: "balanced" | "strict";
-    customInstructions?: string;
-}
-
-export interface CompressLlmOutputSettings {
-    enabled: boolean;
-    mode: "terse" | "ultra_terse";
-    stripPleasantries: boolean;
-    customPrompt?: string;
-}
-
-export interface TokenSaverSettings {
-    enabled: boolean;
-    compressToolOutput: CompressToolOutputSettings;
-    lazySeniorDev: LazySeniorDevSettings;
-    compressLlmOutput: CompressLlmOutputSettings;
-}
-
 export const CompressToolOutputSchema = z.object({
     enabled: z.boolean(),
     compressGit: z.boolean(),
@@ -40,11 +10,15 @@ export const CompressToolOutputSchema = z.object({
     minCharacterThreshold: z.number().min(0).default(50)
 });
 
+export type CompressToolOutputSettings = z.infer<typeof CompressToolOutputSchema>;
+
 export const LazySeniorDevSchema = z.object({
     enabled: z.boolean(),
     mode: z.enum(["balanced", "strict"]),
     customInstructions: z.string().optional()
 });
+
+export type LazySeniorDevSettings = z.infer<typeof LazySeniorDevSchema>;
 
 export const CompressLlmOutputSchema = z.object({
     enabled: z.boolean(),
@@ -53,12 +27,16 @@ export const CompressLlmOutputSchema = z.object({
     customPrompt: z.string().optional()
 });
 
+export type CompressLlmOutputSettings = z.infer<typeof CompressLlmOutputSchema>;
+
 export const TokenSaverSettingsSchema = z.object({
     enabled: z.boolean(),
     compressToolOutput: CompressToolOutputSchema,
     lazySeniorDev: LazySeniorDevSchema,
     compressLlmOutput: CompressLlmOutputSchema
 });
+
+export type TokenSaverSettings = z.infer<typeof TokenSaverSettingsSchema>;
 
 export interface TokenSaverPreviewRequest {
     type: "tool_output" | "prompt";


### PR DESCRIPTION
## Summary
- Modularize model fallback trigger & status code extraction into a shared `fallback.policy.ts` module.
- Eliminate duplicate fallback evaluation logic across `chat.logic.ts` and `images.logic.ts`.
- Clean up OAuth type safety by adding explicit `id_token` schema definition in `TokenImportBodySchema` and typed `OAuthTokens` properties without unsafe `any` casts.
- Add unit tests for `fallback.policy.ts` covering status code extraction and fallback trigger conditions.

## Verification
- `cd packages/types && pnpm run build` passed.
- `cd apps/api && pnpm run build` passed.
- `cd apps/api && pnpm exec tsx --test tests/fallback-policy.test.ts` passed (2/2 tests).
