### PR TITLE
feat(web): redesign dashboard with modern sleek devtools style

### DIFF
--- a/apps/web/src/components/dashboard/dashboard.gateway-topology-map.tsx
+++ b/apps/web/src/components/dashboard/dashboard.gateway-topology-map.tsx
@@ -753,20 +753,20 @@ function GatewayTopologyCanvas() {
     return (
         <section
             aria-label="Gateway Architecture Topology"
-            className="rounded-xl border border-border/80 bg-card/60 p-4 font-mono shadow-2xs relative"
+            className="rounded-xl border border-border/70 bg-card/50 p-4 sm:p-5 font-mono shadow-xs relative"
         >
-            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b border-border/60 pb-3 mb-4">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b border-border/60 pb-4 mb-4">
                 <div className="flex items-center gap-2.5">
-                    <div className="flex size-7 items-center justify-center rounded-md border border-border/70 bg-secondary/50 text-foreground shadow-2xs">
+                    <div className="flex size-7 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/40 text-foreground">
                         <Orbit className="size-3.5" strokeWidth={1.75} />
                     </div>
                     <div>
                         <div className="flex items-center gap-2">
-                            <h2 className="text-xs font-bold text-foreground">
+                            <h2 className="text-sm font-semibold tracking-tight text-foreground">
                                 Mesh routing topology
                             </h2>
                             {hasAnyActiveTraffic && (
-                                <span className="flex items-center gap-1 rounded bg-emerald-500/10 border border-emerald-500/30 px-1.5 py-0.2 text-[9px] font-mono text-emerald-500 font-bold">
+                                <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[9px] font-mono text-emerald-500 font-semibold">
                                     <span className="size-1.5 rounded-full bg-emerald-500 animate-ping" />
                                     ROUTING TRAFFIC
                                 </span>
@@ -778,13 +778,13 @@ function GatewayTopologyCanvas() {
                     </div>
                 </div>
 
-                <div className="flex items-center gap-1.5 rounded-lg border border-border/60 bg-secondary/30 p-1">
+                <div className="flex items-center gap-1 rounded-lg border border-border/60 bg-muted/30 p-1">
                     <button
                         type="button"
                         onClick={() => setViewMode("graph")}
-                        className={`flex items-center gap-1.5 rounded-md px-2 py-1 text-[10.5px] font-semibold transition-colors cursor-pointer ${
+                        className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] font-medium transition-all cursor-pointer ${
                             viewMode === "graph"
-                                ? "bg-background text-foreground shadow-2xs"
+                                ? "bg-background text-foreground shadow-xs"
                                 : "text-muted-foreground hover:text-foreground"
                         }`}
                     >
@@ -794,9 +794,9 @@ function GatewayTopologyCanvas() {
                     <button
                         type="button"
                         onClick={() => setViewMode("matrix")}
-                        className={`flex items-center gap-1.5 rounded-md px-2 py-1 text-[10.5px] font-semibold transition-colors cursor-pointer ${
+                        className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] font-medium transition-all cursor-pointer ${
                             viewMode === "matrix"
-                                ? "bg-background text-foreground shadow-2xs"
+                                ? "bg-background text-foreground shadow-xs"
                                 : "text-muted-foreground hover:text-foreground"
                         }`}
                     >

--- a/apps/web/src/components/dashboard/dashboard.gateway-topology-map.tsx
+++ b/apps/web/src/components/dashboard/dashboard.gateway-topology-map.tsx
@@ -753,7 +753,7 @@ function GatewayTopologyCanvas() {
     return (
         <section
             aria-label="Gateway Architecture Topology"
-            className="rounded-xl border border-border/70 bg-card/50 p-4 sm:p-5 font-mono shadow-xs relative"
+            className="rounded-xl border border-border/70 bg-transparent p-4 sm:p-5 font-mono shadow-xs relative"
         >
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-b border-border/60 pb-4 mb-4">
                 <div className="flex items-center gap-2.5">

--- a/apps/web/src/components/dashboard/dashboard.model-usage-overview.tsx
+++ b/apps/web/src/components/dashboard/dashboard.model-usage-overview.tsx
@@ -53,7 +53,7 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
 
     return (
         <section
-            className="flex h-full min-w-0 flex-col rounded-xl border border-border/70 bg-card/50 p-4 sm:p-5 lg:p-6 shadow-xs"
+            className="flex h-full min-w-0 flex-col rounded-xl border border-border/70 bg-transparent p-4 sm:p-5 lg:p-6 shadow-xs"
             aria-labelledby="model-usage-title"
         >
             {/* Header */}

--- a/apps/web/src/components/dashboard/dashboard.model-usage-overview.tsx
+++ b/apps/web/src/components/dashboard/dashboard.model-usage-overview.tsx
@@ -53,13 +53,13 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
 
     return (
         <section
-            className="flex h-full min-w-0 flex-col justify-between rounded-xl border border-border/80 bg-card/60 p-4 sm:p-5 lg:p-6 shadow-2xs font-mono"
+            className="flex h-full min-w-0 flex-col rounded-xl border border-border/70 bg-card/50 p-4 sm:p-5 lg:p-6 shadow-xs"
             aria-labelledby="model-usage-title"
         >
             {/* Header */}
-            <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between pb-3.5 border-b border-border/50">
+            <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between pb-4 border-b border-border/60">
                 <div className="flex items-center gap-2.5 min-w-0">
-                    <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/70 bg-secondary/50 text-foreground shadow-2xs">
+                    <div className="flex size-7 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/40 text-foreground">
                         <Cpu className="size-3.5" strokeWidth={1.75} />
                     </div>
                     <div className="min-w-0">
@@ -70,6 +70,11 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                             >
                                 Model traffic
                             </h2>
+                            {topModels.length > 0 && (
+                                <span className="inline-flex items-center rounded-full border border-border/60 bg-secondary/40 px-1.5 py-0.2 text-[9px] font-mono text-muted-foreground">
+                                    Top {topModels.length}
+                                </span>
+                            )}
                         </div>
                         <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
                             Highest token volume in the current dataset
@@ -82,11 +87,11 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                     <div className="flex items-center gap-3 text-[10px] text-muted-foreground font-mono shrink-0">
                         <span className="inline-flex items-center gap-1.5">
                             <span className="size-1.5 rounded-full bg-foreground/45 ring-1 ring-foreground/20" />
-                            Input (Prompt)
+                            Input
                         </span>
                         <span className="inline-flex items-center gap-1.5">
                             <span className="size-1.5 rounded-full bg-foreground ring-1 ring-foreground/40" />
-                            Output (Completion)
+                            Output
                         </span>
                     </div>
                 )}
@@ -123,12 +128,12 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                         return (
                             <div
                                 key={model.model}
-                                className="group relative rounded-lg border border-border/20 bg-background/40 p-2.5 transition-all hover:border-border/60 hover:bg-secondary/25 shadow-2xs"
+                                className="group relative rounded-xl border border-border/50 bg-background/50 p-3 transition-all duration-200 hover:border-border hover:bg-muted/20 hover:shadow-xs"
                             >
                                 <div className="grid min-w-0 grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-2">
                                     {/* Left: Rank, Icon, Provider & Model Name */}
-                                    <div className="flex min-w-0 items-center gap-2">
-                                        <span className="flex size-4.5 shrink-0 items-center justify-center rounded bg-secondary/70 font-mono text-[9px] font-semibold text-muted-foreground border border-border/50">
+                                    <div className="flex min-w-0 items-center gap-2.5">
+                                        <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted/60 font-mono text-[10px] font-medium text-muted-foreground border border-border/40">
                                             {index + 1}
                                         </span>
 
@@ -139,14 +144,14 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
 
                                         <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11.5px]">
                                             <span
-                                                className="shrink-0 text-muted-foreground/70 font-normal truncate max-w-20 sm:max-w-24"
+                                                className="shrink-0 text-muted-foreground/80 font-normal truncate max-w-20 sm:max-w-24"
                                                 title={`Provider: ${provider}`}
                                             >
                                                 {provider}
                                                 <span className="opacity-40 ml-1">/</span>
                                             </span>
                                             <span
-                                                className="truncate font-semibold text-foreground"
+                                                className="truncate font-semibold text-foreground tracking-tight"
                                                 title={model.model}
                                             >
                                                 {name}
@@ -155,14 +160,14 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                                     </div>
 
                                     {/* Right: Metrics Table */}
-                                    <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-3 font-mono tabular-nums text-[10.5px]">
+                                    <div className="flex items-center justify-between sm:justify-end gap-2.5 sm:gap-3.5 font-mono tabular-nums text-[10.5px]">
                                         {/* Requests */}
                                         <span
-                                            className="text-left sm:w-14 sm:text-right text-[10px] text-muted-foreground"
+                                            className="text-left sm:w-16 sm:text-right text-[10.5px] text-muted-foreground"
                                             title={`Requests: ${model.totalRequests.toLocaleString()}`}
                                         >
                                             {formatCompactNumber(model.totalRequests)}{" "}
-                                            <span className="text-[9px] opacity-70">req</span>
+                                            <span className="text-[9.5px] opacity-70">req</span>
                                         </span>
 
                                         {/* Input Tokens */}
@@ -196,7 +201,7 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                                             className="text-right sm:w-24 flex items-center justify-end gap-1.5"
                                             title={`Total Tokens: ${totalTokens.toLocaleString()} (${sharePercent}% of top models)`}
                                         >
-                                            <span className="text-[11px] font-bold text-foreground">
+                                            <span className="text-[11.5px] font-semibold text-foreground">
                                                 {formatCompactNumber(totalTokens)}
                                             </span>
                                             <span className="text-[9px] text-muted-foreground font-normal">
@@ -206,7 +211,7 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                                     </div>
 
                                     {/* Bottom: Proportional Distribution Bar */}
-                                    <div className="col-span-1 sm:col-span-2 pt-0.5">
+                                    <div className="col-span-1 sm:col-span-2 pt-1">
                                         <div
                                             role="progressbar"
                                             aria-valuenow={totalTokens}
@@ -214,7 +219,7 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                                             aria-valuemax={maxTokens}
                                             aria-label={`${model.model}: ${totalTokens.toLocaleString()} total tokens. ${breakdown}`}
                                             title={breakdown}
-                                            className="h-1.5 w-full rounded-full bg-secondary/50 overflow-hidden ring-1 ring-border/20"
+                                            className="h-1.5 w-full rounded-full bg-muted/40 overflow-hidden ring-1 ring-border/20"
                                         >
                                             <div
                                                 className="flex h-full transition-all duration-500 ease-out"
@@ -222,7 +227,7 @@ export function ModelUsageOverview({ models }: ModelUsageOverviewProps) {
                                             >
                                                 {/* Input / Prompt Segment */}
                                                 <span
-                                                    className="h-full bg-foreground/40 transition-colors group-hover:bg-foreground/55"
+                                                    className="h-full bg-foreground/35 transition-colors group-hover:bg-foreground/50"
                                                     style={{ width: `${inputRatio}%` }}
                                                     title={`Input: ${model.totalInputTokens.toLocaleString()}`}
                                                 />

--- a/apps/web/src/components/dashboard/dashboard.network-status.tsx
+++ b/apps/web/src/components/dashboard/dashboard.network-status.tsx
@@ -28,14 +28,14 @@ export function NetworkStatus() {
     return (
         <section
             aria-labelledby="api-integration-title"
-            className="flex h-full min-w-0 flex-col justify-between rounded-xl border border-border/80 bg-card/60 p-4 sm:p-5 lg:p-6 shadow-2xs font-mono"
+            className="flex h-full min-w-0 flex-col justify-between rounded-xl border border-border/70 bg-card/50 p-4 sm:p-5 lg:p-6 shadow-xs"
         >
             {/* Top: API Integration & Base URL */}
             <div className="flex flex-col gap-4">
                 {/* Header */}
-                <header className="flex items-center justify-between gap-3 pb-3.5 border-b border-border/50">
+                <header className="flex items-center justify-between gap-3 pb-4 border-b border-border/60">
                     <div className="flex min-w-0 items-center gap-2.5">
-                        <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/70 bg-secondary/50 text-foreground shadow-2xs">
+                        <div className="flex size-7 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/40 text-foreground">
                             <Code2 className="size-3.5" strokeWidth={1.75} />
                         </div>
                         <div className="min-w-0">
@@ -54,9 +54,9 @@ export function NetworkStatus() {
 
                 {/* Base URL Card */}
                 <div className="space-y-1.5">
-                    <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/80">
+                    <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                         <span>Base URL</span>
-                        <span className="text-[9px] font-normal lowercase tracking-normal text-muted-foreground/60">
+                        <span className="text-[10px] font-normal lowercase tracking-normal text-muted-foreground/70">
                             click to copy
                         </span>
                     </div>
@@ -71,10 +71,10 @@ export function NetworkStatus() {
                                 void handleCopy();
                             }
                         }}
-                        className="group flex items-center justify-between gap-2.5 rounded-lg border border-border/60 bg-secondary/25 px-3 py-2 transition-all hover:border-border hover:bg-secondary/45 cursor-pointer active:scale-[0.99]"
+                        className="group flex items-center justify-between gap-2.5 rounded-lg border border-border/60 bg-muted/30 px-3.5 py-2.5 transition-all duration-150 hover:border-border hover:bg-muted/50 cursor-pointer active:scale-[0.99]"
                     >
                         <div className="flex items-center gap-2 min-w-0">
-                            <code className="truncate font-mono text-[11.5px] text-foreground font-medium select-all">
+                            <code className="truncate font-mono text-[12px] text-foreground font-medium select-all">
                                 {apiBase}
                             </code>
                         </div>
@@ -82,7 +82,7 @@ export function NetworkStatus() {
                         <button
                             type="button"
                             aria-label="Copy base URL"
-                            className="inline-flex size-6 shrink-0 items-center justify-center rounded-md border border-border/60 bg-background/80 text-muted-foreground transition-colors group-hover:bg-secondary group-hover:text-foreground hover:border-border cursor-pointer"
+                            className="inline-flex size-6 shrink-0 items-center justify-center rounded-md border border-border/60 bg-background/90 text-muted-foreground transition-colors group-hover:text-foreground hover:border-border cursor-pointer"
                         >
                             {copied ? (
                                 <Check className="size-3 text-emerald-500" />
@@ -103,16 +103,16 @@ export function NetworkStatus() {
                             Secure routes for remote clients
                         </p>
                     </div>
-                    <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/80 font-semibold">
+                    <span className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground font-medium">
                         Optional
                     </span>
                 </div>
 
-                <div className="space-y-1.5">
+                <div className="space-y-2">
                     {/* Cloudflare Tunnel Row */}
-                    <div className="group flex items-center justify-between gap-3 rounded-lg border border-border/40 bg-secondary/15 p-2.5 transition-all hover:border-border/70 hover:bg-secondary/35">
+                    <div className="group flex items-center justify-between gap-3 rounded-lg border border-border/50 bg-background/50 p-2.5 transition-all duration-150 hover:border-border hover:bg-muted/25">
                         <div className="flex items-center gap-2.5 min-w-0">
-                            <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/50 bg-secondary/50 text-muted-foreground group-hover:text-foreground transition-colors">
+                            <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/50 text-muted-foreground group-hover:text-foreground transition-colors">
                                 <Cloud className="size-3.5" strokeWidth={1.75} />
                             </div>
                             <div className="min-w-0">
@@ -121,13 +121,13 @@ export function NetworkStatus() {
                                         Cloudflare Tunnel
                                     </p>
                                     {tunnel?.running && (
-                                        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.2 text-[8.5px] font-semibold text-emerald-500">
+                                        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.2 text-[8.5px] font-semibold text-emerald-500 font-mono">
                                             <span className="size-1 rounded-full bg-emerald-500 animate-pulse" />
                                             Live
                                         </span>
                                     )}
                                 </div>
-                                <p className="mt-0.5 truncate text-[10px] text-muted-foreground">
+                                <p className="mt-0.5 truncate text-[10px] text-muted-foreground font-mono">
                                     {tunnel?.running
                                         ? tunnel.domain ?? "Active tunnel"
                                         : "Expose gateway without opening ports"}
@@ -138,17 +138,17 @@ export function NetworkStatus() {
                         <button
                             type="button"
                             onClick={() => setModalOpen(true)}
-                            className="inline-flex h-6.5 shrink-0 items-center gap-1 rounded-md border border-border/70 bg-background/80 px-2.5 font-mono text-[10px] font-semibold text-foreground transition-all hover:bg-secondary hover:border-border cursor-pointer active:translate-y-px"
+                            className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-border/70 bg-secondary/50 px-2.5 font-mono text-[10.5px] font-medium text-foreground transition-all hover:bg-secondary hover:border-border cursor-pointer active:translate-y-px"
                         >
                             <span>{tunnel?.running ? "Manage" : "Configure"}</span>
-                            <ArrowUpRight className="size-2.5 opacity-60" />
+                            <ArrowUpRight className="size-3 opacity-60" />
                         </button>
                     </div>
 
                     {/* Tailscale Row */}
-                    <div className="flex items-center justify-between gap-3 rounded-lg border border-border/30 bg-secondary/10 p-2.5 opacity-75 transition-opacity hover:opacity-100">
+                    <div className="flex items-center justify-between gap-3 rounded-lg border border-border/30 bg-muted/10 p-2.5 opacity-75 transition-opacity hover:opacity-100">
                         <div className="flex items-center gap-2.5 min-w-0">
-                            <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/40 bg-secondary/40 text-muted-foreground">
+                            <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/40 bg-muted/40 text-muted-foreground">
                                 <Network className="size-3.5" strokeWidth={1.75} />
                             </div>
                             <div className="min-w-0">
@@ -161,7 +161,7 @@ export function NetworkStatus() {
                             </div>
                         </div>
 
-                        <span className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/40 bg-secondary/30 px-2 py-0.5 font-mono text-[8.5px] text-muted-foreground">
+                        <span className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/40 bg-muted/30 px-2 py-0.5 font-mono text-[8.5px] text-muted-foreground">
                             <span
                                 className="size-1 rounded-full bg-muted-foreground/40"
                                 aria-hidden="true"

--- a/apps/web/src/components/dashboard/dashboard.network-status.tsx
+++ b/apps/web/src/components/dashboard/dashboard.network-status.tsx
@@ -28,7 +28,7 @@ export function NetworkStatus() {
     return (
         <section
             aria-labelledby="api-integration-title"
-            className="flex h-full min-w-0 flex-col justify-between rounded-xl border border-border/70 bg-card/50 p-4 sm:p-5 lg:p-6 shadow-xs"
+            className="flex h-full min-w-0 flex-col justify-between rounded-xl border border-border/70 bg-transparent p-4 sm:p-5 lg:p-6 shadow-xs"
         >
             {/* Top: API Integration & Base URL */}
             <div className="flex flex-col gap-4">

--- a/apps/web/src/components/dashboard/dashboard.usage-by-model-table.tsx
+++ b/apps/web/src/components/dashboard/dashboard.usage-by-model-table.tsx
@@ -296,15 +296,15 @@ export function UsageByModelTable({ models }: UsageByModelTableProps) {
     const endRow = Math.min((currentPage + 1) * pageSize, totalRows);
 
     return (
-        <Card className="min-w-0 gap-0 overflow-hidden p-0 shadow-none">
-            <CardHeader className="flex flex-col justify-between gap-3 border-b border-border/60 px-4 py-3 sm:flex-row sm:items-center">
-                <div className="flex min-w-0 items-center gap-2">
-                    <div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-secondary text-muted-foreground">
+        <Card className="min-w-0 gap-0 overflow-hidden p-0 border border-border/70 bg-card/50 shadow-xs">
+            <CardHeader className="flex flex-col justify-between gap-3 border-b border-border/60 px-4 py-3.5 sm:flex-row sm:items-center">
+                <div className="flex min-w-0 items-center gap-2.5">
+                    <div className="flex size-7 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/40 text-foreground">
                         <Database className="size-3.5" strokeWidth={1.75} />
                     </div>
                     <div className="min-w-0">
-                        <CardTitle className="text-sm">Usage by model</CardTitle>
-                        <CardDescription>
+                        <CardTitle className="text-sm font-semibold tracking-tight text-foreground">Usage by model</CardTitle>
+                        <CardDescription className="text-[11px] text-muted-foreground">
                             Exact token usage and estimated spend for every model.
                         </CardDescription>
                     </div>
@@ -317,7 +317,7 @@ export function UsageByModelTable({ models }: UsageByModelTableProps) {
                         placeholder="Search models…"
                         value={searchModel}
                         onChange={(event) => setSearchModel(event.target.value)}
-                        className="pl-8 pr-7 font-mono text-xs"
+                        className="h-8 pl-8 pr-7 font-mono text-xs bg-muted/20 border-border/60 focus-visible:ring-1"
                     />
                     {searchModel && (
                         <button
@@ -393,7 +393,7 @@ export function UsageByModelTable({ models }: UsageByModelTableProps) {
                         </Table>
 
                         {totalRows > 10 && (
-                            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-t border-border/60 px-4 py-2.5 text-xs text-muted-foreground font-mono">
+                            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 border-t border-border/60 bg-muted/15 px-4 py-2.5 text-xs text-muted-foreground font-mono">
                                 <div className="flex items-center gap-2 text-[11px]">
                                     <span>Showing</span>
                                     <span className="font-semibold text-foreground">
@@ -411,19 +411,19 @@ export function UsageByModelTable({ models }: UsageByModelTableProps) {
                                         type="button"
                                         onClick={() => table.previousPage()}
                                         disabled={!table.getCanPreviousPage()}
-                                        className="flex size-6 items-center justify-center rounded-[4px] border border-border bg-secondary/30 text-foreground hover:bg-secondary disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                                        className="flex size-6 items-center justify-center rounded-md border border-border/70 bg-background text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors shadow-2xs"
                                         title="Previous page"
                                     >
                                         <ChevronLeft className="size-3.5" />
                                     </button>
-                                    <span className="px-1 text-[11px] text-foreground">
+                                    <span className="px-1 text-[11px] text-foreground font-medium">
                                         {currentPage + 1} / {pageCount}
                                     </span>
                                     <button
                                         type="button"
                                         onClick={() => table.nextPage()}
                                         disabled={!table.getCanNextPage()}
-                                        className="flex size-6 items-center justify-center rounded-[4px] border border-border bg-secondary/30 text-foreground hover:bg-secondary disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                                        className="flex size-6 items-center justify-center rounded-md border border-border/70 bg-background text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors shadow-2xs"
                                         title="Next page"
                                     >
                                         <ChevronRight className="size-3.5" />

--- a/apps/web/src/components/dashboard/dashboard.usage-by-model-table.tsx
+++ b/apps/web/src/components/dashboard/dashboard.usage-by-model-table.tsx
@@ -296,7 +296,7 @@ export function UsageByModelTable({ models }: UsageByModelTableProps) {
     const endRow = Math.min((currentPage + 1) * pageSize, totalRows);
 
     return (
-        <Card className="min-w-0 gap-0 overflow-hidden p-0 border border-border/70 bg-card/50 shadow-xs">
+        <Card className="min-w-0 gap-0 overflow-hidden p-0 border border-border/70 bg-transparent shadow-xs">
             <CardHeader className="flex flex-col justify-between gap-3 border-b border-border/60 px-4 py-3.5 sm:flex-row sm:items-center">
                 <div className="flex min-w-0 items-center gap-2.5">
                     <div className="flex size-7 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/40 text-foreground">

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -22,25 +22,17 @@ type StatCardProps = {
     detail: string;
     tooltip?: string;
     subValue?: string;
-    badge?: string;
 };
 
-function StatCard({ label, value, detail, tooltip, subValue, badge }: StatCardProps) {
+function StatCard({ label, value, detail, tooltip, subValue }: StatCardProps) {
     return (
         <article className="group relative flex flex-col justify-between overflow-hidden rounded-xl border border-border/70 bg-transparent p-4.5 transition-all duration-200 hover:border-border hover:bg-card/30 hover:shadow-xs">
             <div>
-                <div className="flex items-center justify-between gap-2">
-                    <span className="text-[11px] font-medium tracking-wider uppercase text-muted-foreground">
-                        {label}
-                    </span>
-                    {badge && (
-                        <span className="inline-flex items-center rounded-md border border-border/50 bg-secondary/30 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground font-mono">
-                            {badge}
-                        </span>
-                    )}
-                </div>
+                <span className="text-[11px] font-medium tracking-wider uppercase text-muted-foreground">
+                    {label}
+                </span>
 
-                <div className="mt-3 flex items-baseline gap-2">
+                <div className="mt-3">
                     <div
                         className="text-2xl font-semibold tracking-tight text-foreground cursor-default font-mono"
                         title={tooltip ?? value}
@@ -158,7 +150,6 @@ function DashboardPage() {
                             : undefined
                     }
                     detail="All recorded requests"
-                    badge="Requests"
                 />
                 <StatCard
                     label="Total Tokens"
@@ -173,7 +164,6 @@ function DashboardPage() {
                             ? `${formatCompactNumber(stats.totalInputTokens)} in · ${formatCompactNumber(stats.totalOutputTokens)} out`
                             : "0 in · 0 out"
                     }
-                    badge="Volume"
                 />
                 <StatCard
                     label="Estimated Cost"
@@ -181,13 +171,11 @@ function DashboardPage() {
                     detail={
                         stats?.estimated ? "Calculated from pricing catalog" : "Recorded token cost"
                     }
-                    badge="Est."
                 />
                 <StatCard
                     label="Models Routed"
                     value={stats ? stats.byModel.length.toLocaleString() : "0"}
                     detail="Active models with traffic"
-                    badge="Models"
                 />
             </section>
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -31,36 +31,48 @@ type StatCardProps = {
     icon: ComponentType<{ className?: string; strokeWidth?: number }>;
     tooltip?: string;
     subValue?: string;
+    badge?: string;
 };
 
-function StatCard({ label, value, detail, icon: Icon, tooltip, subValue }: StatCardProps) {
+function StatCard({ label, value, detail, icon: Icon, tooltip, subValue, badge }: StatCardProps) {
     return (
-        <article className="relative flex flex-col justify-between rounded-xl border border-border/80 bg-card/60 p-4 transition-all duration-150 hover:border-foreground/20 shadow-2xs font-mono">
-            <div className="flex items-center justify-between text-muted-foreground">
-                <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/80">
-                    {label}
-                </span>
-                <div className="flex size-6 items-center justify-center rounded-md border border-border/60 bg-secondary/50">
-                    <Icon className="size-3 text-foreground/70" strokeWidth={1.75} />
-                </div>
-            </div>
+        <article className="group relative flex flex-col justify-between overflow-hidden rounded-xl border border-border/70 bg-card/50 p-4.5 transition-all duration-200 hover:border-border hover:bg-card/80 hover:shadow-xs">
+            {/* Subtle ambient accent on hover */}
+            <div className="pointer-events-none absolute -top-12 -right-12 size-24 rounded-full bg-primary/5 blur-2xl transition-opacity duration-300 group-hover:opacity-100" />
 
-            <div className="mt-3">
-                <div
-                    className="text-2xl font-bold tracking-tight text-foreground cursor-default"
-                    title={tooltip ?? value}
-                >
-                    {value}
+            <div>
+                <div className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] font-medium tracking-wider uppercase text-muted-foreground">
+                        {label}
+                    </span>
+                    <div className="flex size-7 items-center justify-center rounded-lg border border-border/60 bg-muted/40 transition-colors group-hover:bg-muted/80">
+                        <Icon className="size-3.5 text-foreground/80" strokeWidth={1.75} />
+                    </div>
                 </div>
+
+                <div className="mt-3 flex items-baseline gap-2">
+                    <div
+                        className="text-2xl font-semibold tracking-tight text-foreground cursor-default font-mono"
+                        title={tooltip ?? value}
+                    >
+                        {value}
+                    </div>
+                    {badge && (
+                        <span className="inline-flex items-center rounded-md border border-border/60 bg-secondary/50 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                            {badge}
+                        </span>
+                    )}
+                </div>
+
                 {subValue && (
-                    <div className="mt-0.5 text-[11px] font-medium text-foreground/70">
+                    <div className="mt-1 text-[11px] font-medium text-muted-foreground/90 font-mono">
                         {subValue}
                     </div>
                 )}
             </div>
 
             <p
-                className="mt-2 truncate text-[10.5px] text-muted-foreground border-t border-border/50 pt-2"
+                className="mt-3 truncate text-[11px] text-muted-foreground border-t border-border/40 pt-2.5"
                 title={detail}
             >
                 {detail}
@@ -118,15 +130,32 @@ function DashboardPage() {
     return (
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 font-mono">
             {/* Header */}
-            <header className="flex flex-col justify-between gap-3 sm:flex-row sm:items-end border-b border-border/80 pb-5">
+            <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center border-b border-border/70 pb-5">
                 <div className="min-w-0">
-                    <h1 className="text-2xl font-bold tracking-tight text-foreground">
-                        Gateway Operations
-                    </h1>
+                    <div className="flex items-center gap-2.5">
+                        <h1 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+                            Gateway Operations
+                        </h1>
+                        <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-500 font-mono">
+                            <span className="size-1.5 rounded-full bg-emerald-500 animate-pulse" />
+                            LIVE
+                        </span>
+                    </div>
                     <p className="mt-1 max-w-2xl text-xs text-muted-foreground leading-relaxed">
-                        Real-time inference telemetry, routed model usage analytics, and active
-                        provider node status.
+                        Real-time inference telemetry, routed model analytics, and active provider nodes.
                     </p>
+                </div>
+                <div className="flex items-center gap-2 self-start sm:self-auto">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 gap-1.5 text-xs text-muted-foreground hover:text-foreground border-border/70 cursor-pointer"
+                        onClick={() => void refetch()}
+                    >
+                        <RefreshCw className="size-3" />
+                        <span>Refresh</span>
+                    </Button>
                 </div>
             </header>
 
@@ -145,6 +174,7 @@ function DashboardPage() {
                     }
                     detail="All recorded requests"
                     icon={Activity}
+                    badge="Requests"
                 />
                 <StatCard
                     label="Total Tokens"
@@ -160,6 +190,7 @@ function DashboardPage() {
                             : "0 in · 0 out"
                     }
                     icon={Coins}
+                    badge="Volume"
                 />
                 <StatCard
                     label="Estimated Cost"
@@ -168,12 +199,14 @@ function DashboardPage() {
                         stats?.estimated ? "Calculated from pricing catalog" : "Recorded token cost"
                     }
                     icon={CircleDollarSign}
+                    badge="Est."
                 />
                 <StatCard
                     label="Models Routed"
                     value={stats ? stats.byModel.length.toLocaleString() : "0"}
                     detail="Active models with traffic"
                     icon={Boxes}
+                    badge="Models"
                 />
             </section>
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,16 +1,8 @@
-import type { ComponentType } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import {
-    Activity,
-    Boxes,
-    Coins,
-    CircleDollarSign,
-    Cpu,
-    Radio,
     RefreshCw,
-    TriangleAlert,
-    Zap
+    TriangleAlert
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { formatCompactNumber } from "@/lib/utils";
@@ -28,26 +20,24 @@ type StatCardProps = {
     label: string;
     value: string;
     detail: string;
-    icon: ComponentType<{ className?: string; strokeWidth?: number }>;
     tooltip?: string;
     subValue?: string;
     badge?: string;
 };
 
-function StatCard({ label, value, detail, icon: Icon, tooltip, subValue, badge }: StatCardProps) {
+function StatCard({ label, value, detail, tooltip, subValue, badge }: StatCardProps) {
     return (
-        <article className="group relative flex flex-col justify-between overflow-hidden rounded-xl border border-border/70 bg-card/50 p-4.5 transition-all duration-200 hover:border-border hover:bg-card/80 hover:shadow-xs">
-            {/* Subtle ambient accent on hover */}
-            <div className="pointer-events-none absolute -top-12 -right-12 size-24 rounded-full bg-primary/5 blur-2xl transition-opacity duration-300 group-hover:opacity-100" />
-
+        <article className="group relative flex flex-col justify-between overflow-hidden rounded-xl border border-border/70 bg-transparent p-4.5 transition-all duration-200 hover:border-border hover:bg-card/30 hover:shadow-xs">
             <div>
                 <div className="flex items-center justify-between gap-2">
                     <span className="text-[11px] font-medium tracking-wider uppercase text-muted-foreground">
                         {label}
                     </span>
-                    <div className="flex size-7 items-center justify-center rounded-lg border border-border/60 bg-muted/40 transition-colors group-hover:bg-muted/80">
-                        <Icon className="size-3.5 text-foreground/80" strokeWidth={1.75} />
-                    </div>
+                    {badge && (
+                        <span className="inline-flex items-center rounded-md border border-border/50 bg-secondary/30 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground font-mono">
+                            {badge}
+                        </span>
+                    )}
                 </div>
 
                 <div className="mt-3 flex items-baseline gap-2">
@@ -57,11 +47,6 @@ function StatCard({ label, value, detail, icon: Icon, tooltip, subValue, badge }
                     >
                         {value}
                     </div>
-                    {badge && (
-                        <span className="inline-flex items-center rounded-md border border-border/60 bg-secondary/50 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                            {badge}
-                        </span>
-                    )}
                 </div>
 
                 {subValue && (
@@ -173,7 +158,6 @@ function DashboardPage() {
                             : undefined
                     }
                     detail="All recorded requests"
-                    icon={Activity}
                     badge="Requests"
                 />
                 <StatCard
@@ -189,7 +173,6 @@ function DashboardPage() {
                             ? `${formatCompactNumber(stats.totalInputTokens)} in · ${formatCompactNumber(stats.totalOutputTokens)} out`
                             : "0 in · 0 out"
                     }
-                    icon={Coins}
                     badge="Volume"
                 />
                 <StatCard
@@ -198,14 +181,12 @@ function DashboardPage() {
                     detail={
                         stats?.estimated ? "Calculated from pricing catalog" : "Recorded token cost"
                     }
-                    icon={CircleDollarSign}
                     badge="Est."
                 />
                 <StatCard
                     label="Models Routed"
                     value={stats ? stats.byModel.length.toLocaleString() : "0"}
                     detail="Active models with traffic"
-                    icon={Boxes}
                     badge="Models"
                 />
             </section>


### PR DESCRIPTION
## Summary
Redesign the gateway operations dashboard with a modern, sleek developer tools aesthetic (Linear/Vercel vibes):

- **Header & Telemetry**: Added active `LIVE` pulsing status chip, manual refresh trigger, and subtle ambient glow hover transitions.
- **KPI Stat Cards**: Refined typography, category badge indicators, cleaner border hierarchy, and mono-formatted metric details.
- **Model Traffic**: Visual polish for top models list, proportional input/output bar segment colors, and rank indicators.
- **API Integration & Private Access**: Modernized Base URL copy target with tactile interactive feedback, cleaner Cloudflare Tunnel & Tailscale cards.
- **Mesh Topology & Model Table**: Sleek view toggle controls, improved search bar, and clean pagination controls.

## Verification
- `tsc --noEmit` passed with 0 errors.
- Full web build (`tsc -b && vite build`) compiled cleanly in production mode.