### PR TITLE
fix(cli): resolve claude configuration across multiple candidate paths

### DIFF
--- a/apps/cli/src/adapters/claude.ts
+++ b/apps/cli/src/adapters/claude.ts
@@ -49,66 +49,89 @@ export class ClaudeAdapter extends AbstractToolAdapter {
         const configPath = this.getConfigPath();
         const installed = await this.isInstalled();
 
-        try {
-            const raw = await fs.readFile(configPath, "utf-8");
-            const parsed = parseJsonSafe(raw);
-            const baseUrl =
-                parsed.env?.ANTHROPIC_BASE_URL ||
-                parsed.ANTHROPIC_BASE_URL ||
-                parsed.baseUrl ||
-                undefined;
-            const model =
-                parsed.env?.ANTHROPIC_DEFAULT_MODEL ||
-                parsed.env?.ANTHROPIC_MODEL ||
-                parsed.model ||
-                parsed.ANTHROPIC_MODEL ||
-                undefined;
-            const opusModel =
-                parsed.env?.ANTHROPIC_DEFAULT_OPUS_MODEL ||
-                parsed.ANTHROPIC_DEFAULT_OPUS_MODEL ||
-                parsed.env?.ANTHROPIC_OPUS_MODEL ||
-                parsed.ANTHROPIC_OPUS_MODEL ||
-                undefined;
-            const sonnetModel =
-                parsed.env?.ANTHROPIC_DEFAULT_SONNET_MODEL ||
-                parsed.ANTHROPIC_DEFAULT_SONNET_MODEL ||
-                parsed.env?.ANTHROPIC_SONNET_MODEL ||
-                parsed.ANTHROPIC_SONNET_MODEL ||
-                undefined;
-            const haikuModel =
-                parsed.env?.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
-                parsed.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
-                parsed.env?.ANTHROPIC_HAIKU_MODEL ||
-                parsed.ANTHROPIC_HAIKU_MODEL ||
-                undefined;
-            const linked = Boolean(
-                baseUrl &&
-                (baseUrl.includes("localhost") ||
-                    baseUrl.includes("127.0.0.1") ||
-                    baseUrl.includes("srouter"))
-            );
-
-            return {
-                id: this.id,
-                name: this.name,
-                installed,
-                linked,
-                configPath,
-                currentBaseUrl: baseUrl,
-                currentModel: model,
-                currentOpusModel: opusModel,
-                currentSonnetModel: sonnetModel,
-                currentHaikuModel: haikuModel
-            };
-        } catch {
-            return {
-                id: this.id,
-                name: this.name,
-                installed,
-                linked: false,
-                configPath
-            };
+        // Check primary configPath. If customConfigPath is not set, also check fallback candidate paths.
+        const candidatePaths = [configPath];
+        if (!this.customConfigPath) {
+            const homeClaudeJson = path.join(os.homedir(), ".claude.json");
+            const homeClaudeSettings = path.join(os.homedir(), ".claude", "settings.json");
+            if (!candidatePaths.includes(homeClaudeJson)) candidatePaths.push(homeClaudeJson);
+            if (!candidatePaths.includes(homeClaudeSettings)) candidatePaths.push(homeClaudeSettings);
         }
+
+        let unlinkedModel: string | undefined;
+        let unlinkedBaseUrl: string | undefined;
+
+        for (const targetPath of candidatePaths) {
+            try {
+                const raw = await fs.readFile(targetPath, "utf-8");
+                const parsed = parseJsonSafe(raw);
+                const baseUrl =
+                    parsed.env?.ANTHROPIC_BASE_URL ||
+                    parsed.ANTHROPIC_BASE_URL ||
+                    parsed.baseUrl ||
+                    undefined;
+                const model =
+                    parsed.env?.ANTHROPIC_DEFAULT_MODEL ||
+                    parsed.env?.ANTHROPIC_MODEL ||
+                    parsed.model ||
+                    parsed.ANTHROPIC_MODEL ||
+                    undefined;
+                const opusModel =
+                    parsed.env?.ANTHROPIC_DEFAULT_OPUS_MODEL ||
+                    parsed.ANTHROPIC_DEFAULT_OPUS_MODEL ||
+                    parsed.env?.ANTHROPIC_OPUS_MODEL ||
+                    parsed.ANTHROPIC_OPUS_MODEL ||
+                    undefined;
+                const sonnetModel =
+                    parsed.env?.ANTHROPIC_DEFAULT_SONNET_MODEL ||
+                    parsed.ANTHROPIC_DEFAULT_SONNET_MODEL ||
+                    parsed.env?.ANTHROPIC_SONNET_MODEL ||
+                    parsed.ANTHROPIC_SONNET_MODEL ||
+                    undefined;
+                const haikuModel =
+                    parsed.env?.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
+                    parsed.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
+                    parsed.env?.ANTHROPIC_HAIKU_MODEL ||
+                    parsed.ANTHROPIC_HAIKU_MODEL ||
+                    undefined;
+                const linked = Boolean(
+                    baseUrl &&
+                    (baseUrl.includes("localhost") ||
+                        baseUrl.includes("127.0.0.1") ||
+                        baseUrl.includes("srouter"))
+                );
+
+                if (linked) {
+                    return {
+                        id: this.id,
+                        name: this.name,
+                        installed,
+                        linked: true,
+                        configPath: targetPath,
+                        currentBaseUrl: baseUrl,
+                        currentModel: model,
+                        currentOpusModel: opusModel,
+                        currentSonnetModel: sonnetModel,
+                        currentHaikuModel: haikuModel
+                    };
+                }
+
+                if (!unlinkedModel && model) unlinkedModel = model;
+                if (!unlinkedBaseUrl && baseUrl) unlinkedBaseUrl = baseUrl;
+            } catch {
+                // check next candidate
+            }
+        }
+
+        return {
+            id: this.id,
+            name: this.name,
+            installed,
+            linked: false,
+            configPath,
+            currentBaseUrl: unlinkedBaseUrl,
+            currentModel: unlinkedModel
+        };
     }
 
     async link(context: ToolConfigContext): Promise<LinkResult> {

--- a/apps/cli/src/lib/platform.ts
+++ b/apps/cli/src/lib/platform.ts
@@ -112,12 +112,12 @@ export function getClaudeConfigPath(): string {
         candidatePaths.push(path.join(process.env.CLAUDE_CONFIG_DIR, "config.json"));
     }
 
+    // Standard ~/.claude.json across all platforms (check first if it contains config)
+    candidatePaths.push(path.join(home, ".claude.json"));
+
     // Claude Code v2 settings.json
     candidatePaths.push(path.join(home, ".claude", "settings.json"));
     candidatePaths.push(path.join(home, ".config", "claude", "settings.json"));
-
-    // Standard ~/.claude.json across all platforms
-    candidatePaths.push(path.join(home, ".claude.json"));
 
     // Platform-specific secondary paths
     if (isWindows()) {


### PR DESCRIPTION
## Summary
Fix false-negative `NOT CONFIGURED` status for Claude Code in the CLI by inspecting all candidate configuration paths (`~/.claude.json` and `~/.claude/settings.json`) rather than stopping at the first existing file.

## Root Cause
Previously, `getClaudeConfigPath()` returned `~/.claude/settings.json` if the directory existed, even when SRouter's proxy settings (`ANTHROPIC_BASE_URL`) were written to `~/.claude.json`. As a result, `getStatus()` inspected only `settings.json` (which contained only hooks/permissions) and incorrectly reported Claude Code as unlinked.

## Key Changes
- **`ClaudeAdapter.getStatus`** (`apps/cli/src/adapters/claude.ts`):
  - Iterates over all candidate paths (`~/.claude.json`, `~/.claude/settings.json`).
  - Returns `linked: true` with the matching config path as soon as any active SRouter connection is detected.
  - Retains unlinked metadata (model, base URL) as fallback when not linked.
- **`getClaudeConfigPath`** (`apps/cli/src/lib/platform.ts`):
  - Prioritizes standard root `~/.claude.json` before subfolder settings files.

## Verification
- Run tests: `pnpm exec tsx --test tests/claudeAdapter.test.ts` passed (2/2).
- Built CLI: `pnpm run build` passed.
- Smoke tested: `srouter status` correctly displays `Claude Code ● CONFIGURED (LINKED)` pointing to `/root/.claude.json`.
