### PR TITLE
chore(constants): prune dead and unsupported opencode zen free models

### DIFF
--- a/packages/constants/src/providers/opencode.ts
+++ b/packages/constants/src/providers/opencode.ts
@@ -9,9 +9,7 @@ export interface OpenCodeZenModelDefinition {
 
 export const OPENCODE_ZEN_MODELS: OpenCodeZenModelDefinition[] = [
     { id: "big-pickle", name: "Big Pickle (Free)" },
-    { id: "laguna-s-2.1-free", name: "Poolside Laguna S 2.1 (Free)" },
     { id: "nemotron-3.5-lightning-free", name: "Nemotron 3.5 Lightning (Free)" },
-    { id: "nemotron-3-ultra-free", name: "Nemotron 3 Ultra (Free)" },
     { id: "mimo-v2.5-free", name: "Xiaomi MiMo V2.5 (Free)" }
 ];
 


### PR DESCRIPTION
## Summary
Prune dead and unsupported models from OpenCode Zen free tier definitions in `@srouter/constants`.

## Details
Tested all upstream free models against `https://opencode.ai/zen/v1/chat/completions`.
- `laguna-s-2.1-free` is rejected with `HTTP 401: Model laguna-s-2.1-free is not supported`.
- `nemotron-3-ultra-free` upstream server consistently times out.
- Retained only verified working models:
  - `big-pickle`
  - `nemotron-3.5-lightning-free`
  - `mimo-v2.5-free`

## Verification
- Built packages: `pnpm run build` in `packages/constants` and `packages/executors` passed.
- Tests: `apps/api/tests/models-endpoint.test.ts` and `apps/api/tests/opencode-compat.test.ts` passed (6/6).
