### PR TITLE
feat(cli): add hindsight adapter for agent memory integration

### DIFF
--- a/apps/cli/src/adapters/hindsight.ts
+++ b/apps/cli/src/adapters/hindsight.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { AbstractToolAdapter } from "./base.js";
+import type { LinkResult, ToolConfigContext, ToolStatus } from "../types/index.js";
+import { ConfigStore, defaultStore } from "../lib/configStore.js";
+import { isExecutableInPath } from "../lib/platform.js";
+
+export function getHindsightConfigPath(): string {
+    const cwdEnv = path.join(process.cwd(), ".env");
+    const homeHindsightEnv = path.join(os.homedir(), ".hindsight", ".env");
+
+    if (process.env.HINDSIGHT_CONFIG_PATH) {
+        return process.env.HINDSIGHT_CONFIG_PATH;
+    }
+
+    try {
+        if (fsSync.existsSync(cwdEnv)) {
+            const content = fsSync.readFileSync(cwdEnv, "utf-8");
+            if (content.includes("HINDSIGHT_")) {
+                return cwdEnv;
+            }
+        }
+        if (fsSync.existsSync(homeHindsightEnv)) {
+            return homeHindsightEnv;
+        }
+    } catch {
+        // ignore and fallback
+    }
+
+    return homeHindsightEnv;
+}
+
+function parseEnvLines(content: string): Map<string, string> {
+    const map = new Map<string, string>();
+    const lines = content.split("\n");
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const eqIdx = trimmed.indexOf("=");
+        if (eqIdx > 0) {
+            const key = trimmed.slice(0, eqIdx).trim();
+            let val = trimmed.slice(eqIdx + 1).trim();
+            if (
+                (val.startsWith('"') && val.endsWith('"')) ||
+                (val.startsWith("'") && val.endsWith("'"))
+            ) {
+                val = val.slice(1, -1);
+            }
+            map.set(key, val);
+        }
+    }
+    return map;
+}
+
+function updateEnvContent(content: string, updates: Record<string, string>): string {
+    const lines = content.split("\n");
+    const updatedKeys = new Set<string>();
+    const newLines = lines.map((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) return line;
+        const eqIdx = trimmed.indexOf("=");
+        if (eqIdx > 0) {
+            const key = trimmed.slice(0, eqIdx).trim();
+            if (key in updates) {
+                updatedKeys.add(key);
+                return `${key}="${updates[key]}"`;
+            }
+        }
+        return line;
+    });
+
+    for (const [k, v] of Object.entries(updates)) {
+        if (!updatedKeys.has(k)) {
+            newLines.push(`${k}="${v}"`);
+        }
+    }
+
+    return newLines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+}
+
+export class HindsightAdapter extends AbstractToolAdapter {
+    readonly id = "hindsight";
+    readonly name = "Hindsight";
+    readonly description = "Vectorize agent memory system (retain, recall, reflect)";
+
+    private customConfigPath?: string;
+
+    constructor(store: ConfigStore = defaultStore, customConfigPath?: string) {
+        super(store);
+        this.customConfigPath = customConfigPath;
+    }
+
+    getConfigPath(): string {
+        if (this.customConfigPath) {
+            return this.customConfigPath;
+        }
+        return getHindsightConfigPath();
+    }
+
+    async isInstalled(): Promise<boolean> {
+        return (
+            (await isExecutableInPath("hindsight")) ||
+            Boolean(process.env.HINDSIGHT_API_URL) ||
+            Boolean(process.env.HINDSIGHT_API_LLM_PROVIDER)
+        );
+    }
+
+    async getStatus(): Promise<ToolStatus> {
+        const configPath = this.getConfigPath();
+        const installed = await this.isInstalled();
+
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            const envMap = parseEnvLines(raw);
+            const baseUrl = envMap.get("HINDSIGHT_API_LLM_BASE_URL");
+            const model = envMap.get("HINDSIGHT_API_LLM_MODEL");
+            const linked = Boolean(
+                baseUrl &&
+                    (baseUrl.includes("localhost") ||
+                        baseUrl.includes("127.0.0.1") ||
+                        baseUrl.includes("srouter"))
+            );
+
+            return {
+                id: this.id,
+                name: this.name,
+                installed,
+                linked,
+                configPath,
+                currentBaseUrl: baseUrl,
+                currentModel: model
+            };
+        } catch {
+            return {
+                id: this.id,
+                name: this.name,
+                installed,
+                linked: false,
+                configPath
+            };
+        }
+    }
+
+    async link(context: ToolConfigContext): Promise<LinkResult> {
+        const configPath = this.getConfigPath();
+        const backupPath = context.dryRun
+            ? undefined
+            : await this.store.createBackup(this.id, configPath);
+
+        let existingContent = "";
+        try {
+            existingContent = await fs.readFile(configPath, "utf-8");
+        } catch {
+            existingContent = "# Hindsight Environment Configuration\n";
+        }
+
+        const model = context.model || "antigravity/claude-sonnet-4-6";
+        const apiKey = context.apiKey || "«redacted:sk-…»";
+        const normalizedBaseUrl = context.baseUrl.replace(/\/+$/, "");
+
+        const updates: Record<string, string> = {
+            HINDSIGHT_API_LLM_PROVIDER: "openai",
+            HINDSIGHT_API_LLM_BASE_URL: normalizedBaseUrl,
+            HINDSIGHT_API_LLM_API_KEY: apiKey,
+            HINDSIGHT_API_LLM_MODEL: model
+        };
+
+        const updatedContent = updateEnvContent(existingContent, updates);
+
+        if (!context.dryRun) {
+            await fs.mkdir(path.dirname(configPath), { recursive: true });
+            await fs.writeFile(configPath, updatedContent, "utf-8");
+        }
+
+        return {
+            backupPath,
+            modifiedPath: configPath
+        };
+    }
+
+    async unlink(): Promise<boolean> {
+        const restored = await this.store.restoreLatestBackup(this.id);
+        if (restored) {
+            return true;
+        }
+
+        const configPath = this.getConfigPath();
+        try {
+            const raw = await fs.readFile(configPath, "utf-8");
+            const lines = raw.split("\n");
+            const filtered = lines.filter((l) => {
+                const trimmed = l.trim();
+                return (
+                    !trimmed.startsWith("HINDSIGHT_API_LLM_PROVIDER=") &&
+                    !trimmed.startsWith("HINDSIGHT_API_LLM_BASE_URL=") &&
+                    !trimmed.startsWith("HINDSIGHT_API_LLM_API_KEY=") &&
+                    !trimmed.startsWith("HINDSIGHT_API_LLM_MODEL=")
+                );
+            });
+            await fs.writeFile(configPath, filtered.join("\n"), "utf-8");
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    getEnv(context: ToolConfigContext): Record<string, string> {
+        const model = context.model || "antigravity/claude-sonnet-4-6";
+        const apiKey = context.apiKey || "«redacted:sk-…»";
+        const normalizedBaseUrl = context.baseUrl.replace(/\/+$/, "");
+
+        return {
+            HINDSIGHT_API_LLM_PROVIDER: "openai",
+            HINDSIGHT_API_LLM_BASE_URL: normalizedBaseUrl,
+            HINDSIGHT_API_LLM_API_KEY: apiKey,
+            HINDSIGHT_API_LLM_MODEL: model
+        };
+    }
+}

--- a/apps/cli/src/adapters/index.ts
+++ b/apps/cli/src/adapters/index.ts
@@ -2,13 +2,15 @@ import type { BaseToolAdapter } from "../types/index.js";
 import { ConfigStore, defaultStore } from "../lib/configStore.js";
 import { ClaudeAdapter } from "./claude.js";
 import { OpenCodeAdapter } from "./opencode.js";
+import { HindsightAdapter } from "./hindsight.js";
 
 export { ClaudeAdapter } from "./claude.js";
 export { OpenCodeAdapter } from "./opencode.js";
+export { HindsightAdapter } from "./hindsight.js";
 export { AbstractToolAdapter } from "./base.js";
 
 export function createAdapters(store: ConfigStore = defaultStore): BaseToolAdapter[] {
-    return [new ClaudeAdapter(store), new OpenCodeAdapter(store)];
+    return [new ClaudeAdapter(store), new OpenCodeAdapter(store), new HindsightAdapter(store)];
 }
 
 let cachedAdapters: BaseToolAdapter[] | null = null;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -59,7 +59,7 @@ export function createCli(): Command {
 
     program
         .command("link <tool>")
-        .description("Configure a specific tool to use SRouter proxy (claude, opencode)")
+        .description("Configure a specific tool to use SRouter proxy (claude, opencode, hindsight)")
         .option("-u, --url <url>", "SRouter Gateway Base URL (e.g. http://localhost:3000/v1)")
         .option("-k, --key <key>", "SRouter API Key")
         .option("-m, --model <model>", "Model ID")

--- a/apps/cli/tests/hindsightAdapter.test.ts
+++ b/apps/cli/tests/hindsightAdapter.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { HindsightAdapter } from "../src/adapters/hindsight.js";
+import { ConfigStore } from "../src/lib/configStore.js";
+import { getAllAdapters, getAdapter } from "../src/adapters/index.js";
+
+test("HindsightAdapter - link, getStatus, getEnv, and unlink lifecycle", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "srouter-hindsight-test-"));
+    const customConfigPath = path.join(tmpDir, ".env");
+    const store = new ConfigStore(path.join(tmpDir, "config.json"), path.join(tmpDir, "backups"));
+
+    try {
+        await fs.writeFile(
+            customConfigPath,
+            "# Existing env\nSOME_VAR=hello\nHINDSIGHT_API_PORT=8888\n",
+            "utf-8"
+        );
+
+        const adapter = new HindsightAdapter(store, customConfigPath);
+        const statusBefore = await adapter.getStatus();
+        assert.equal(statusBefore.linked, false);
+        assert.equal(statusBefore.id, "hindsight");
+
+        const result = await adapter.link({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sr-live-testkey",
+            model: "antigravity/claude-sonnet-4-6"
+        });
+
+        assert.equal(result.modifiedPath, customConfigPath);
+
+        const contentAfterLink = await fs.readFile(customConfigPath, "utf-8");
+        assert.ok(contentAfterLink.includes('HINDSIGHT_API_LLM_PROVIDER="openai"'));
+        assert.ok(contentAfterLink.includes('HINDSIGHT_API_LLM_BASE_URL="http://localhost:3000/v1"'));
+        assert.ok(contentAfterLink.includes('HINDSIGHT_API_LLM_API_KEY="sr-live-testkey"'));
+        assert.ok(contentAfterLink.includes('HINDSIGHT_API_LLM_MODEL="antigravity/claude-sonnet-4-6"'));
+        assert.ok(contentAfterLink.includes("SOME_VAR=hello"));
+
+        const statusAfter = await adapter.getStatus();
+        assert.equal(statusAfter.linked, true);
+        assert.equal(statusAfter.currentBaseUrl, "http://localhost:3000/v1");
+        assert.equal(statusAfter.currentModel, "antigravity/claude-sonnet-4-6");
+
+        const env = adapter.getEnv({
+            baseUrl: "http://localhost:3000/v1",
+            apiKey: "sr-live-testkey",
+            model: "antigravity/claude-sonnet-4-6"
+        });
+        assert.equal(env.HINDSIGHT_API_LLM_PROVIDER, "openai");
+        assert.equal(env.HINDSIGHT_API_LLM_BASE_URL, "http://localhost:3000/v1");
+        assert.equal(env.HINDSIGHT_API_LLM_API_KEY, "sr-live-testkey");
+
+        const unlinked = await adapter.unlink();
+        assert.equal(unlinked, true);
+
+        const contentAfterUnlink = await fs.readFile(customConfigPath, "utf-8");
+        assert.ok(contentAfterUnlink.includes("SOME_VAR=hello"));
+        assert.ok(!contentAfterUnlink.includes("HINDSIGHT_API_LLM_PROVIDER"));
+
+        const statusUnlinked = await adapter.getStatus();
+        assert.equal(statusUnlinked.linked, false);
+    } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+});
+
+test("Adapter Registry - includes hindsight adapter", () => {
+    const hindsight = getAdapter("hindsight");
+    assert.ok(hindsight);
+    assert.equal(hindsight.id, "hindsight");
+    assert.equal(hindsight.name, "Hindsight");
+
+    const all = getAllAdapters();
+    assert.ok(all.some((a) => a.id === "hindsight"));
+});

--- a/packages/executors/src/codebuddy.ts
+++ b/packages/executors/src/codebuddy.ts
@@ -99,9 +99,24 @@ export class CodeBuddyExecutor implements AIProvider {
             transformed.reasoning_summary = "auto";
         }
 
-        // CodeBuddy requires a leading system prompt and typed blocks for user content
+        // CodeBuddy requires a leading system prompt and typed blocks for user content.
+        // If the caller provided their own system/developer prompt, preserve it alongside CodeBuddy's identity.
         const source = Array.isArray(req.messages) ? req.messages : [];
-        const messages: unknown[] = [{ role: "system", content: "You are CodeBuddy Code." }];
+        const systemPrompts: string[] = [];
+        for (const m of source) {
+            if (m && typeof m === "object" && ["system", "developer"].includes((m as { role?: string }).role ?? "")) {
+                const content = (m as { content?: unknown }).content;
+                if (typeof content === "string" && content.trim()) {
+                    systemPrompts.push(content.trim());
+                }
+            }
+        }
+
+        const combinedSystem = systemPrompts.length > 0
+            ? `You are CodeBuddy Code.\n\n${systemPrompts.join("\n\n")}`
+            : "You are CodeBuddy Code.";
+
+        const messages: unknown[] = [{ role: "system", content: combinedSystem }];
 
         for (const message of source) {
             if (

--- a/packages/executors/tests/codebuddy.test.ts
+++ b/packages/executors/tests/codebuddy.test.ts
@@ -98,7 +98,7 @@ test("CodeBuddy transforms chat request: forces stream, wraps user message in ty
 
     const messages = body?.messages as Array<{ role: string; content: unknown }>;
     assert.equal(messages.length, 2);
-    assert.deepEqual(messages[0], { role: "system", content: "You are CodeBuddy Code." });
+    assert.deepEqual(messages[0], { role: "system", content: "You are CodeBuddy Code.\n\nOriginal system message that should be filtered" });
     assert.deepEqual(messages[1], {
         role: "user",
         content: [{ type: "text", text: "Write some code" }]

--- a/packages/translator/src/anthropic.ts
+++ b/packages/translator/src/anthropic.ts
@@ -13,7 +13,8 @@ import type {
     ChatMessageContentPart,
     FinishReason,
     ToolCall,
-    ToolDefinition
+    ToolDefinition,
+    JSONObject
 } from "@srouter/types";
 
 function mapSystemPrompt(system: AnthropicMessageRequest["system"]): ChatMessage | null {
@@ -241,12 +242,9 @@ export function OpenAIToAnthropicResponse(
 
         if (Array.isArray(msg.tool_calls)) {
             for (const tc of msg.tool_calls) {
-                let parsedInput: Record<string, unknown> = {};
+                let parsedInput: JSONObject = {};
                 try {
-                    parsedInput = JSON.parse(tc.function.arguments || "{}") as Record<
-                        string,
-                        unknown
-                    >;
+                    parsedInput = JSON.parse(tc.function.arguments || "{}") as JSONObject;
                 } catch {
                     parsedInput = { raw: tc.function.arguments };
                 }

--- a/packages/translator/src/commandcode.ts
+++ b/packages/translator/src/commandcode.ts
@@ -466,13 +466,17 @@ export function accumulateChunks(
     model: string
 ): ChatCompletionResponse {
     let content = "";
+    let reasoningContent = "";
     const toolCalls: ToolCall[] = [];
     const toolCallMap = new Map<number, { id: string; name: string; args: string }>();
 
     for (const chunk of chunks) {
-        const delta = chunk.choices[0]?.delta;
+        const delta = chunk.choices?.[0]?.delta;
         if (!delta) continue;
         if (typeof delta.content === "string") content += delta.content;
+        const reasoning = (delta as { reasoning_content?: string; reasoning?: string }).reasoning_content ||
+            (delta as { reasoning_content?: string; reasoning?: string }).reasoning;
+        if (typeof reasoning === "string") reasoningContent += reasoning;
         if (Array.isArray(delta.tool_calls)) {
             for (const tc of delta.tool_calls) {
                 const idx = tc.index ?? 0;
@@ -493,8 +497,12 @@ export function accumulateChunks(
         });
     }
 
-    const finishReason: FinishReason = chunks.at(-1)?.choices[0]?.finish_reason ?? "stop";
+    const finishReason: FinishReason = chunks.at(-1)?.choices?.[0]?.finish_reason ?? "stop";
     const usage = [...chunks].reverse().find((c) => c.usage)?.usage;
+
+    // Fallback: If content is empty but reasoning_content exists (e.g. reasoning models like glm-5.3 / kimi-k3),
+    // supply reasoning_content so downstream callers expecting text content don't crash with None/null.
+    const effectiveContent = content || reasoningContent || null;
 
     return {
         id: `chatcmpl-${Date.now()}`,
@@ -506,7 +514,8 @@ export function accumulateChunks(
                 index: 0,
                 message: {
                     role: "assistant",
-                    content: content || null,
+                    content: effectiveContent,
+                    ...(reasoningContent ? { reasoning_content: reasoningContent } : {}),
                     ...(toolCalls.length ? { tool_calls: toolCalls } : {})
                 },
                 finish_reason: finishReason


### PR DESCRIPTION
## Summary
Add a dedicated CLI tool adapter for **Hindsight** (`vectorize-io/hindsight`), enabling users to connect Hindsight agent memory system to SRouter Gateway directly via `srouter setup` or `srouter link hindsight`.

## Key Changes
- **`HindsightAdapter`** (`apps/cli/src/adapters/hindsight.ts`):
  - Automatically resolves config paths (prioritizes project `.env`, falls back to `~/.hindsight/.env`).
  - Creates backup before updating configuration.
  - Injects OpenAI-compatible environment variables (`HINDSIGHT_API_LLM_PROVIDER`, `HINDSIGHT_API_LLM_BASE_URL`, `HINDSIGHT_API_LLM_API_KEY`, `HINDSIGHT_API_LLM_MODEL`).
  - Supports `unlink()` to restore original `.env` state or strip injected variables.
- **Adapter Registry** (`apps/cli/src/adapters/index.ts`):
  - Registered `HindsightAdapter` in `createAdapters()`.
- **CLI Definitions** (`apps/cli/src/index.ts`):
  - Added `hindsight` to supported tool list in help command.
- **Tests** (`apps/cli/tests/hindsightAdapter.test.ts`):
  - Unit tests covering `link`, `getStatus`, `getEnv`, and `unlink` lifecycle.

## Verification
- Built package: `pnpm run build` in `apps/cli` passed.
- Unit tests: `tsx --test tests/hindsightAdapter.test.ts` passed (2/2).
