### PR TITLE
fix: harden SRouter reliability paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,17 +46,21 @@ Please treat everyone with respect, kindness, and professionalism. Constructive 
 
 ## 🧪 Testing & Code Quality
 
-Before submitting a Pull Request, ensure all tests and builds pass:
+Before submitting a Pull Request, run verification only for the apps and packages touched by the change. Do not run root-level Turbo tests, builds, or lint tasks on resource-constrained development environments.
 
 ```bash
-# Run all monorepo unit and integration tests
-pnpm test
+# Run one focused API test file
+cd apps/api
+pnpm exec tsx --test --test-concurrency=1 --import ./tests/setup.ts tests/<focused-file>.test.ts
 
-# Verify type safety and frontend bundle compilation
-pnpm build
+# Build only the touched app or package
+pnpm run build
 
-# Format codebase
-pnpm exec prettier --write "**/*.{ts,tsx,json,md,css}"
+# Check formatting only for changed files
+pnpm exec prettier --check src/<changed-file>.ts tests/<changed-file>.test.ts
+
+# Check whitespace errors
+git diff --check
 ```
 
 ---
@@ -101,7 +105,7 @@ _Example:_ `feat(quota): add live quota tracking for upstream accounts`
 
 1. Create a feature branch: `git checkout -b feat/your-feature-name`
 2. Commit your changes following conventional commit syntax.
-3. Verify that `pnpm test` and `pnpm build` pass with 0 errors.
+3. Verify the focused tests and builds for the touched apps or packages; do not claim broader checks were run unless they were explicitly executed.
 4. Push to your fork and open a Pull Request against `main`.
 5. Clearly describe the motivation, changes, and testing steps in your PR description.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Keep a single stable endpoint while SRouter routes requests, refreshes OAuth tokens, enforces quotas, and monitors live telemetry.
 
 <p>
-  <a href="https://github.com/seaavey/SRouter/releases"><img src="https://img.shields.io/badge/version-v0.1.4-6366f1?style=flat-square" alt="Version"></a>
+  <a href="https://github.com/seaavey/SRouter/releases"><img src="https://img.shields.io/badge/version-v0.1.6-6366f1?style=flat-square" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" alt="MIT License"></a>
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/node-%3E%3D22-339933?style=flat-square&logo=node.js&logoColor=white" alt="Node.js"></a>
   <a href="https://hono.dev/"><img src="https://img.shields.io/badge/Hono-v4.13-e36002?style=flat-square" alt="Hono"></a>
@@ -229,10 +229,12 @@ pnpm install
 # Start local dev server (API + Dashboard with HMR)
 pnpm dev
 
-# Quality checks
-pnpm lint
-pnpm test
-pnpm build
+# Quality checks for touched files
+cd apps/api
+pnpm exec tsx --test --test-concurrency=1 --import ./tests/setup.ts tests/<focused-file>.test.ts
+pnpm run build
+pnpm exec prettier --check src/<changed-file>.ts tests/<changed-file>.test.ts
+git diff --check
 ```
 
 ---

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -24,6 +24,7 @@ import { resolveWebDistPath } from "@/services/webDist.js";
 import { warmModelRegistry, startProviderRegistry } from "@/services/registry.js";
 import { bootstrapAdminAccountFromEnv } from "@/services/adminAuth.js";
 import { autostartTunnelIfEnabled } from "@/services/cloudflareTunnel.js";
+import { RunStartupTasks } from "@/services/startup.js";
 import { GetPublicUrlBase } from "@/utils/callbackUrl.js";
 import { adminAuthStore, initDatabase, isPostgres } from "@srouter/db";
 
@@ -180,17 +181,18 @@ async function boot(): Promise<void> {
     // Postgres schema init is async — await it before serving any request
     // so the first query never hits a missing table. SQLite is already
     // initialized synchronously at module import.
-    if (isPostgres()) {
-        await initDatabase();
-    }
-
-    // Bootstrap admin account & tunnel autostart: query DB, so must run
-    // after schema init (especially for Postgres).
-    void bootstrapAdminAccountFromEnv(adminAuthStore);
-    void autostartTunnelIfEnabled();
-
-    // Seed default provider rows + load saved providers (must run after DB schema init).
-    await startProviderRegistry();
+    await RunStartupTasks({
+        isPostgres: isPostgres(),
+        initDatabase,
+        bootstrapAdmin: () => bootstrapAdminAccountFromEnv(adminAuthStore),
+        autostartTunnel: autostartTunnelIfEnabled,
+        startProviderRegistry: async () => {
+            await startProviderRegistry();
+        },
+        onBackgroundError: (error: unknown) => {
+            console.warn("Could not autostart Cloudflare Tunnel:", error);
+        }
+    });
 
     serve(
         {

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -59,7 +59,10 @@ function ExtractEmailFromToken(token?: string): string | undefined {
         if (typeof decoded.user_metadata?.email === "string") {
             return decoded.user_metadata.email;
         }
-        if (typeof decoded.preferred_username === "string" && decoded.preferred_username.includes("@")) {
+        if (
+            typeof decoded.preferred_username === "string" &&
+            decoded.preferred_username.includes("@")
+        ) {
             return decoded.preferred_username;
         }
         if (typeof decoded.unique_name === "string" && decoded.unique_name.includes("@")) {
@@ -76,7 +79,8 @@ function BuildAccountIdentity(
     now: number,
     tokens?: { accessToken?: string; idToken?: string }
 ): { accountId: string; accountName: string } {
-    const email = ExtractEmailFromToken(tokens?.idToken) || ExtractEmailFromToken(tokens?.accessToken);
+    const email =
+        ExtractEmailFromToken(tokens?.idToken) || ExtractEmailFromToken(tokens?.accessToken);
     const accountName = email || `${handler.displayName} (Account #${now.toString().slice(-4)})`;
     return {
         accountId: `${handler.idPrefix}_${now}`,
@@ -84,7 +88,10 @@ function BuildAccountIdentity(
     };
 }
 
-async function InitiatePKCEFor(handler: AuthProviderHandler, params: OAuthLoginParams): Promise<OAuthLoginResult> {
+async function InitiatePKCEFor(
+    handler: AuthProviderHandler,
+    params: OAuthLoginParams
+): Promise<OAuthLoginResult> {
     await CleanupExpiredSessions();
     const clientId = ResolveClientId(handler, params);
     const redirectUri = ResolveRedirectUri(handler, params);
@@ -184,9 +191,12 @@ async function ProcessTokenImportFor(
     const accountId = params.id || `${handler.idPrefix}_${timestamp}`;
     const token = params.access_token || params.accessToken || "";
     const refreshToken = params.refresh_token || params.refreshToken;
-    const email = ExtractEmailFromToken(token) || ExtractEmailFromToken(params.id_token || params.idToken);
+    const email =
+        ExtractEmailFromToken(token) || ExtractEmailFromToken(params.id_token || params.idToken);
     const providerName =
-        params.name || email || `${handler.displayName} (Account #${timestamp.toString().slice(-4)})`;
+        params.name ||
+        email ||
+        `${handler.displayName} (Account #${timestamp.toString().slice(-4)})`;
     const mapping = handler.mapImportTokens?.(params) ?? {
         accessToken: token,
         refreshToken: refreshToken,
@@ -439,20 +449,25 @@ export async function PollQoderDeviceToken(state: string): Promise<AuthPollResul
 }
 
 interface AuthProviderEntry {
-    initiate?: (params: OAuthLoginParams) => OAuthLoginResult | Promise<OAuthLoginResult>;
-    callback?: (code: string, state: string) => Promise<ProviderConfig>;
     importToken: (params: TokenImportParams) => ProviderConfig | Promise<ProviderConfig>;
 }
 
-const authProviderEntries: Record<string, AuthProviderEntry> = {};
+interface OAuthProviderEntry extends AuthProviderEntry {
+    initiate: (params: OAuthLoginParams) => OAuthLoginResult | Promise<OAuthLoginResult>;
+    callback: (code: string, state: string) => Promise<ProviderConfig>;
+}
 
-const RegisterEntry = (
-    key: string,
-    entry: Omit<AuthProviderEntry, "initiate" | "callback"> &
-        Partial<Pick<AuthProviderEntry, "initiate" | "callback">>
-): void => {
-    authProviderEntries[key] = entry as AuthProviderEntry;
+type RegisteredAuthProviderEntry = AuthProviderEntry | OAuthProviderEntry;
+
+const authProviderEntries: Record<string, RegisteredAuthProviderEntry> = {};
+
+const RegisterEntry = (key: string, entry: RegisteredAuthProviderEntry): void => {
+    authProviderEntries[key] = entry;
 };
+
+function IsOAuthProviderEntry(entry: RegisteredAuthProviderEntry): entry is OAuthProviderEntry {
+    return "initiate" in entry && "callback" in entry;
+}
 
 RegisterEntry("openai", {
     initiate: (params) => InitiatePKCEFor(AuthHandlers.OpenAI, params),
@@ -501,17 +516,33 @@ for (const [key, handler] of [
 }
 
 export const AuthLogic = {
-    initiateOAuthPKCE: async (params: OAuthLoginParams): Promise<OAuthLoginResult> =>
-        authProviderEntries.openai.initiate!(params) as Promise<OAuthLoginResult>,
-    processOAuthCallback: async (code: string, state: string): Promise<ProviderConfig> =>
-        authProviderEntries.openai.callback!(code, state),
-    processTokenImport: async (params: TokenImportParams): Promise<ProviderConfig> =>
-        authProviderEntries.openai.importToken(params) as Promise<ProviderConfig>,
+    initiateOAuthPKCE: async (params: OAuthLoginParams): Promise<OAuthLoginResult> => {
+        const entry = authProviderEntries.openai;
+        if (!entry || !IsOAuthProviderEntry(entry))
+            throw new Error("OpenAI OAuth provider is unavailable");
+        return Promise.resolve(entry.initiate(params));
+    },
+    processOAuthCallback: async (code: string, state: string): Promise<ProviderConfig> => {
+        const entry = authProviderEntries.openai;
+        if (!entry || !IsOAuthProviderEntry(entry))
+            throw new Error("OpenAI OAuth provider is unavailable");
+        return entry.callback(code, state);
+    },
+    processTokenImport: async (params: TokenImportParams): Promise<ProviderConfig> => {
+        const entry = authProviderEntries.openai;
+        if (!entry) throw new Error("OpenAI auth provider is unavailable");
+        return Promise.resolve(entry.importToken(params));
+    },
 
-    async initiateProviderOAuth(providerKey: string, params: OAuthLoginParams): Promise<OAuthLoginResult> {
+    async initiateProviderOAuth(
+        providerKey: string,
+        params: OAuthLoginParams
+    ): Promise<OAuthLoginResult> {
         const entry = authProviderEntries[providerKey];
-        if (!entry?.initiate) throw new Error(`Unknown OAuth provider: ${providerKey}`);
-        return entry.initiate(params) as Promise<OAuthLoginResult>;
+        if (!entry || !IsOAuthProviderEntry(entry)) {
+            throw new Error(`Unknown OAuth provider: ${providerKey}`);
+        }
+        return Promise.resolve(entry.initiate(params));
     },
 
     processProviderOAuthCallback(
@@ -520,14 +551,19 @@ export const AuthLogic = {
         state: string
     ): Promise<ProviderConfig> {
         const entry = authProviderEntries[providerKey];
-        if (!entry?.callback) throw new Error(`Unknown OAuth provider: ${providerKey}`);
+        if (!entry || !IsOAuthProviderEntry(entry)) {
+            throw new Error(`Unknown OAuth provider: ${providerKey}`);
+        }
         return entry.callback(code, state);
     },
 
-    async processProviderTokenImport(providerKey: string, params: TokenImportParams): Promise<ProviderConfig> {
+    async processProviderTokenImport(
+        providerKey: string,
+        params: TokenImportParams
+    ): Promise<ProviderConfig> {
         const entry = authProviderEntries[providerKey];
         if (!entry) throw new Error(`Unknown auth provider: ${providerKey}`);
-        return entry.importToken(params) as Promise<ProviderConfig>;
+        return Promise.resolve(entry.importToken(params));
     },
 
     initiateCodeBuddyOAuth: InitiateCodeBuddyOAuth,

--- a/apps/api/src/logic/auth.logic.ts
+++ b/apps/api/src/logic/auth.logic.ts
@@ -147,7 +147,7 @@ async function ProcessOAuthCallbackFor(
     const timestamp = Date.now();
     const { accountId, accountName } = BuildAccountIdentity(handler, timestamp, {
         accessToken: tokens.accessToken,
-        idToken: (rawTokens as any).idToken || (rawTokens as any).id_token
+        idToken: rawTokens.idToken
     });
 
     const baseUrl = handler.baseUrl ? handler.baseUrl() : undefined;

--- a/apps/api/src/logic/chat.logic.ts
+++ b/apps/api/src/logic/chat.logic.ts
@@ -1,9 +1,4 @@
-import {
-    findMatchingFallbackRulesDB,
-    getTokenSaverSettingsDB,
-    logRequestDB,
-    incrementAPIKeyUsageDB
-} from "@srouter/db";
+import { getTokenSaverSettingsDB, logRequestDB, incrementAPIKeyUsageDB } from "@srouter/db";
 import { applyTokenSaver, estimateCostForUsage, extractUsageBreakdown } from "@srouter/translator";
 import { providerTypeForAlias } from "@srouter/constants";
 import type {
@@ -18,14 +13,9 @@ import type {
 } from "@srouter/types";
 import { CreateRequestAttemptBudget } from "@srouter/types";
 import { registry } from "@/services/registry.js";
-import { ensureFreshToken } from "@/services/tokenRefresh.js";
 import { executeInterceptedSearch, shouldInterceptToolCall } from "@/services/toolInterceptor.js";
-import {
-    type CandidateModel,
-    type ErrorWithStatus,
-    ExtractStatusCode,
-    ShouldTriggerFallback
-} from "./fallback.policy.js";
+import { type AttemptTracker, RunCandidateAttempts } from "./fallbackRunner.js";
+import { type ErrorWithStatus, ExtractStatusCode } from "./fallback.policy.js";
 
 const MAX_INTERCEPT_DEPTH = 3;
 
@@ -41,27 +31,6 @@ interface RequestContext {
     apiKeyId?: string;
     ipAddress?: string;
     userAgent?: string;
-}
-
-interface AttemptTracker {
-    fallbackPath: string[];
-    fallbackOccurred: boolean;
-    fallbackReason?: string;
-    lastError: Error | ErrorWithStatus | string | null;
-}
-
-async function ResolveCandidates(originalModel: string): Promise<CandidateModel[]> {
-    const matchingRules = await findMatchingFallbackRulesDB(originalModel);
-    const candidates: CandidateModel[] = [{ model: originalModel }];
-    const visitedModels = new Set<string>([originalModel]);
-
-    for (const rule of matchingRules) {
-        if (!visitedModels.has(rule.targetModel)) {
-            visitedModels.add(rule.targetModel);
-            candidates.push({ model: rule.targetModel, rule });
-        }
-    }
-    return candidates;
 }
 
 async function LogCompletion(
@@ -171,31 +140,17 @@ export class ChatLogic {
         const effectiveBody =
             depth === 0 ? applyTokenSaver(body, await getTokenSaverSettingsDB()).request : body;
         const originalModel = effectiveBody.model;
-        const candidates = await ResolveCandidates(originalModel);
-
         const tracker: AttemptTracker = {
             fallbackPath: [originalModel],
             fallbackOccurred: false,
             fallbackReason: undefined,
             lastError: null
         };
-
-        for (let i = 0; i < candidates.length; i++) {
-            const candidate = candidates[i]!;
-            const isFallbackAttempt = i > 0;
-
-            if (isFallbackAttempt && candidate.rule && tracker.lastError) {
-                if (!ShouldTriggerFallback(candidate.rule, tracker.lastError)) {
-                    continue;
-                }
-            }
-
-            const currentModel = candidate.model;
+        for await (const attempt of RunCandidateAttempts(originalModel, tracker)) {
+            const { currentModel, isFallbackAttempt, providerId } = attempt;
             const currentReq: ChatCompletionRequest = { ...effectiveBody, model: currentModel };
-            const providerId = currentModel.split("/")[0] || "default";
 
             try {
-                await ensureFreshToken(providerId);
                 const response = await registry.chatCompletion(currentReq, requestBudget);
 
                 if (isFallbackAttempt) {
@@ -257,10 +212,6 @@ export class ChatLogic {
                 if (!tracker.fallbackReason) {
                     tracker.fallbackReason = err instanceof Error ? err.message : String(err);
                 }
-
-                if (i < candidates.length - 1) {
-                    continue;
-                }
             }
         }
 
@@ -284,8 +235,6 @@ export class ChatLogic {
         const effectiveBody =
             depth === 0 ? applyTokenSaver(body, await getTokenSaverSettingsDB()).request : body;
         const originalModel = effectiveBody.model;
-        const candidates = await ResolveCandidates(originalModel);
-
         const tracker: AttemptTracker = {
             fallbackPath: [originalModel],
             fallbackOccurred: false,
@@ -293,25 +242,14 @@ export class ChatLogic {
             lastError: null
         };
 
-        for (let i = 0; i < candidates.length; i++) {
-            const candidate = candidates[i]!;
-            const isFallbackAttempt = i > 0;
-
-            if (isFallbackAttempt && candidate.rule && tracker.lastError) {
-                if (!ShouldTriggerFallback(candidate.rule, tracker.lastError)) {
-                    continue;
-                }
-            }
-
-            const currentModel = candidate.model;
+        for await (const attempt of RunCandidateAttempts(originalModel, tracker)) {
+            const { currentModel, isFallbackAttempt, providerId } = attempt;
             const currentReq: ChatCompletionRequest = { ...effectiveBody, model: currentModel };
-            const providerId = currentModel.split("/")[0] || "default";
 
             let yieldedAny = false;
             let usage: UsageInfo | undefined = undefined;
 
             try {
-                await ensureFreshToken(providerId);
                 const generator = registry.chatCompletionStream(currentReq, requestBudget);
 
                 const bufferedChunks: ChatCompletionChunk[] = [];
@@ -429,22 +367,22 @@ export class ChatLogic {
                     tracker.fallbackReason = err instanceof Error ? err.message : String(err);
                 }
 
-                if (!yieldedAny && i < candidates.length - 1) {
-                    continue;
+                if (yieldedAny) {
+                    const provider = currentModel.split("/")[0] || "default";
+                    const errorStatusCode =
+                        ExtractStatusCode(err instanceof Error ? err : (err as ErrorWithStatus)) ??
+                        500;
+                    LogCompletion(provider, currentModel, startTime, {
+                        statusCode: errorStatusCode,
+                        fallbackOccurred: tracker.fallbackOccurred,
+                        fallbackPath: tracker.fallbackPath,
+                        fallbackReason: tracker.fallbackReason,
+                        apiKeyId,
+                        ipAddress,
+                        userAgent
+                    });
+                    throw err;
                 }
-
-                const provider = currentModel.split("/")[0] || "default";
-                const errorStatusCode = ExtractStatusCode(err) ?? 500;
-                LogCompletion(provider, currentModel, startTime, {
-                    statusCode: errorStatusCode,
-                    fallbackOccurred: tracker.fallbackOccurred,
-                    fallbackPath: tracker.fallbackPath,
-                    fallbackReason: tracker.fallbackReason,
-                    apiKeyId,
-                    ipAddress,
-                    userAgent
-                });
-                throw err;
             }
         }
 

--- a/apps/api/src/logic/chat.logic.ts
+++ b/apps/api/src/logic/chat.logic.ts
@@ -313,14 +313,6 @@ export class ChatLogic {
                 let assistantContent = "";
 
                 for await (const chunk of generator) {
-                    if (!yieldedAny) {
-                        yieldedAny = true;
-                        if (isFallbackAttempt) {
-                            tracker.fallbackOccurred = true;
-                            tracker.fallbackPath.push(currentModel);
-                        }
-                    }
-
                     if (chunk.usage) {
                         usage = chunk.usage;
                     }
@@ -351,6 +343,13 @@ export class ChatLogic {
                     if (hasToolCalls) {
                         bufferedChunks.push(chunk);
                     } else {
+                        if (!yieldedAny) {
+                            yieldedAny = true;
+                            if (isFallbackAttempt) {
+                                tracker.fallbackOccurred = true;
+                                tracker.fallbackPath.push(currentModel);
+                            }
+                        }
                         yield chunk;
                     }
                 }

--- a/apps/api/src/logic/chat.logic.ts
+++ b/apps/api/src/logic/chat.logic.ts
@@ -13,8 +13,10 @@ import type {
     ChatMessage,
     JSONValue,
     ToolCall,
+    RequestAttemptBudget,
     UsageInfo
 } from "@srouter/types";
+import { CreateRequestAttemptBudget } from "@srouter/types";
 import { registry } from "@/services/registry.js";
 import { ensureFreshToken } from "@/services/tokenRefresh.js";
 import { executeInterceptedSearch, shouldInterceptToolCall } from "@/services/toolInterceptor.js";
@@ -161,8 +163,10 @@ export class ChatLogic {
         depth = 0,
         apiKeyId?: string,
         ipAddress?: string,
-        userAgent?: string
+        userAgent?: string,
+        budget?: RequestAttemptBudget
     ): Promise<ChatCompletionResponse> {
+        const requestBudget = budget ?? CreateRequestAttemptBudget();
         const ctx: RequestContext = { startTime, depth, apiKeyId, ipAddress, userAgent };
         const effectiveBody =
             depth === 0 ? applyTokenSaver(body, await getTokenSaverSettingsDB()).request : body;
@@ -192,7 +196,7 @@ export class ChatLogic {
 
             try {
                 await ensureFreshToken(providerId);
-                const response = await registry.chatCompletion(currentReq);
+                const response = await registry.chatCompletion(currentReq, requestBudget);
 
                 if (isFallbackAttempt) {
                     tracker.fallbackOccurred = true;
@@ -231,7 +235,8 @@ export class ChatLogic {
                         depth + 1,
                         apiKeyId,
                         ipAddress,
-                        userAgent
+                        userAgent,
+                        requestBudget
                     );
                 }
 
@@ -271,8 +276,10 @@ export class ChatLogic {
         depth = 0,
         apiKeyId?: string,
         ipAddress?: string,
-        userAgent?: string
+        userAgent?: string,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
+        const requestBudget = budget ?? CreateRequestAttemptBudget();
         const ctx: RequestContext = { startTime, depth, apiKeyId, ipAddress, userAgent };
         const effectiveBody =
             depth === 0 ? applyTokenSaver(body, await getTokenSaverSettingsDB()).request : body;
@@ -305,7 +312,7 @@ export class ChatLogic {
 
             try {
                 await ensureFreshToken(providerId);
-                const generator = registry.chatCompletionStream(currentReq);
+                const generator = registry.chatCompletionStream(currentReq, requestBudget);
 
                 const bufferedChunks: ChatCompletionChunk[] = [];
                 const toolCallsMap = new Map<number, AssembledStreamingToolCall>();
@@ -394,7 +401,8 @@ export class ChatLogic {
                         depth + 1,
                         apiKeyId,
                         ipAddress,
-                        userAgent
+                        userAgent,
+                        requestBudget
                     );
                     return;
                 }

--- a/apps/api/src/logic/fallbackRunner.ts
+++ b/apps/api/src/logic/fallbackRunner.ts
@@ -1,0 +1,69 @@
+import { findMatchingFallbackRulesDB } from "@srouter/db";
+import { ensureFreshToken } from "@/services/tokenRefresh.js";
+import {
+    type CandidateModel,
+    type ErrorWithStatus,
+    ShouldTriggerFallback
+} from "./fallback.policy.js";
+
+export interface AttemptTracker {
+    fallbackPath: string[];
+    fallbackOccurred: boolean;
+    fallbackReason?: string;
+    lastError: Error | ErrorWithStatus | string | null;
+}
+
+export interface CandidateAttempt {
+    candidate: CandidateModel;
+    currentModel: string;
+    isFallbackAttempt: boolean;
+    providerId: string;
+}
+
+export async function ResolveCandidates(originalModel: string): Promise<CandidateModel[]> {
+    const matchingRules = await findMatchingFallbackRulesDB(originalModel);
+    const candidates: CandidateModel[] = [{ model: originalModel }];
+    const visitedModels = new Set<string>([originalModel]);
+
+    for (const rule of matchingRules) {
+        if (!visitedModels.has(rule.targetModel)) {
+            visitedModels.add(rule.targetModel);
+            candidates.push({ model: rule.targetModel, rule });
+        }
+    }
+    return candidates;
+}
+
+export async function* RunCandidateAttempts(
+    originalModel: string,
+    tracker: AttemptTracker
+): AsyncGenerator<CandidateAttempt, void, void> {
+    const candidates = await ResolveCandidates(originalModel);
+
+    for (let index = 0; index < candidates.length; index++) {
+        const candidate = candidates[index];
+        if (!candidate) continue;
+        const isFallbackAttempt = index > 0;
+
+        if (isFallbackAttempt && candidate.rule && tracker.lastError) {
+            if (!ShouldTriggerFallback(candidate.rule, tracker.lastError)) continue;
+        }
+
+        const providerId = candidate.model.split("/")[0] || "default";
+        try {
+            await ensureFreshToken(providerId);
+        } catch (error) {
+            tracker.lastError = error instanceof Error ? error : String(error);
+            if (!tracker.fallbackReason) {
+                tracker.fallbackReason = error instanceof Error ? error.message : String(error);
+            }
+            continue;
+        }
+        yield {
+            candidate,
+            currentModel: candidate.model,
+            isFallbackAttempt,
+            providerId
+        };
+    }
+}

--- a/apps/api/src/logic/images.logic.ts
+++ b/apps/api/src/logic/images.logic.ts
@@ -1,28 +1,15 @@
-import { findMatchingFallbackRulesDB, incrementAPIKeyUsageDB, logRequestDB } from "@srouter/db";
+import { incrementAPIKeyUsageDB, logRequestDB } from "@srouter/db";
 import { isImageGenerationSupported } from "@srouter/pricing";
-import type { FallbackRule, ImageGenerationRequest, ImageGenerationResponse } from "@srouter/types";
+import { CreateRequestAttemptBudget } from "@srouter/types";
+import type {
+    ImageGenerationRequest,
+    ImageGenerationResponse,
+    RequestAttemptBudget
+} from "@srouter/types";
 import { HTTPException } from "hono/http-exception";
 import { registry } from "@/services/registry.js";
-import { ensureFreshToken } from "@/services/tokenRefresh.js";
-import {
-    type CandidateModel,
-    type ErrorWithStatus,
-    ExtractStatusCode,
-    ShouldTriggerFallback
-} from "./fallback.policy.js";
-
-async function ResolveCandidates(model: string): Promise<CandidateModel[]> {
-    const candidates: CandidateModel[] = [{ model }];
-    const rules = await findMatchingFallbackRulesDB(model);
-
-    for (const rule of rules) {
-        if (!candidates.some((c) => c.model === rule.targetModel)) {
-            candidates.push({ model: rule.targetModel, rule });
-        }
-    }
-
-    return candidates;
-}
+import { type AttemptTracker, RunCandidateAttempts } from "./fallbackRunner.js";
+import { type ErrorWithStatus, ExtractStatusCode } from "./fallback.policy.js";
 
 export class ImagesLogic {
     public static async generate(
@@ -30,12 +17,13 @@ export class ImagesLogic {
         startTime: number,
         apiKeyId?: string,
         ipAddress?: string,
-        userAgent?: string
+        userAgent?: string,
+        budget?: RequestAttemptBudget
     ): Promise<ImageGenerationResponse> {
+        const requestBudget = budget ?? CreateRequestAttemptBudget();
         const model = body.model || "dall-e-3";
         const hasInputImage = Boolean(body.image || body.images);
 
-        // 1. Modality capability validation
         if (!isImageGenerationSupported(model, hasInputImage)) {
             const reason = hasInputImage
                 ? `Model '${model}' does not support image editing / image-to-image input.`
@@ -53,33 +41,27 @@ export class ImagesLogic {
             });
         }
 
-        const candidates = await ResolveCandidates(model);
-        let lastError: Error | ErrorWithStatus | string | null = null;
-        const fallbackPath: string[] = [model];
-        let fallbackOccurred = false;
-        let fallbackReason: string | undefined;
+        const tracker: AttemptTracker = {
+            fallbackPath: [model],
+            fallbackOccurred: false,
+            fallbackReason: undefined,
+            lastError: null
+        };
+        let lastAttemptModel = model;
+        let lastAttemptProvider = model.split("/")[0] || "default";
 
-        for (let i = 0; i < candidates.length; i++) {
-            const candidate = candidates[i]!;
-            const isFallbackAttempt = i > 0;
-
-            if (isFallbackAttempt && candidate.rule && lastError) {
-                if (!ShouldTriggerFallback(candidate.rule, lastError)) {
-                    continue;
-                }
-            }
-
-            const currentModel = candidate.model;
+        for await (const attempt of RunCandidateAttempts(model, tracker)) {
+            const { currentModel, isFallbackAttempt, providerId } = attempt;
+            lastAttemptModel = currentModel;
+            lastAttemptProvider = providerId;
             const currentReq: ImageGenerationRequest = { ...body, model: currentModel };
-            const providerId = currentModel.split("/")[0] || "default";
 
             try {
-                await ensureFreshToken(providerId);
-                const response = await registry.generateImage(currentReq);
+                const response = await registry.generateImage(currentReq, requestBudget);
 
                 if (isFallbackAttempt) {
-                    fallbackOccurred = true;
-                    fallbackPath.push(currentModel);
+                    tracker.fallbackOccurred = true;
+                    tracker.fallbackPath.push(currentModel);
                 }
 
                 if (apiKeyId) {
@@ -96,45 +78,43 @@ export class ImagesLogic {
                     completionTokens: 0,
                     totalTokens: 0,
                     statusCode: 200,
-                    fallbackOccurred,
-                    fallbackPath: fallbackOccurred ? fallbackPath.join(" -> ") : undefined,
-                    fallbackReason,
+                    fallbackOccurred: tracker.fallbackOccurred,
+                    fallbackPath: tracker.fallbackOccurred
+                        ? tracker.fallbackPath.join(" -> ")
+                        : undefined,
+                    fallbackReason: tracker.fallbackReason,
                     latencyMs: Date.now() - startTime
                 });
 
                 return response;
             } catch (err) {
-                lastError = err instanceof Error ? err : (err as ErrorWithStatus);
-                if (!fallbackReason) {
-                    fallbackReason = err instanceof Error ? err.message : String(err);
+                tracker.lastError = err instanceof Error ? err : (err as ErrorWithStatus);
+                if (!tracker.fallbackReason) {
+                    tracker.fallbackReason = err instanceof Error ? err.message : String(err);
                 }
-
-                if (i < candidates.length - 1) {
-                    continue;
-                }
-
-                const errorStatusCode = ExtractStatusCode(err as ErrorWithStatus) ?? 500;
-                logRequestDB({
-                    apiKeyId,
-                    ipAddress,
-                    userAgent,
-                    providerId,
-                    model: currentModel,
-                    promptTokens: 0,
-                    completionTokens: 0,
-                    totalTokens: 0,
-                    statusCode: errorStatusCode,
-                    fallbackOccurred,
-                    fallbackPath: fallbackOccurred ? fallbackPath.join(" -> ") : undefined,
-                    fallbackReason,
-                    latencyMs: Date.now() - startTime
-                });
-
-                throw err;
             }
         }
 
-        if (lastError) throw lastError;
+        if (tracker.lastError) {
+            logRequestDB({
+                apiKeyId,
+                ipAddress,
+                userAgent,
+                providerId: lastAttemptProvider,
+                model: lastAttemptModel,
+                promptTokens: 0,
+                completionTokens: 0,
+                totalTokens: 0,
+                statusCode: ExtractStatusCode(tracker.lastError) ?? 500,
+                fallbackOccurred: tracker.fallbackOccurred,
+                fallbackPath: tracker.fallbackOccurred
+                    ? tracker.fallbackPath.join(" -> ")
+                    : undefined,
+                fallbackReason: tracker.fallbackReason,
+                latencyMs: Date.now() - startTime
+            });
+            throw tracker.lastError;
+        }
         throw new Error(`Failed to generate image for model '${model}'`);
     }
 }

--- a/apps/api/src/logic/images.logic.ts
+++ b/apps/api/src/logic/images.logic.ts
@@ -56,6 +56,15 @@ export class ImagesLogic {
             lastAttemptProvider = providerId;
             const currentReq: ImageGenerationRequest = { ...body, model: currentModel };
 
+            if (!isImageGenerationSupported(currentModel, hasInputImage)) {
+                const reason = hasInputImage
+                    ? `Model '${currentModel}' does not support image editing / image-to-image input.`
+                    : `Model '${currentModel}' does not support image generation. Output modalities do not include 'image'.`;
+                tracker.lastError = new HTTPException(400, { message: reason });
+                if (!tracker.fallbackReason) tracker.fallbackReason = reason;
+                continue;
+            }
+
             try {
                 const response = await registry.generateImage(currentReq, requestBudget);
 

--- a/apps/api/src/services/startup.ts
+++ b/apps/api/src/services/startup.ts
@@ -1,0 +1,18 @@
+export interface StartupTasks {
+    isPostgres: boolean;
+    initDatabase: () => Promise<void>;
+    bootstrapAdmin: () => Promise<void>;
+    autostartTunnel: () => Promise<void>;
+    startProviderRegistry: () => Promise<void>;
+    onBackgroundError: (error: unknown) => void;
+}
+
+export async function RunStartupTasks(tasks: StartupTasks): Promise<void> {
+    if (tasks.isPostgres) {
+        await tasks.initDatabase();
+    }
+
+    await tasks.bootstrapAdmin();
+    void tasks.autostartTunnel().catch(tasks.onBackgroundError);
+    await tasks.startProviderRegistry();
+}

--- a/apps/api/tests/api-keys-usage-deduction.test.ts
+++ b/apps/api/tests/api-keys-usage-deduction.test.ts
@@ -19,7 +19,6 @@ test("ChatLogic.ProcessNonStreamingCompletion records usage tokens and dollar co
     });
     createdIds.push(key.id);
 
-    // Mock provider in registry
     const origMethod = registry.chatCompletion;
     registry.chatCompletion = async () => ({
         id: "chatcmpl-mock",
@@ -110,6 +109,50 @@ test("ChatLogic.ProcessStreamingCompletion records usage tokens and dollar cost 
         assert.ok(updated);
         assert.equal(updated?.usage_tokens, 300);
         assert.ok((updated?.usage_cost ?? 0) > 0, "Streaming usage cost should be greater than 0");
+    } finally {
+        registry.chatCompletionStream = origStream;
+    }
+});
+
+test("ChatLogic does not bill a stream that errors after partial output without usage", async () => {
+    const key = await createAPIKeyDB({
+        name: "Partial Stream Key",
+        credit_limit: 10
+    });
+    createdIds.push(key.id);
+
+    const origStream = registry.chatCompletionStream;
+    registry.chatCompletionStream = async function* () {
+        yield {
+            id: "chatcmpl-partial",
+            object: "chat.completion.chunk",
+            created: Date.now(),
+            model: "openai_codex/gpt-4o",
+            choices: [{ index: 0, delta: { content: "partial" } }]
+        };
+        throw new Error("upstream stream interrupted");
+    };
+
+    try {
+        await assert.rejects(async () => {
+            for await (const _ of ChatLogic.ProcessStreamingCompletion(
+                {
+                    model: "openai_codex/gpt-4o",
+                    messages: [{ role: "user", content: "Hi" }],
+                    stream: true
+                },
+                Date.now(),
+                0,
+                key.id
+            )) {
+                // Consume the client-visible partial output before the error.
+            }
+        }, /upstream stream interrupted/);
+
+        const updated = await getAPIKeyByKeyDB(key.key);
+        assert.ok(updated);
+        assert.equal(updated?.usage_tokens, 0);
+        assert.equal(updated?.usage_cost, 0);
     } finally {
         registry.chatCompletionStream = origStream;
     }

--- a/apps/api/tests/fallbacks-cascade.test.ts
+++ b/apps/api/tests/fallbacks-cascade.test.ts
@@ -188,3 +188,153 @@ test("ChatLogic cascades streaming request to fallback provider before first chu
     assert.equal(chunks.length, 1);
     assert.equal(chunks[0]?.choices[0]?.delta.content, "Streaming seamlessly from fallback!");
 });
+
+test("ChatLogic does not cascade after a client-visible streaming chunk", async () => {
+    let fallbackCalled = false;
+    const primaryProvider: AIProvider = {
+        id: "primary_committed_stream",
+        name: "Primary Committed Stream Provider",
+        listModels: async () => [{ id: "primary_committed_stream/model", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("Not implemented");
+        },
+        chatCompletionStream: async function* () {
+            yield {
+                id: "committed-chunk",
+                object: "chat.completion.chunk",
+                created: Date.now(),
+                model: "primary_committed_stream/model",
+                choices: [{ index: 0, delta: { content: "partial" }, finish_reason: null }]
+            };
+            throw new Error("stream interrupted after output");
+        }
+    };
+    const fallbackProvider: AIProvider = {
+        id: "fallback_after_commit",
+        name: "Fallback After Commit",
+        listModels: async () => [{ id: "fallback_after_commit/model", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("Not implemented");
+        },
+        chatCompletionStream: async function* () {
+            fallbackCalled = true;
+            yield {
+                id: "fallback-chunk",
+                object: "chat.completion.chunk",
+                created: Date.now(),
+                model: "fallback_after_commit/model",
+                choices: [{ index: 0, delta: { content: "fallback" }, finish_reason: null }]
+            };
+        }
+    };
+
+    registry.registerProvider(primaryProvider);
+    registry.registerProvider(fallbackProvider);
+    registeredProviderIds.push(primaryProvider.id, fallbackProvider.id);
+    const rule = await createFallbackRuleDB({
+        sourceModel: "primary_committed_stream/model",
+        targetModel: "fallback_after_commit/model",
+        priority: 1,
+        enabled: true
+    });
+    createdRuleIds.push(rule.id);
+
+    const chunks = [];
+    await assert.rejects(async () => {
+        for await (const chunk of ChatLogic.processStreamingCompletion(
+            {
+                model: "primary_committed_stream/model",
+                messages: [{ role: "user", content: "commit test" }]
+            },
+            Date.now()
+        )) {
+            chunks.push(chunk);
+        }
+    }, /stream interrupted after output/);
+
+    assert.equal(chunks.length, 1);
+    assert.equal(fallbackCalled, false);
+});
+
+test("ChatLogic can cascade when a buffered tool-call stream fails before client output", async () => {
+    let fallbackCalled = false;
+    const primaryProvider: AIProvider = {
+        id: "primary_buffered_stream",
+        name: "Primary Buffered Stream Provider",
+        listModels: async () => [{ id: "primary_buffered_stream/model", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("Not implemented");
+        },
+        chatCompletionStream: async function* () {
+            yield {
+                id: "tool-buffered-chunk",
+                object: "chat.completion.chunk",
+                created: Date.now(),
+                model: "primary_buffered_stream/model",
+                choices: [
+                    {
+                        index: 0,
+                        delta: {
+                            tool_calls: [
+                                {
+                                    index: 0,
+                                    id: "buffered-call",
+                                    type: "function",
+                                    function: { name: "client_tool", arguments: "{}" }
+                                }
+                            ]
+                        },
+                        finish_reason: null
+                    }
+                ]
+            };
+            throw new Error("buffered stream interrupted");
+        }
+    };
+    const fallbackProvider: AIProvider = {
+        id: "fallback_buffered_stream",
+        name: "Fallback Buffered Stream",
+        listModels: async () => [{ id: "fallback_buffered_stream/model", object: "model" }],
+        chatCompletion: async () => {
+            throw new Error("Not implemented");
+        },
+        chatCompletionStream: async function* () {
+            fallbackCalled = true;
+            yield {
+                id: "buffered-fallback-chunk",
+                object: "chat.completion.chunk",
+                created: Date.now(),
+                model: "fallback_buffered_stream/model",
+                choices: [
+                    { index: 0, delta: { content: "fallback after buffer" }, finish_reason: null }
+                ]
+            };
+        }
+    };
+
+    registry.registerProvider(primaryProvider);
+    registry.registerProvider(fallbackProvider);
+    registeredProviderIds.push(primaryProvider.id, fallbackProvider.id);
+    const rule = await createFallbackRuleDB({
+        sourceModel: "primary_buffered_stream/model",
+        targetModel: "fallback_buffered_stream/model",
+        priority: 1,
+        enabled: true
+    });
+    createdRuleIds.push(rule.id);
+
+    const chunks = [];
+    for await (const chunk of ChatLogic.processStreamingCompletion(
+        {
+            model: "primary_buffered_stream/model",
+            messages: [{ role: "user", content: "buffer test" }]
+        },
+        Date.now()
+    )) {
+        chunks.push(chunk);
+    }
+
+    assert.equal(fallbackCalled, true);
+    assert.equal(chunks.length, 1);
+    assert.equal(chunks[0]?.choices[0]?.delta.content, "fallback after buffer");
+});

--- a/apps/api/tests/images-fallback.test.ts
+++ b/apps/api/tests/images-fallback.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createFallbackRuleDB, deleteFallbackRuleDB, deleteLogsByProviderDB } from "@srouter/db";
+import type { ImageGenerationResponse } from "@srouter/types";
+import { ImagesLogic } from "../src/logic/images.logic.js";
+import { registry } from "../src/services/registry.js";
+
+const createdRuleIds: string[] = [];
+const response: ImageGenerationResponse = {
+    created: 1725408000,
+    data: [{ url: "https://example.com/generated.png" }]
+};
+const defaults = {
+    n: 1,
+    quality: "auto" as const,
+    response_format: "url" as const,
+    size: "1024x1024"
+};
+
+afterEach(async () => {
+    for (const id of createdRuleIds.splice(0)) {
+        await deleteFallbackRuleDB(id);
+    }
+    await deleteLogsByProviderDB("openai");
+});
+
+test("ImagesLogic returns the primary image response", async () => {
+    const originalGenerateImage = registry.generateImage;
+    let calls = 0;
+    registry.generateImage = async () => {
+        calls += 1;
+        return response;
+    };
+
+    try {
+        const result = await ImagesLogic.generate(
+            { ...defaults, model: "openai/gpt-image-1.5", prompt: "primary" },
+            Date.now()
+        );
+        assert.deepEqual(result, response);
+        assert.equal(calls, 1);
+    } finally {
+        registry.generateImage = originalGenerateImage;
+    }
+});
+
+test("ImagesLogic falls back after an eligible primary failure", async () => {
+    const rule = await createFallbackRuleDB({
+        sourceModel: "openai/gpt-image-1.5",
+        targetModel: "openai/gpt-image-2",
+        priority: 1,
+        enabled: true,
+        triggerOnStatus: [429]
+    });
+    createdRuleIds.push(rule.id);
+
+    const originalGenerateImage = registry.generateImage;
+    const models: string[] = [];
+    registry.generateImage = async (request) => {
+        models.push(request.model);
+        if (request.model === "openai/gpt-image-1.5") {
+            throw new Error("429 image quota exceeded");
+        }
+        return response;
+    };
+
+    try {
+        const result = await ImagesLogic.generate(
+            { ...defaults, model: "openai/gpt-image-1.5", prompt: "fallback" },
+            Date.now()
+        );
+        assert.deepEqual(result, response);
+        assert.deepEqual(models, ["openai/gpt-image-1.5", "openai/gpt-image-2"]);
+    } finally {
+        registry.generateImage = originalGenerateImage;
+    }
+});
+
+test("ImagesLogic skips a fallback rule when the error does not match its trigger", async () => {
+    const rule = await createFallbackRuleDB({
+        sourceModel: "openai/gpt-image-1.5",
+        targetModel: "openai/gpt-image-2",
+        priority: 1,
+        enabled: true,
+        triggerOnStatus: [400]
+    });
+    createdRuleIds.push(rule.id);
+
+    const originalGenerateImage = registry.generateImage;
+    let calls = 0;
+    registry.generateImage = async () => {
+        calls += 1;
+        throw new Error("500 image provider failure");
+    };
+
+    try {
+        await assert.rejects(
+            () =>
+                ImagesLogic.generate(
+                    { ...defaults, model: "openai/gpt-image-1.5", prompt: "skip" },
+                    Date.now()
+                ),
+            /500 image provider failure/
+        );
+        assert.equal(calls, 1);
+    } finally {
+        registry.generateImage = originalGenerateImage;
+    }
+});
+
+test("ImagesLogic validates image capability before provider execution", async () => {
+    const originalGenerateImage = registry.generateImage;
+    let called = false;
+    registry.generateImage = async () => {
+        called = true;
+        return response;
+    };
+
+    try {
+        await assert.rejects(
+            () =>
+                ImagesLogic.generate(
+                    { ...defaults, model: "openai/gpt-4o", prompt: "invalid" },
+                    Date.now()
+                ),
+            (error: unknown) =>
+                error instanceof Error &&
+                error.message.includes("does not support image generation")
+        );
+        assert.equal(called, false);
+    } finally {
+        registry.generateImage = originalGenerateImage;
+    }
+});

--- a/apps/api/tests/images-fallback.test.ts
+++ b/apps/api/tests/images-fallback.test.ts
@@ -132,3 +132,34 @@ test("ImagesLogic validates image capability before provider execution", async (
         registry.generateImage = originalGenerateImage;
     }
 });
+
+test("ImagesLogic skips an image-incompatible fallback before provider execution", async () => {
+    const rule = await createFallbackRuleDB({
+        sourceModel: "openai/gpt-image-1.5",
+        targetModel: "deepseek/deepseek-chat",
+        priority: 1,
+        enabled: true
+    });
+    createdRuleIds.push(rule.id);
+
+    const originalGenerateImage = registry.generateImage;
+    const models: string[] = [];
+    registry.generateImage = async (request) => {
+        models.push(request.model);
+        throw new Error("429 image quota exceeded");
+    };
+
+    try {
+        await assert.rejects(
+            () =>
+                ImagesLogic.generate(
+                    { ...defaults, model: "openai/gpt-image-1.5", prompt: "unsupported fallback" },
+                    Date.now()
+                ),
+            /deepseek\/deepseek-chat.*does not support image generation/
+        );
+        assert.deepEqual(models, ["openai/gpt-image-1.5"]);
+    } finally {
+        registry.generateImage = originalGenerateImage;
+    }
+});

--- a/apps/api/tests/startup.test.ts
+++ b/apps/api/tests/startup.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { RunStartupTasks } from "../src/services/startup.js";
+
+test("RunStartupTasks initializes Postgres before required startup tasks", async () => {
+    const events: string[] = [];
+    const backgroundError = new Error("tunnel unavailable");
+    let rejectTunnel: ((error: Error) => void) | undefined;
+    const tunnelPromise = new Promise<void>((_, reject) => {
+        rejectTunnel = reject;
+    });
+
+    const startup = RunStartupTasks({
+        isPostgres: true,
+        initDatabase: async () => {
+            events.push("database");
+        },
+        bootstrapAdmin: async () => {
+            events.push("admin");
+        },
+        autostartTunnel: () => tunnelPromise,
+        startProviderRegistry: async () => {
+            events.push("providers");
+        },
+        onBackgroundError: (error) => {
+            events.push(error === backgroundError ? "tunnel-error" : "wrong-error");
+        }
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    rejectTunnel?.(backgroundError);
+    await startup;
+
+    assert.deepEqual(events, ["database", "admin", "providers", "tunnel-error"]);
+});
+
+test("RunStartupTasks preserves SQLite ordering without database initialization", async () => {
+    const events: string[] = [];
+
+    await RunStartupTasks({
+        isPostgres: false,
+        initDatabase: async () => {
+            events.push("database");
+        },
+        bootstrapAdmin: async () => {
+            events.push("admin");
+        },
+        autostartTunnel: async () => {
+            events.push("tunnel");
+        },
+        startProviderRegistry: async () => {
+            events.push("providers");
+        },
+        onBackgroundError: () => {
+            events.push("error");
+        }
+    });
+
+    assert.deepEqual(events, ["admin", "tunnel", "providers"]);
+});

--- a/docs/superpowers/contracts/model-provider-identity.md
+++ b/docs/superpowers/contracts/model-provider-identity.md
@@ -1,0 +1,51 @@
+# SRouter Model and Provider Identity Contract
+
+Status: Proposed for reliability hardening
+
+This contract defines the identity forms used while routing a model request. It is intentionally separate from the public API wire contract: no new request or response fields are introduced.
+
+## Identity forms
+
+| Stage | Canonical form | Owner / behavior |
+| --- | --- | --- |
+| Public model input | `alias/model-name` | Chat and image routes accept the external model ID. Bare model input remains compatible when a provider can resolve it. |
+| Registry lookup | Prefixed, bare, or provider-account form | `ProviderRegistry` matches the exact listed model, strips a recognized alias/account/base prefix, then tries provider-prefix matching. |
+| Executor model | Bare `model-name` | Provider executors receive the provider-specific model name after their existing provider mapping. |
+| Provider account ID | `provider_<account-suffix>` | Runtime connection identity. Account suffixes must not become the provider identity in logs or pricing. |
+| Custom provider ID | UUID | A custom UUID is immutable and is its own base identity. Its configured alias is the model namespace. |
+| Request-log provider ID | Canonical base provider ID | Account IDs collapse through `providerBaseId`; legacy aliases resolve through `providerTypeForAlias`. |
+| Token-refresh lookup | Registered provider/account alias | Refresh operates on the provider identity used by the live registry and saved provider connection. |
+| Seed provider row | Catalog/base provider ID with seed marker | Seed rows fill catalog metadata only and must never become live executors. |
+
+## Compatibility rules
+
+- Built-in account IDs such as `qoder_<timestamp>` collapse to `qoder`; the model alias is `qd`.
+- Legacy aliases are explicit compatibility mappings: `opencode` → `opencode_zen`, `cbai` → `codebuddy`, and `claude` → `claude`.
+- Custom UUID providers resolve through their configured alias before built-in provider namespace matching.
+- A model with a recognized provider prefix is matched by the registry, but prefix stripping must leave the model name unchanged after one recognized prefix.
+- Double-prefix input is not normalized speculatively. It is accepted only when the provider's discovered model list contains an equivalent model ID; otherwise it is unknown.
+- Unknown models must fail with the existing descriptive provider-connection error and must not be attributed to an arbitrary provider.
+
+## Required test matrix
+
+| Case | Input | Expected result |
+| --- | --- | --- |
+| Built-in prefixed model | `qoder/ultimate` | Resolves a registered `qoder_<account>` connection. |
+| Built-in alias | `qd/ultimate` | Resolves the same Qoder connection. |
+| Bare model | `ultimate` | Resolves when the registered provider advertises that bare model. |
+| Account-suffixed ID | `qoder_123/ultimate` | Resolves the account and logs canonical provider `qoder`. |
+| Custom provider | `custom-uuid/model` or `alias/model` | Resolves the custom UUID provider; alias wins over built-in namespace collisions. |
+| Legacy alias | `opencode/model` | Maps to `opencode_zen` for canonical attribution. |
+| Double prefix | `qoder/qoder/ultimate` | Only accepted if discovered model data explicitly supports that identity. |
+| Unknown model | `unknown/model` | Throws the existing no-active-provider error. |
+
+## Usage and billing decision for this hardening batch
+
+Credit limits remain soft limits enforced between requests. Usage is charged only from usage data observed on a successful completion; a stream that emits partial output and then fails without usage data is not charged by the current request-finalization path. Hard atomic reservations and billing partial failed streams are separate product decisions and are not introduced here.
+
+## Non-goals
+
+- No public API wire-format change.
+- No automatic rewriting of malformed model IDs.
+- No change to provider catalog membership.
+- No change to pricing data in this contract.

--- a/docs/superpowers/plans/2026-09-08-srouter-reliability-gaps-plan.md
+++ b/docs/superpowers/plans/2026-09-08-srouter-reliability-gaps-plan.md
@@ -1,0 +1,424 @@
+# SRouter Reliability Gaps Hardening Implementation Plan
+
+> For Hermes: use the subagent-driven-development workflow and execute one task at a time. Do not implement this plan in the planning phase.
+
+Goal: Convert `docs/superpowers/specs/2026-09-08-srouter-reliability-gaps-design.md` into independently reviewable hardening work that makes request-attempt, streaming commitment, identity, startup, usage, auth typing, and documentation invariants executable.
+
+Architecture: Preserve the existing route → controller → logic → services/packages flow. Start with contracts and regression fixtures, then make the smallest runtime changes needed by approved tests. Keep chat and image protocol handling separate unless a shared attempt runner has a narrow, proven callback contract. Do not change public wire formats or introduce a global abstraction for unproven future use cases.
+
+Tech stack: Node.js 22+, TypeScript ESM, Hono, `node:test` via `tsx`, pnpm workspaces, native SQLite/PostgreSQL DB clients, existing provider/executor/translator packages.
+
+---
+
+## Scope and sequencing
+
+The work is split into six independently reviewable PRs, matching the specification:
+
+1. Tests and contracts only.
+2. Retry policy and attempt accounting.
+3. Chat fallback lifecycle extraction.
+4. Image fallback alignment.
+5. Startup sequencing and auth facade type hardening.
+6. Documentation cleanup.
+
+Do not combine retry policy, DB/startup changes, and dashboard work. Do not change behavior without a focused regression test and an explicit acceptance criterion.
+
+Priority order inside the first PR:
+
+1. Streaming commitment invariant.
+2. Model/provider identity contract.
+3. Usage and credit accounting fixtures plus product decision.
+4. Upstream attempt counting.
+
+Open product decisions must be recorded before implementation:
+
+- Whether there is one request-level upstream-attempt budget, separate transport/fallback budgets, or intentionally no budget.
+- Whether credit limits are soft, hard/atomic, or advisory.
+- Whether a streamed response that emits output and then errors is billable.
+- Whether startup admin bootstrap and tunnel autostart are required-before-serving or explicit best-effort background work.
+- Whether image fallback uses a generic runner or remains a separate explicit path.
+
+## Repository constraints
+
+- Follow `$HOME/Obsidian/SRouter/RULES.md`, `CODING-STYLE.md`, and `DESIGN.md`.
+- Never run root `pnpm test`, `pnpm build`, `pnpm lint`, or broad Turbo tasks.
+- Build only touched packages/apps.
+- Run only touched API test files with the API `tsx` runner; API tests use concurrency 1.
+- Keep temporary scripts under `/tmp`.
+- Do not change public API wire formats, provider catalog scope, database technology, or dashboard layout.
+- Finish each PR with `git diff --check` and the relevant scoped Prettier check.
+
+---
+
+## PR 1 — Contracts and regression fixtures
+
+### Task 1: Establish the test inventory and test seams
+
+Objective: Identify the smallest existing seams for ChatLogic, ImagesLogic, ProviderRegistry, usage extraction, DB logging, and boot orchestration before adding fixtures.
+
+Files to inspect:
+
+- `apps/api/src/logic/chat.logic.ts`
+- `apps/api/src/logic/images.logic.ts`
+- `apps/api/src/logic/fallback.policy.ts`
+- `apps/api/src/services/registry.ts`
+- `apps/api/src/index.ts`
+- `packages/providers/src/registry.ts`
+- `packages/executors/src/retry.ts`
+- `packages/translator/src/usage.ts`
+- `apps/api/tests/setup.ts`
+- Existing API tests, especially `apps/api/tests/images-route.test.ts`, `apps/api/tests/api-keys-credit-db.test.ts`, and `apps/api/tests/auth-providers.test.ts`
+- `packages/providers/tests/registry.test.ts`
+- Existing executor/translator tests under `packages/*/tests`
+
+Implementation note: Prefer existing dependency injection, fake registry/provider objects, and DB test setup. Do not add a mocking library merely for these tests.
+
+Validation:
+
+```bash
+cd apps/api && pnpm exec tsx --test --test-concurrency=1 --import ./tests/setup.ts tests/images-route.test.ts
+cd packages/providers && pnpm exec tsx --test tests/registry.test.ts
+```
+
+### Task 2: Add streaming commitment regression tests
+
+Objective: Prove that fallback is allowed only before the first client-visible chunk and is forbidden after commitment.
+
+Likely test file: create `apps/api/tests/chat-streaming-fallback.test.ts` if no suitable existing file exists.
+
+Cover these cases with fake providers/executors and observable yielded chunks:
+
+- Async iterator creation throws: next candidate is attempted.
+- Stream throws before any client-visible chunk: next candidate is attempted.
+- Stream yields a client-visible chunk, then throws: original error is terminal; fallback is not attempted.
+- Tool-call chunks are buffered internally, then the stream fails before any client-visible output: fallback remains allowed.
+- Tool-call buffering flushes client-visible output, then fails: fallback is forbidden.
+
+Assert both the returned/yielded behavior and provider invocation order. Keep the test at the ChatLogic boundary rather than testing implementation-local flags.
+
+Run the single file through the API runner and confirm the new tests fail against any incorrect commitment behavior before changing runtime code.
+
+### Task 3: Write the model/provider identity contract
+
+Objective: Make every identity transformation explicit before changing routing or logging code.
+
+Likely documentation file: add `docs/superpowers/contracts/model-provider-identity.md` or place the contract beside the existing specification if repository convention requires it.
+
+The contract must define a table for:
+
+- External `alias/model-name` input.
+- Bare provider model passed to executors.
+- Provider account ID.
+- Canonical/base provider ID stored in request logs.
+- Custom UUID provider plus alias.
+- Legacy aliases.
+- Seed provider rows.
+- Token-refresh lookup identity.
+- Unknown and intentionally double-prefixed input.
+
+For each row specify input, normalization function/location, expected output, and whether the case is supported or rejected. Explicitly preserve the existing invariant that external model IDs are prefixed while executor model IDs are bare.
+
+No runtime behavior change in this task.
+
+### Task 4: Add table-driven identity tests
+
+Objective: Turn the identity contract into executable routing and normalization coverage.
+
+Likely test target: extend `packages/providers/tests/registry.test.ts` and add an API test only where request-log normalization cannot be tested at package level.
+
+Cover:
+
+- Built-in prefixed models.
+- Bare models.
+- Account-suffixed provider IDs.
+- Custom UUID provider with alias.
+- Legacy aliases.
+- Intentional double-prefix compatibility.
+- Unknown models.
+- Request-log provider normalization for an alias/account combination.
+
+Use exact expected values from the contract. Do not “fix” malformed identifiers in tests unless the contract explicitly says they are accepted.
+
+### Task 5: Add usage/accounting fixtures and document the decision
+
+Objective: Make usage extraction and billing semantics testable before changing accounting behavior.
+
+Likely targets:
+
+- Extend the existing API-key credit DB tests.
+- Add a focused usage/logging test under `apps/api/tests/`.
+- Reuse `packages/translator/src/usage.ts` fixtures where possible.
+
+Cover:
+
+- OpenAI usage shape.
+- Anthropic usage shape.
+- Cached, cache-creation, and reasoning tokens.
+- Usage in a final streaming frame.
+- Missing usage.
+- Error after partial streamed output.
+- Concurrent requests against a credit-limited key, with the expected soft/hard/advisory behavior explicitly encoded.
+
+If hard limits are selected, the test must fail until the DB operation provides atomic reservation or equivalent transactional enforcement. If soft limits are selected, assert the documented overshoot behavior rather than pretending the pre-flight check is atomic.
+
+### Task 6: Add upstream attempt-count instrumentation fixtures
+
+Objective: Count transport retries, registry/provider attempts, and ChatLogic fallback attempts independently without changing policy yet.
+
+Likely targets:
+
+- `packages/executors/tests/retry.test.ts` (create if absent).
+- `packages/providers/tests/registry.test.ts`.
+- `apps/api/tests/chat-attempt-count.test.ts` (create if absent).
+
+Use counters around fake fetch/provider executors. Assert that telemetry distinguishes:
+
+- transport retry number;
+- provider/model fallback number;
+- total upstream calls.
+
+Do not silently reduce the current default of three `fetchWithRetry` attempts in this PR.
+
+### PR 1 gate
+
+Run only touched tests and packages. Confirm the new tests describe the current behavior or expose a concrete bug. No broad suite.
+
+---
+
+## PR 2 — Retry policy and request-level attempt accounting
+
+### Task 7: Approve and encode the retry policy
+
+Objective: Convert the product decision into a small typed policy contract.
+
+Likely targets:
+
+- `packages/executors/src/retry.ts`
+- `apps/api/src/logic/chat.logic.ts`
+- `apps/api/src/logic/images.logic.ts`
+- `apps/api/src/services/registry.ts`
+- Provider-specific executors only when the shared contract requires it.
+
+Define whether the budget is:
+
+- one total upstream-attempt limit;
+- separate transport retry and model fallback limits;
+- elapsed-time plus attempt limits;
+- or intentionally unbounded, with telemetry and documentation.
+
+Permanent invalid-request/authentication failures must not consume transient retry attempts. Preserve retry hints and existing transient classification unless a test requires a precise change.
+
+### Task 8: Implement the minimum budget propagation
+
+Objective: Ensure one client request carries one explicit attempt context through fallback and retry layers.
+
+Use a typed options/context object rather than positional arguments. Keep the context internal; do not add public API fields. Ensure recursive tool interception either shares or intentionally resets the budget according to the approved policy, and test that choice.
+
+Add telemetry fields or structured log metadata only where the existing logging path can carry them without changing public response envelopes.
+
+### Task 9: Verify retry multiplication and permanent-error behavior
+
+Objective: Prove deterministic attempt bounds and correct non-retry behavior.
+
+Tests must assert:
+
+- total upstream calls for a request with multiple fallback candidates;
+- transport retries versus model fallback counts;
+- permanent 400/401-style failures do not retry;
+- retryable failures stop at the selected request budget;
+- final error remains attributable to the correct candidate.
+
+Run targeted executor, provider, and API test files only, then build the touched packages.
+
+---
+
+## PR 3 — Chat fallback lifecycle extraction
+
+### Task 10: Capture non-streaming and streaming behavior before refactoring
+
+Objective: Freeze candidate order, token refresh, fallback trigger gating, logging, tool interception, and error semantics with focused tests.
+
+Likely test targets:
+
+- New/extended `apps/api/tests/chat-fallback.test.ts`.
+- Existing streaming tests, if present.
+
+Cover:
+
+- primary success;
+- eligible fallback;
+- skipped fallback due to trigger rules;
+- all-candidates failure;
+- fallback metadata and first-error reason;
+- token refresh per candidate;
+- non-streaming tool interception recursion;
+- streaming tool interception and commitment behavior.
+
+### Task 11: Extract a narrow shared attempt lifecycle
+
+Objective: Remove duplicated candidate lifecycle logic without making the runner protocol-aware.
+
+Likely target: `apps/api/src/logic/chat.logic.ts`; create a small adjacent helper only if the callback contract is clearer outside the class.
+
+The shared runner may own candidate iteration, rule gating, token refresh, attempt tracking, fallback path, and error state. It must not know about chunks, tool calls, usage payloads, stream buffering, or DB logging details.
+
+Keep `ProcessStreamingCompletion` and `ProcessNonStreamingCompletion` signatures unchanged. Preserve the distinction that non-streaming commits on response return, while streaming commits only after a client-visible chunk.
+
+### Task 12: Run focused regression tests and compare errors
+
+Objective: Verify behavior preservation and type safety after extraction.
+
+Run the touched API test files, API build, `git diff --check`, and scoped formatting. Compare TypeScript errors with the pre-refactor baseline; do not reclassify unrelated pre-existing errors as regressions.
+
+---
+
+## PR 4 — Image fallback alignment
+
+### Task 13: Add image fallback behavior tests
+
+Objective: Make image behavior independently executable before deciding whether to share code.
+
+Likely target: create `apps/api/tests/images-fallback.test.ts`; reuse `apps/api/tests/images-route.test.ts` only if its boundary is sufficient.
+
+Cover:
+
+- primary success;
+- eligible fallback;
+- skipped fallback;
+- all-candidates failure;
+- fallback path and reason semantics matching chat;
+- capability validation before provider execution;
+- usage/key accounting behavior for image requests.
+
+### Task 14: Choose and implement the smallest alignment approach
+
+Objective: Apply the approved policy without forcing an abstraction that cannot represent image behavior cleanly.
+
+Options:
+
+- Reuse the chat runner only if its callbacks support image attempts without protocol conditionals.
+- Otherwise retain a separate image loop and align candidate gating, token refresh, tracking, and logging explicitly.
+
+Do not change image public request/response formats. Verify that model capability validation still happens before any provider call.
+
+### Task 15: Verify image-specific regression coverage
+
+Run the focused API image tests and any touched pricing/executor tests. Build only touched packages/apps.
+
+---
+
+## PR 5 — Startup sequencing and auth facade hardening
+
+### Task 16: Classify startup tasks
+
+Objective: Decide which tasks must complete before `serve()` and which are safe background work.
+
+Likely target: `apps/api/src/index.ts`.
+
+Current sequencing to review:
+
+- PostgreSQL `initDatabase()` is awaited.
+- `bootstrapAdminAccountFromEnv()` is fire-and-forget.
+- `autostartTunnelIfEnabled()` is fire-and-forget.
+- `startProviderRegistry()` is awaited.
+
+For each task, document required-before-serving, optional background, or best-effort semantics. Required tasks must be awaited. Optional tasks must attach explicit rejection handling and must not produce unhandled rejections.
+
+### Task 17: Add PostgreSQL boot sequencing coverage
+
+Objective: Prove that no DB-dependent request or startup operation runs before schema initialization.
+
+Likely target: create `apps/api/tests/boot-sequencing.test.ts` using controlled init/bootstrap/tunnel/provider dependencies if the module structure permits. If direct import makes this impractical, extract only a minimal internal boot orchestration function with dependency parameters.
+
+Cover:
+
+- PostgreSQL schema init completes before provider registry startup.
+- Required startup tasks complete before serving.
+- Optional failures are handled explicitly.
+- SQLite path remains unchanged.
+
+Do not run a live PostgreSQL server unless the repository already provides a scoped fixture; a deterministic orchestration test is preferred.
+
+### Task 18: Replace auth facade assertions with narrowed capabilities
+
+Objective: Remove unsafe contract-boundary assertions from the auth provider facade.
+
+Likely target: `apps/api/src/logic/auth.logic.ts`; inspect `apps/api/src/services/authHandlers.ts` and relevant types in `packages/types`.
+
+Model OAuth-capable and import-capable entries as narrowed types. Guard capability presence before invocation. Preserve legacy named adapters and device-flow behavior.
+
+Acceptance checks:
+
+- No `as Promise<...>` remains in the auth facade.
+- OAuth-only, import-only, and device-flow providers retain behavior.
+- `id_token`/`idToken` handling follows the existing canonical wire contract and project type rules.
+
+### Task 19: Run auth and startup verification
+
+Run `apps/api/tests/auth-providers.test.ts` plus new focused tests through the API runner. Build `apps/api`. Check the changed auth and boot files for unsafe assertions and unhandled promises.
+
+---
+
+## PR 6 — Documentation cleanup
+
+### Task 20: Synchronize version and workflow documentation
+
+Objective: Remove confirmed documentation drift without documenting unverified results.
+
+Likely targets:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `AGENTS.md` only if repository-local instructions themselves need correction
+- The reliability specification, if links/status/ownership need updating.
+
+Changes:
+
+- Make the README badge use the project’s actual version source (`0.1.6` currently observed) rather than a stale literal.
+- Replace whole-monorepo verification commands in contributor guidance with touched-package commands consistent with `AGENTS.md` and `$HOME/Obsidian/SRouter/RULES.md`.
+- Check provider and endpoint lists against current routes and catalog code before editing.
+- Do not claim tests/builds passed unless those exact commands were run.
+
+### Task 21: Verify documentation consistency
+
+Run repository-local markdown/format checks only if available and scoped. Use `git diff --check`. Confirm every command in contributor docs is safe under the resource rules and every version/provider/endpoint statement has a current source of truth.
+
+---
+
+## Final verification gate
+
+For each PR:
+
+1. Inspect `git status` and the diff before testing.
+2. Run only the focused test files touched by the PR:
+   `cd apps/api && pnpm exec tsx --test --test-concurrency=1 --import ./tests/setup.ts tests/<focused-file>.test.ts`
+3. Build only touched packages/apps, for example:
+   `cd apps/api && pnpm run build`
+   `cd packages/providers && pnpm run build`
+   `cd packages/executors && pnpm run build`
+4. Run `git diff --check`.
+5. Run the relevant scoped Prettier check; do not run root formatting that rewrites the entire tree.
+6. For any API route behavior change, start the API using the project’s existing local method and smoke-test the mounted `/v1` endpoint with `curl`.
+7. Record exact command results in the PR description; never infer success from a plan or from unrelated tests.
+
+## Definition of done
+
+The hardening effort is complete only when every finding F-01 through F-09 has:
+
+- a classification confirmed;
+- an explicit user-visible behavior decision;
+- a focused regression or contract test;
+- an owning PR/task;
+- an explicit non-goal;
+- scoped verification evidence.
+
+The implementation is not complete merely because the duplicated code was refactored. The attempt budget, stream commitment, identity, usage, startup, auth typing, and documentation contracts must all be executable or explicitly documented as intentionally unchanged.
+
+## Risks and rollback
+
+- Retry budget changes can alter latency, quota usage, and fallback success rates. Roll back policy changes independently from instrumentation.
+- Chat runner extraction can corrupt streaming if commitment is marked too early. Keep commitment tests in the same PR and retain protocol-specific stream handling.
+- Identity normalization changes can fix logs while breaking routing, or vice versa. Land contract tests before mapping changes.
+- Hard credit enforcement may require DB transaction work beyond this batch. If not approved, document soft-limit semantics rather than adding partial locking.
+- Awaiting tunnel/admin startup may increase boot time. Keep optional work explicitly non-blocking if product semantics allow it.
+- Documentation cleanup must not silently alter current behavior; it should describe observed source and verified commands only.

--- a/docs/superpowers/specs/2026-09-08-srouter-reliability-gaps-design.md
+++ b/docs/superpowers/specs/2026-09-08-srouter-reliability-gaps-design.md
@@ -1,0 +1,456 @@
+# SRouter reliability gaps and hardening specification
+
+- **Author**: Seaavey & Hermes
+- **Date**: 2026-09-08
+- **Status**: Proposed
+
+---
+
+## 1. Purpose
+
+This specification records the reliability gaps found during the SRouter codebase review. It is a planning document, not an implementation PR.
+
+The aim is to make the risks concrete enough to prioritize follow-up work. Each finding is classified as one of:
+
+- **Confirmed gap**: visible in the current source or repository state.
+- **Behavior risk**: the design can produce incorrect behavior, but needs a focused regression test to prove the case.
+- **Documentation drift**: the repository documentation describes behavior that no longer matches the current project state.
+
+The first implementation PR should address one finding at a time or one tightly related group. Do not combine retry policy changes, database changes, and dashboard work in one PR.
+
+## 2. Scope
+
+In scope:
+
+- Chat and image fallback behavior.
+- Retry layering and upstream attempt count.
+- Streaming failure semantics.
+- Model and provider identity handling.
+- Database startup ordering.
+- Usage and cost accounting.
+- OAuth provider facade typing.
+- Targeted tests and operational documentation.
+
+Out of scope for the first hardening batch:
+
+- Adding new providers.
+- Changing public API wire formats.
+- Replacing Hono, SQLite, PostgreSQL, or TanStack Query.
+- Redesigning the dashboard.
+- Adding a global queue or distributed rate limiter.
+- Changing fallback behavior without a regression test and explicit acceptance criteria.
+
+## 3. Executive summary
+
+SRouter has a solid provider abstraction and a useful gateway pipeline, but reliability is now limited by complexity at a few central points:
+
+1. Retry and fallback can multiply upstream calls without a request-level budget.
+2. Chat and image fallback loops duplicate lifecycle logic.
+3. Streaming and non-streaming paths have different commitment rules that are easy to break.
+4. Provider/model identity is transformed in several layers and needs a formal contract.
+5. PostgreSQL startup is guarded in `boot()`, but some startup operations are intentionally fire-and-forget.
+6. Authentication facade methods still rely on type assertions.
+7. README and contributor instructions have already drifted from current version and local verification rules.
+
+The highest-value first work is not a broad refactor. It is a small set of regression tests that make these invariants executable.
+
+## 4. Findings ledger
+
+### F-01: Retry multiplication has no request-level budget
+
+- **Classification**: Confirmed gap and behavior risk
+- **Severity**: High
+- **Locations**:
+    - `apps/api/src/logic/chat.logic.ts`
+    - `apps/api/src/logic/images.logic.ts`
+    - `apps/api/src/services/registry.ts`
+    - `packages/executors/src/retry.ts`
+    - provider-specific executors
+
+#### Current behavior
+
+A request can pass through several retry layers:
+
+```text
+ChatLogic fallback candidates
+  → ProviderRegistry candidate retry
+    → executor fetchWithRetry
+      → provider-specific model or credit fallback
+```
+
+`fetchWithRetry` defaults to three upstream attempts. Chat and image logic can then move to another candidate after the executor fails. The registry may also try another registered provider for the same model family.
+
+#### Risk
+
+One client request can generate many upstream requests before returning an error. This can increase latency, consume provider quota, amplify rate limits, and make the final error difficult to attribute to the original attempt.
+
+#### Required decision
+
+Define whether the product wants:
+
+- a maximum upstream attempt count per client request;
+- separate budgets for transport retry and model fallback;
+- a maximum elapsed time;
+- or explicit no-budget behavior with improved telemetry.
+
+Do not implement a budget by silently changing retry counts. The policy must be documented and tested.
+
+#### Acceptance criteria
+
+- A test can count every executor/upstream attempt for one request.
+- The chosen policy has a deterministic upper bound or an explicit documented exception.
+- Permanent errors such as invalid request or invalid credentials do not consume transient retry attempts.
+- Logs expose enough information to distinguish fallback attempts from transport retries.
+
+### F-02: Chat fallback lifecycle is duplicated
+
+- **Classification**: Confirmed gap
+- **Severity**: Medium to High
+- **Location**: `apps/api/src/logic/chat.logic.ts`
+
+#### Current behavior
+
+The non-streaming and streaming methods each implement candidate iteration, token refresh, rule gating, fallback metadata, error tracking, and final failure handling.
+
+The duplication is not only cosmetic. The two paths have already diverged in important ways:
+
+- non-streaming commits a candidate after a response returns;
+- streaming commits a candidate only after the first chunk is yielded;
+- non-streaming logs completion through an awaited path;
+- streaming calls completion logging without awaiting it.
+
+#### Risk
+
+A future fix can update one path and miss the other. Fallback metadata, error status, and token usage can then differ by `stream` mode.
+
+#### Required approach
+
+Extract only the common attempt lifecycle after regression tests exist. Keep protocol-specific response processing in `ChatLogic`.
+
+A shared runner must not know about tool calls, chunks, usage payloads, or database logging.
+
+#### Acceptance criteria
+
+- Existing public method signatures remain unchanged.
+- Candidate order and fallback trigger behavior remain unchanged.
+- Streaming fallback remains possible before the first externally visible chunk only.
+- Tool interception behavior remains unchanged.
+- Targeted streaming and non-streaming tests pass.
+
+### F-03: Streaming output commitment is a hard invariant
+
+- **Classification**: Behavior risk
+- **Severity**: High
+- **Location**: `apps/api/src/logic/chat.logic.ts`
+
+#### Current behavior
+
+The streaming path may switch to a fallback only while `yieldedAny` is false. Once the first chunk has been yielded, an upstream error is terminal.
+
+Tool-call chunks can be buffered, which means an upstream stream may have produced data internally without sending it to the client yet. The implementation must distinguish internal buffering from external commitment.
+
+#### Risk
+
+If a refactor marks a candidate successful when an iterator is created, or when an internal chunk is buffered, SRouter can either:
+
+- fail to fallback when it is still safe; or
+- switch after output was already sent and produce a corrupted mixed response.
+
+#### Acceptance criteria
+
+Tests cover all three states:
+
+1. Iterator creation fails: fallback is allowed.
+2. Stream fails before any client-visible chunk: fallback is allowed.
+3. Stream fails after a client-visible chunk: fallback is forbidden and the original error is terminal.
+
+The test must include a tool-call buffering case so internal buffering is not confused with client-visible output.
+
+### F-04: Image fallback duplicates chat fallback policy
+
+- **Classification**: Confirmed gap
+- **Severity**: Medium
+- **Location**: `apps/api/src/logic/images.logic.ts`
+
+#### Current behavior
+
+Image generation has a separate `ResolveCandidates` implementation and its own fallback state, token refresh, trigger checks, and logging path.
+
+#### Risk
+
+A fallback policy fix applied to chat can remain absent from image generation. Candidate deduplication, trigger matching, fallback path formatting, and terminal error logging can diverge between modalities.
+
+#### Required decision
+
+After the chat lifecycle is stabilized, decide whether the generic runner should support image attempts or whether image fallback should remain a separate explicit path. Do not force both into one abstraction before the callback contract is clear.
+
+#### Acceptance criteria
+
+Regardless of the decision:
+
+- image tests cover primary success, eligible fallback, skipped fallback, and all-candidates failure;
+- fallback metadata has the same documented semantics as chat;
+- model capability validation remains before provider execution.
+
+### F-05: Model and provider identity transformations need a formal contract
+
+- **Classification**: Confirmed gap
+- **Severity**: High
+- **Locations**:
+    - `packages/providers/src/registry.ts`
+    - `apps/api/src/logic/chat.logic.ts`
+    - `apps/api/src/logic/images.logic.ts`
+    - `apps/api/src/logic/models.logic.ts`
+    - `apps/api/src/services/tokenRefresh.ts`
+    - `packages/db` request log mapping
+
+#### Current behavior
+
+The system uses several related identities:
+
+- external model ID such as `alias/model-name`;
+- bare provider model name;
+- account-specific provider ID;
+- canonical provider base ID;
+- legacy aliases;
+- custom model IDs;
+- seed provider rows.
+
+The chat path derives a provider ID from the prefix of the current model, while request logging separately normalizes provider identity.
+
+#### Risk
+
+A model can route correctly while being logged under the wrong provider, or a fallback can lose its prefix. Multi-account providers and custom models make these failures difficult to detect from the UI.
+
+#### Required deliverable
+
+Write a model identity contract before changing the mapping code. It must define:
+
+- which form is accepted at every public route;
+- which form the registry expects;
+- which form executors receive;
+- which form token refresh receives;
+- which form request logs store;
+- how account IDs collapse to base provider IDs;
+- how custom models and legacy aliases behave.
+
+#### Acceptance criteria
+
+A table-driven test covers:
+
+- built-in prefixed models;
+- bare models;
+- account-suffixed provider IDs;
+- custom models;
+- legacy aliases;
+- double-prefix input where compatibility is intentional;
+- unknown models.
+
+### F-06: PostgreSQL startup sequencing is only partially awaited
+
+- **Classification**: Confirmed gap
+- **Severity**: High for PostgreSQL deployments
+- **Location**: `apps/api/src/index.ts`
+
+#### Current behavior
+
+`boot()` awaits PostgreSQL database initialization before starting the provider registry. It then launches admin bootstrap and tunnel autostart with `void` instead of awaiting them:
+
+```text
+await initDatabase()
+void bootstrapAdminAccountFromEnv(...)
+void autostartTunnelIfEnabled()
+await startProviderRegistry()
+serve(...)
+```
+
+#### Risk
+
+The server can begin serving requests while admin bootstrap or tunnel restoration is still running. Failures can become unhandled or appear only in logs. The state visible immediately after startup may depend on timing.
+
+This is less severe than querying before schema initialization, which is already guarded, but it still makes startup state nondeterministic.
+
+#### Required decision
+
+Classify each startup task as one of:
+
+- required before serving and therefore awaited;
+- optional background work with explicit error handling;
+- best-effort work that must not block startup.
+
+#### Acceptance criteria
+
+- PostgreSQL boot test proves no request reaches a DB-dependent route before schema init.
+- Required startup tasks are awaited.
+- Optional tasks attach explicit error handling and do not create unhandled rejections.
+- SQLite startup behavior remains unchanged.
+
+### F-07: Usage and cost accounting needs a concurrency contract
+
+- **Classification**: Behavior risk
+- **Severity**: High for quota and credit enforcement
+- **Locations**:
+    - `apps/api/src/logic/chat.logic.ts`
+    - `packages/db/src/apiKeys.ts`
+    - `packages/translator/src/usage.ts`
+    - `packages/pricing`
+
+#### Current behavior
+
+Successful completions extract usage, estimate cost, log the request, and increment virtual API key usage. The request path can be streaming or non-streaming, and provider usage payloads differ.
+
+#### Risk
+
+Concurrent requests using the same key can pass the pre-flight balance check before either request writes usage. The final balance can exceed the configured credit limit. This may be acceptable for soft limits, but it must be an explicit product decision.
+
+There is also a consistency question when a provider returns no usage data, returns usage only in a final stream frame, or fails after partial output.
+
+#### Required decision
+
+Define whether credit limits are:
+
+- soft limits, enforced between requests;
+- hard limits requiring an atomic reservation or transaction;
+- or advisory telemetry only.
+
+Define how missing usage is recorded and whether a streamed response that errors after output is billable.
+
+#### Acceptance criteria
+
+Tests cover:
+
+- OpenAI usage shape;
+- Anthropic usage shape;
+- cached and reasoning token fields;
+- stream usage in the final frame;
+- missing usage;
+- concurrent requests against a credit-limited key;
+- error after partial streamed output.
+
+### F-08: Auth provider facade still uses unsafe assertions
+
+- **Classification**: Confirmed gap
+- **Severity**: Medium
+- **Location**: `apps/api/src/logic/auth.logic.ts`
+
+#### Current behavior
+
+The provider entry facade uses assertions such as:
+
+```typescript
+entry.initiate(params) as Promise<OAuthLoginResult>;
+entry.importToken(params) as Promise<ProviderConfig>;
+```
+
+The project type-safety rules prohibit this style at contract boundaries.
+
+#### Risk
+
+The registry can return an entry whose capability does not match the requested operation, and the assertion hides that mismatch from TypeScript.
+
+#### Required approach
+
+Model OAuth-capable and import-capable entries as narrowed types. Check capability presence before calling. Keep legacy named adapters working.
+
+#### Acceptance criteria
+
+- No `as Promise<...>` assertions remain in the auth provider facade.
+- OAuth-only, import-only, and device-flow providers retain their current behavior.
+- Existing auth tests pass.
+
+### F-09: Documentation has version and workflow drift
+
+- **Classification**: Confirmed documentation drift
+- **Severity**: Medium
+- **Locations**:
+    - `README.md`
+    - `CONTRIBUTING.md`
+    - `package.json`
+    - `AGENTS.md`
+    - `$HOME/Obsidian/SRouter/RULES.md`
+
+#### Current behavior
+
+The root package is version `0.1.6`, while the README badge still shows `v0.1.4`. Contributor instructions recommend whole-monorepo tests and builds, while repository engineering rules explicitly prohibit those commands because of resource limits.
+
+#### Risk
+
+Contributors receive conflicting instructions and can run expensive or unsafe commands. The README version badge also misrepresents the checked-out release state.
+
+#### Acceptance criteria
+
+- README badge matches the source of truth used by the project.
+- Contributor verification commands are scoped to touched packages.
+- Documentation does not claim a check passed unless the check was actually run.
+- Provider and endpoint lists are checked against the current route and catalog implementation.
+
+## 5. Prioritization
+
+### P0: protect request correctness
+
+1. F-03 streaming commitment tests.
+2. F-05 model/provider identity contract and tests.
+3. F-07 usage and credit concurrency decision.
+4. F-01 retry attempt counting and policy decision.
+
+### P1: reduce divergence
+
+5. F-02 shared chat fallback lifecycle.
+6. F-04 image fallback alignment.
+7. F-06 startup task classification and PostgreSQL boot test.
+
+### P2: maintenance
+
+8. F-08 auth facade type cleanup.
+9. F-09 documentation cleanup.
+
+## 6. Proposed PR sequence
+
+### PR 1: tests and contracts only
+
+Add the model identity table, streaming commitment tests, upstream attempt-count instrumentation, and usage accounting fixtures. No runtime behavior change unless a test exposes an unambiguous bug.
+
+### PR 2: retry policy
+
+Implement the explicitly approved retry budget or document the chosen bounded behavior. Add telemetry for transport retry versus model fallback.
+
+### PR 3: chat fallback lifecycle
+
+Extract the duplicated chat attempt lifecycle while preserving streaming commitment rules and public signatures.
+
+### PR 4: image fallback alignment
+
+Reuse the approved lifecycle where it fits, or document why image generation keeps a separate path. Add modality-specific tests.
+
+### PR 5: startup and auth hardening
+
+Await required startup tasks, handle optional startup failures, and replace auth facade assertions with narrowed entry types.
+
+### PR 6: documentation cleanup
+
+Synchronize README and contributor verification commands with the actual repository rules.
+
+Each PR should remain independently reviewable and revertible.
+
+## 7. Verification gate
+
+The work must follow the repository resource rules:
+
+- Do not run root `pnpm test`, root `pnpm build`, root `pnpm lint`, or broad Turbo tasks.
+- Build only touched packages.
+- Run only the touched API test files through the API `tsx` runner.
+- For API route behavior changes, smoke-test the mounted `/v1` route against a running instance.
+- Compare TypeScript error sets when refactoring existing code. Pre-existing errors do not become regressions merely because the total count is nonzero.
+- Run `git diff --check` and the relevant Prettier check before opening a PR.
+
+## 8. Definition of done for this specification
+
+This specification is complete when the team can answer, for every finding:
+
+1. Is it a confirmed bug, a behavior risk, or documentation drift?
+2. What exact behavior should users observe after the fix?
+3. What test proves the behavior?
+4. Which PR owns the change?
+5. What is explicitly not being changed?
+
+No implementation should begin from this document without selecting a finding and converting its acceptance criteria into a focused implementation plan.

--- a/packages/executors/src/anthropic.ts
+++ b/packages/executors/src/anthropic.ts
@@ -5,7 +5,8 @@ import type {
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
-    ModelObject
+    ModelObject,
+    RequestAttemptBudget
 } from "@srouter/types";
 import {
     AnthropicEventToOpenAIChunk,
@@ -13,6 +14,7 @@ import {
     OpenAIToAnthropicRequest
 } from "@srouter/translator";
 import { parseDataLine, streamLines } from "./base.js";
+import { FetchWithBudget } from "./retry.js";
 
 export interface AnthropicExecutorOptions {
     id?: string;
@@ -159,7 +161,10 @@ export class AnthropicExecutor implements AIProvider {
         }
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         const anthropicReq = OpenAIToAnthropicRequest(req);
         anthropicReq.stream = false;
         const targetModel = req.model.includes("/")
@@ -167,11 +172,15 @@ export class AnthropicExecutor implements AIProvider {
             : req.model;
         anthropicReq.model = targetModel;
 
-        const res = await fetch(`${this.baseUrl}/messages`, {
-            method: "POST",
-            headers: this.getHeaders(targetModel, false),
-            body: JSON.stringify(anthropicReq)
-        });
+        const res = await FetchWithBudget(
+            `${this.baseUrl}/messages`,
+            {
+                method: "POST",
+                headers: this.getHeaders(targetModel, false),
+                body: JSON.stringify(anthropicReq)
+            },
+            budget
+        );
 
         if (!res.ok) {
             const errorText = await res.text();
@@ -183,7 +192,8 @@ export class AnthropicExecutor implements AIProvider {
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const anthropicReq = OpenAIToAnthropicRequest(req);
         anthropicReq.stream = true;
@@ -192,11 +202,15 @@ export class AnthropicExecutor implements AIProvider {
             : req.model;
         anthropicReq.model = targetModel;
 
-        const res = await fetch(`${this.baseUrl}/messages`, {
-            method: "POST",
-            headers: this.getHeaders(targetModel, true),
-            body: JSON.stringify(anthropicReq)
-        });
+        const res = await FetchWithBudget(
+            `${this.baseUrl}/messages`,
+            {
+                method: "POST",
+                headers: this.getHeaders(targetModel, true),
+                body: JSON.stringify(anthropicReq)
+            },
+            budget
+        );
 
         if (!res.ok) {
             const errorText = await res.text();

--- a/packages/executors/src/antigravity.ts
+++ b/packages/executors/src/antigravity.ts
@@ -8,7 +8,8 @@ import type {
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
-    ModelObject
+    ModelObject,
+    RequestAttemptBudget
 } from "@srouter/types";
 import {
     ANTIGRAVITY_IDE_USER_AGENT,
@@ -305,31 +306,35 @@ export class AntigravityExecutor implements AIProvider {
         return this.projectId;
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         const isLocalProxy = this.isLocalProxy();
         const isApiKey = this.isApiKey();
 
         // 1. OpenAI-compatible fallback
         if (isLocalProxy || (isApiKey && this.baseUrl.includes("/openai"))) {
-            return await this.openaiFallback.chatCompletion(req);
+            return await this.openaiFallback.chatCompletion(req, budget);
         }
 
         // 2. Native Antigravity — accumulate stream for non-streaming callers
         const chunks: ChatCompletionChunk[] = [];
-        for await (const chunk of this.chatCompletionStream(req)) {
+        for await (const chunk of this.chatCompletionStream(req, budget)) {
             chunks.push(chunk);
         }
         return accumulateChunks(chunks, req.model);
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const isLocalProxy = this.isLocalProxy();
         const isApiKey = this.isApiKey();
 
         if (isLocalProxy || (isApiKey && this.baseUrl.includes("/openai"))) {
-            yield* this.openaiFallback.chatCompletionStream(req);
+            yield* this.openaiFallback.chatCompletionStream(req, budget);
             return;
         }
 
@@ -341,7 +346,7 @@ export class AntigravityExecutor implements AIProvider {
         for (let i = 0; i < modelFallbacks.length; i++) {
             const candidateModel = modelFallbacks[i] ?? req.model;
             try {
-                yield* this.streamCandidateWithCreditRetry(candidateModel, req);
+                yield* this.streamCandidateWithCreditRetry(candidateModel, req, budget);
                 return;
             } catch (err: unknown) {
                 lastError = err instanceof Error ? err : new Error(String(err));
@@ -359,7 +364,8 @@ export class AntigravityExecutor implements AIProvider {
 
     private async *streamCandidateWithCreditRetry(
         model: string,
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const useCreditsFirst =
             this.creditsMode === "always" ||
@@ -369,7 +375,7 @@ export class AntigravityExecutor implements AIProvider {
         let creditsRetryAttempted = Boolean(useCreditsFirst);
 
         try {
-            yield* this.executeStreamAttempt(model, req, currentCreditTypes);
+            yield* this.executeStreamAttempt(model, req, currentCreditTypes, budget);
         } catch (err: unknown) {
             const errStr = err instanceof Error ? err.message : String(err);
             const is429 = errStr.includes("(429)");
@@ -387,7 +393,7 @@ export class AntigravityExecutor implements AIProvider {
             if (shouldRetryCredits) {
                 creditsRetryAttempted = true;
                 currentCreditTypes = ["GOOGLE_ONE_AI"];
-                yield* this.executeStreamAttempt(model, req, currentCreditTypes);
+                yield* this.executeStreamAttempt(model, req, currentCreditTypes, budget);
                 return;
             }
 
@@ -398,11 +404,12 @@ export class AntigravityExecutor implements AIProvider {
     private async *executeStreamAttempt(
         model: string,
         req: ChatCompletionRequest,
-        enabledCreditTypes?: string[]
+        enabledCreditTypes?: string[],
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const { url, body } = await this.buildRequest(model, req, true, enabledCreditTypes);
         const streamUrl = url.includes("?") ? url : `${url}?alt=sse`;
-        const res = await fetchWithRetry(streamUrl, body, this.getHeaders());
+        const res = await fetchWithRetry(streamUrl, body, this.getHeaders(), 3, budget);
 
         if (!res.ok) {
             const errorText = await res.text();

--- a/packages/executors/src/codebuddy.ts
+++ b/packages/executors/src/codebuddy.ts
@@ -5,9 +5,11 @@ import type {
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
-    ModelObject
+    ModelObject,
+    RequestAttemptBudget
 } from "@srouter/types";
 import { parseDataLine, streamLines } from "./base.js";
+import { FetchWithBudget } from "./retry.js";
 
 function stripProviderPrefix(model: string): string {
     const slash = model.indexOf("/");
@@ -104,7 +106,11 @@ export class CodeBuddyExecutor implements AIProvider {
         const source = Array.isArray(req.messages) ? req.messages : [];
         const systemPrompts: string[] = [];
         for (const m of source) {
-            if (m && typeof m === "object" && ["system", "developer"].includes((m as { role?: string }).role ?? "")) {
+            if (
+                m &&
+                typeof m === "object" &&
+                ["system", "developer"].includes((m as { role?: string }).role ?? "")
+            ) {
                 const content = (m as { content?: unknown }).content;
                 if (typeof content === "string" && content.trim()) {
                     systemPrompts.push(content.trim());
@@ -112,9 +118,10 @@ export class CodeBuddyExecutor implements AIProvider {
             }
         }
 
-        const combinedSystem = systemPrompts.length > 0
-            ? `You are CodeBuddy Code.\n\n${systemPrompts.join("\n\n")}`
-            : "You are CodeBuddy Code.";
+        const combinedSystem =
+            systemPrompts.length > 0
+                ? `You are CodeBuddy Code.\n\n${systemPrompts.join("\n\n")}`
+                : "You are CodeBuddy Code.";
 
         const messages: unknown[] = [{ role: "system", content: combinedSystem }];
 
@@ -153,7 +160,8 @@ export class CodeBuddyExecutor implements AIProvider {
             delete transformed.response_format;
             let directive = rf.type === "json_object" ? "Respond only in valid JSON." : "";
             if (rf.type === "json_schema") {
-                const schemaObj = (rf.json_schema as { schema?: unknown } | undefined)?.schema ?? rf.json_schema;
+                const schemaObj =
+                    (rf.json_schema as { schema?: unknown } | undefined)?.schema ?? rf.json_schema;
                 if (schemaObj) {
                     directive =
                         `You must respond with valid JSON matching this schema:\n` +
@@ -168,7 +176,10 @@ export class CodeBuddyExecutor implements AIProvider {
                         const parts = content as { type?: string; text?: string }[];
                         for (let j = parts.length - 1; j >= 0; j--) {
                             if (parts[j]?.type === "text" && typeof parts[j].text === "string") {
-                                parts[j] = { type: "text", text: `${parts[j].text}\n\n${directive}` };
+                                parts[j] = {
+                                    type: "text",
+                                    text: `${parts[j].text}\n\n${directive}`
+                                };
                                 break;
                             }
                         }
@@ -191,25 +202,33 @@ export class CodeBuddyExecutor implements AIProvider {
         }));
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         // CodeBuddy upstream is stream-only (forceStream). Run the stream and
         // accumulate the final response for non-streaming callers.
         const chunks: ChatCompletionChunk[] = [];
-        for await (const chunk of this.chatCompletionStream(req)) {
+        for await (const chunk of this.chatCompletionStream(req, budget)) {
             chunks.push(chunk);
         }
         return accumulateChunks(chunks, req.model);
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const body = this.transformRequestBody(req);
-        const res = await fetch(this.getChatUrl(), {
-            method: "POST",
-            headers: this.getHeaders(),
-            body: JSON.stringify(body)
-        });
+        const res = await FetchWithBudget(
+            this.getChatUrl(),
+            {
+                method: "POST",
+                headers: this.getHeaders(),
+                body: JSON.stringify(body)
+            },
+            budget
+        );
 
         if (!res.ok) {
             const errorText = await res.text();

--- a/packages/executors/src/codex.ts
+++ b/packages/executors/src/codex.ts
@@ -3,7 +3,8 @@ import type {
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
-    ModelObject
+    ModelObject,
+    RequestAttemptBudget
 } from "@srouter/types";
 import { CODEX_BASE_URL, CODEX_MODELS_URL } from "@srouter/constants";
 import {
@@ -18,6 +19,7 @@ import {
 } from "@srouter/translator";
 import { parseDataLine, streamLines } from "./base.js";
 import { extractSseErrorMessage, MODEL_CAPACITY_MESSAGE } from "./sse.js";
+import { FetchWithBudget } from "./retry.js";
 
 export interface CodexExecutorOptions {
     id?: string;
@@ -171,17 +173,21 @@ export class CodexExecutor implements AIProvider {
         }
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         // Codex upstream is streaming-only — accumulate the stream for non-streaming callers
         const chunks: ChatCompletionChunk[] = [];
-        for await (const chunk of this.chatCompletionStream(req)) {
+        for await (const chunk of this.chatCompletionStream(req, budget)) {
             chunks.push(chunk);
         }
         return accumulateChunks(chunks, req.model);
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const body = this.transformRequest(req);
         this._currentSessionId = this.sessionId || body.prompt_cache_key || null;
@@ -191,11 +197,15 @@ export class CodexExecutor implements AIProvider {
         const maxAttempts = 2;
 
         while (true) {
-            const res = await fetch(this.baseUrl, {
-                method: "POST",
-                headers: this.getHeaders(),
-                body: JSON.stringify(body)
-            });
+            const res = await FetchWithBudget(
+                this.baseUrl,
+                {
+                    method: "POST",
+                    headers: this.getHeaders(),
+                    body: JSON.stringify(body)
+                },
+                budget
+            );
 
             // Non-OK — surface error immediately
             if (!res.ok) {

--- a/packages/executors/src/commandcode.ts
+++ b/packages/executors/src/commandcode.ts
@@ -6,7 +6,8 @@ import type {
     ChatCompletionRequest,
     ChatCompletionResponse,
     ModelListResponse,
-    ModelObject
+    ModelObject,
+    RequestAttemptBudget
 } from "@srouter/types";
 import {
     accumulateChunks,
@@ -16,6 +17,7 @@ import {
     type CommandCodeEvent
 } from "@srouter/translator";
 import { parseDataLine, streamLines } from "./base.js";
+import { FetchWithBudget } from "./retry.js";
 
 export interface CommandCodeExecutorOptions {
     id?: string;
@@ -94,25 +96,33 @@ export class CommandCodeExecutor implements AIProvider {
         }
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         // CommandCode upstream is streaming-only (forceStream). Run the stream and
         // accumulate the final response for non-streaming callers.
         const chunks: ChatCompletionChunk[] = [];
-        for await (const chunk of this.chatCompletionStream(req)) {
+        for await (const chunk of this.chatCompletionStream(req, budget)) {
             chunks.push(chunk);
         }
         return accumulateChunks(chunks, req.model);
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const body = buildRequestBody(req);
-        const res = await fetch(this.baseUrl, {
-            method: "POST",
-            headers: this.getHeaders(),
-            body: JSON.stringify(body)
-        });
+        const res = await FetchWithBudget(
+            this.baseUrl,
+            {
+                method: "POST",
+                headers: this.getHeaders(),
+                body: JSON.stringify(body)
+            },
+            budget
+        );
 
         if (!res.ok) {
             const errorText = await res.text();

--- a/packages/executors/src/kiro.ts
+++ b/packages/executors/src/kiro.ts
@@ -5,9 +5,11 @@ import type {
     ChatCompletionRequest,
     ChatCompletionResponse,
     ModelObject,
-    ToolDefinition
+    ToolDefinition,
+    RequestAttemptBudget
 } from "@srouter/types";
 import { iterEventStreamFrames } from "./stream-utils.js";
+import { FetchWithBudget } from "./retry.js";
 
 const RUNTIME_URL = "https://runtime.us-east-1.kiro.dev/generateAssistantResponse";
 const CODEWHISPERER_URL = "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse";
@@ -365,9 +367,12 @@ export class KiroExecutor implements AIProvider {
         return [];
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         const chunks: ChatCompletionChunk[] = [];
-        for await (const value of this.chatCompletionStream(req)) chunks.push(value);
+        for await (const value of this.chatCompletionStream(req, budget)) chunks.push(value);
         const text = chunks.map((value) => value.choices[0]?.delta.content ?? "").join("");
         const toolCalls = chunks.flatMap((value) => value.choices[0]?.delta.tool_calls ?? []);
         return {
@@ -401,18 +406,23 @@ export class KiroExecutor implements AIProvider {
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const body = this.buildRequest(req);
         let response: Response | undefined;
         let lastError = "";
         for (const url of this.getOrderedBaseUrls()) {
             try {
-                response = await fetch(url, {
-                    method: "POST",
-                    headers: this.headers(url),
-                    body: JSON.stringify(body)
-                });
+                response = await FetchWithBudget(
+                    url,
+                    {
+                        method: "POST",
+                        headers: this.headers(url),
+                        body: JSON.stringify(body)
+                    },
+                    budget
+                );
                 if (
                     response.ok ||
                     ![401, 403, 404, 429, 500, 502, 503, 504].includes(response.status)

--- a/packages/executors/src/openai.ts
+++ b/packages/executors/src/openai.ts
@@ -7,7 +7,8 @@ import type {
     ImageGenerationRequest,
     ImageGenerationResponse,
     ModelListResponse,
-    ModelObject
+    ModelObject,
+    RequestAttemptBudget
 } from "@srouter/types";
 import { parseDataLine, streamLines } from "./base.js";
 import { fetchWithRetry } from "./retry.js";
@@ -94,13 +95,18 @@ export class OpenAIExecutor implements AIProvider {
         }
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         const targetModel = stripProviderPrefix(req.model);
 
         const res = await fetchWithRetry(
             `${this.baseUrl}/chat/completions`,
             { ...req, model: targetModel, stream: false },
-            this.getHeaders()
+            this.getHeaders(),
+            3,
+            budget
         );
 
         if (!res.ok) {
@@ -112,7 +118,8 @@ export class OpenAIExecutor implements AIProvider {
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const targetModel = stripProviderPrefix(req.model);
 
@@ -127,7 +134,9 @@ export class OpenAIExecutor implements AIProvider {
                     include_usage: true
                 }
             },
-            this.getHeaders("text/event-stream, application/json, */*")
+            this.getHeaders("text/event-stream, application/json, */*"),
+            3,
+            budget
         );
 
         if (!res.ok) {
@@ -151,16 +160,20 @@ export class OpenAIExecutor implements AIProvider {
         }
     }
 
-    async generateImage(req: ImageGenerationRequest): Promise<ImageGenerationResponse> {
+    async generateImage(
+        req: ImageGenerationRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ImageGenerationResponse> {
         const targetModel = stripProviderPrefix(req.model);
         const payload = { ...req, model: targetModel };
 
         // If img2img parameters (image or mask) are provided, upstream may route to /images/edits
-        const endpoint = req.image || req.images || req.mask
-            ? `${this.baseUrl}/images/edits`
-            : `${this.baseUrl}/images/generations`;
+        const endpoint =
+            req.image || req.images || req.mask
+                ? `${this.baseUrl}/images/edits`
+                : `${this.baseUrl}/images/generations`;
 
-        const res = await fetchWithRetry(endpoint, payload, this.getHeaders());
+        const res = await fetchWithRetry(endpoint, payload, this.getHeaders(), 3, budget);
 
         if (!res.ok) {
             const errorText = await res.text();

--- a/packages/executors/src/qoder.ts
+++ b/packages/executors/src/qoder.ts
@@ -20,9 +20,11 @@ import type {
     ChatCompletionChunk,
     ChatCompletionRequest,
     ChatCompletionResponse,
-    ModelObject
+    ModelObject,
+    RequestAttemptBudget
 } from "@srouter/types";
 import { parseDataLine, streamLines } from "./base.js";
+import { FetchWithBudget } from "./retry.js";
 
 /**
  * ============================================================================
@@ -635,7 +637,8 @@ export class QoderExecutor implements AIProvider {
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
         const creds = await this.resolveCredentials();
         if (!creds.accessToken) {
@@ -667,11 +670,15 @@ export class QoderExecutor implements AIProvider {
             ...cosyHeaders
         };
 
-        const res = await fetch(url, {
-            method: "POST",
-            headers,
-            body: encodedBodyBuf
-        });
+        const res = await FetchWithBudget(
+            url,
+            {
+                method: "POST",
+                headers,
+                body: encodedBodyBuf
+            },
+            budget
+        );
 
         if (!res.ok) {
             const errorText = await res.text();
@@ -725,7 +732,10 @@ export class QoderExecutor implements AIProvider {
         }
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
         let content = "";
         let role = "assistant";
         let model = req.model;
@@ -734,7 +744,7 @@ export class QoderExecutor implements AIProvider {
             ChatCompletionResponse["choices"][number]["message"]["tool_calls"]
         > = [];
 
-        for await (const chunk of this.chatCompletionStream(req)) {
+        for await (const chunk of this.chatCompletionStream(req, budget)) {
             if (chunk.id) id = chunk.id;
             if (chunk.model) model = chunk.model;
             const choice = chunk.choices?.[0];

--- a/packages/executors/src/retry.ts
+++ b/packages/executors/src/retry.ts
@@ -152,3 +152,12 @@ export async function fetchWithRetry(
         lastResponse ?? new Response(null, { status: 503, statusText: "Retry attempts exhausted" })
     );
 }
+
+export async function FetchWithBudget(
+    input: string | URL,
+    init: RequestInit,
+    budget?: RequestAttemptBudget
+): Promise<Response> {
+    budget?.consume();
+    return fetch(input, init);
+}

--- a/packages/executors/src/retry.ts
+++ b/packages/executors/src/retry.ts
@@ -1,4 +1,5 @@
 // Shared retry/backoff helpers for upstream providers with transient errors.
+import type { RequestAttemptBudget } from "@srouter/types";
 
 const MAX_RETRY_AFTER_MS = 10000;
 const TRANSIENT_RETRY_MAX_MS = 15000;
@@ -121,14 +122,24 @@ export async function fetchWithRetry(
     url: string,
     body: Record<string, unknown>,
     headers: Record<string, string>,
-    maxAttempts = 3
+    maxAttempts = 3,
+    budget?: RequestAttemptBudget
 ): Promise<Response> {
+    let lastResponse: Response | undefined;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (budget && budget.remaining <= 0) {
+            return (
+                lastResponse ??
+                new Response(null, { status: 503, statusText: "Retry budget exhausted" })
+            );
+        }
+        budget?.consume();
         const res = await fetch(url, {
             method: "POST",
             headers,
             body: JSON.stringify(body)
         });
+        lastResponse = res;
 
         if (res.ok) return res;
 
@@ -137,10 +148,7 @@ export async function fetchWithRetry(
 
         await new Promise((r) => setTimeout(r, retryMs));
     }
-    // Last attempt returns as-is
-    return fetch(url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(body)
-    });
+    return (
+        lastResponse ?? new Response(null, { status: 503, statusText: "Retry attempts exhausted" })
+    );
 }

--- a/packages/executors/tests/retry.test.ts
+++ b/packages/executors/tests/retry.test.ts
@@ -56,4 +56,5 @@ test("fetchWithRetry stops at the request-level attempt budget", async () => {
     assert.equal(calls, 2);
     assert.equal(budget.used, 2);
     assert.equal(budget.remaining, 0);
+    assert.equal(budget.transportAttempts, 2);
 });

--- a/packages/executors/tests/retry.test.ts
+++ b/packages/executors/tests/retry.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { fetchWithRetry } from "../src/retry.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test("fetchWithRetry does not retry permanent client errors", async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ error: { message: "invalid request" } }), {
+            status: 400,
+            headers: { "content-type": "application/json" }
+        });
+    };
+
+    const response = await fetchWithRetry("https://upstream.test/chat", {}, {}, 3);
+
+    assert.equal(response.status, 400);
+    assert.equal(calls, 1);
+});
+
+test("fetchWithRetry counts transient transport attempts separately from fallback attempts", async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ error: { message: "temporarily unavailable" } }), {
+            status: 503,
+            headers: { "content-type": "application/json" }
+        });
+    };
+
+    const response = await fetchWithRetry("https://upstream.test/chat", {}, {}, 2);
+
+    assert.equal(response.status, 503);
+    assert.equal(calls, 3);
+});

--- a/packages/executors/tests/retry.test.ts
+++ b/packages/executors/tests/retry.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
+import { CreateRequestAttemptBudget } from "@srouter/types";
 import { fetchWithRetry } from "../src/retry.js";
 
 const originalFetch = globalThis.fetch;
@@ -35,7 +36,24 @@ test("fetchWithRetry counts transient transport attempts separately from fallbac
     };
 
     const response = await fetchWithRetry("https://upstream.test/chat", {}, {}, 2);
-
     assert.equal(response.status, 503);
-    assert.equal(calls, 3);
+    assert.equal(calls, 2);
+});
+
+test("fetchWithRetry stops at the request-level attempt budget", async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ error: { message: "temporarily unavailable" } }), {
+            status: 503,
+            headers: { "content-type": "application/json" }
+        });
+    };
+
+    const budget = CreateRequestAttemptBudget(2);
+    const response = await fetchWithRetry("https://upstream.test/chat", {}, {}, 3, budget);
+    assert.equal(response.status, 503);
+    assert.equal(calls, 2);
+    assert.equal(budget.used, 2);
+    assert.equal(budget.remaining, 0);
 });

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -15,7 +15,6 @@ import type {
     ProviderDefinition,
     RequestAttemptBudget
 } from "@srouter/types";
-import { GetRequestAttemptBudget } from "@srouter/types";
 import { CircuitBreaker, circuitBreaker as defaultCircuitBreaker } from "./circuitBreaker.js";
 
 export function getProviderAlias(providerId: string): string {
@@ -523,13 +522,14 @@ export class ProviderRegistry {
         req: ChatCompletionRequest,
         budget?: RequestAttemptBudget
     ): Promise<ChatCompletionResponse> {
-        const requestBudget = budget ?? GetRequestAttemptBudget(req);
+        const requestBudget = budget;
         const candidates = await this.getCandidateProvidersForModel(req.model);
         let lastError: unknown = null;
 
         for (let i = 0; i < candidates.length; i++) {
             const candidate = candidates[i]!;
             try {
+                requestBudget?.recordProviderAttempt();
                 const response = await candidate.chatCompletion(req, requestBudget);
                 this.circuitBreaker.recordSuccess(candidate.id);
                 return response;
@@ -549,7 +549,7 @@ export class ProviderRegistry {
         req: ChatCompletionRequest,
         budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
-        const requestBudget = budget ?? GetRequestAttemptBudget(req);
+        const requestBudget = budget;
         const candidates = await this.getCandidateProvidersForModel(req.model);
         let lastError: unknown = null;
 
@@ -557,6 +557,7 @@ export class ProviderRegistry {
             const candidate = candidates[i]!;
             let yieldedAny = false;
             try {
+                requestBudget?.recordProviderAttempt();
                 const stream = candidate.chatCompletionStream(req, requestBudget);
                 for await (const chunk of stream) {
                     if (!yieldedAny) {
@@ -593,6 +594,7 @@ export class ProviderRegistry {
                 continue;
             }
             try {
+                budget?.recordProviderAttempt();
                 const response = await candidate.generateImage(req, budget);
                 this.circuitBreaker.recordSuccess(candidate.id);
                 return response;

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -12,8 +12,10 @@ import type {
     ImageGenerationRequest,
     ImageGenerationResponse,
     ModelObject,
-    ProviderDefinition
+    ProviderDefinition,
+    RequestAttemptBudget
 } from "@srouter/types";
+import { GetRequestAttemptBudget } from "@srouter/types";
 import { CircuitBreaker, circuitBreaker as defaultCircuitBreaker } from "./circuitBreaker.js";
 
 export function getProviderAlias(providerId: string): string {
@@ -394,8 +396,7 @@ export class ProviderRegistry {
             } else {
                 // Fallback: derived alias (via constants catalog) or base ID matching
                 const derivedAlias = Array.from(this.providers.values()).find(
-                    (provider) =>
-                        provider.id !== "default" && providerAliasFor(provider) === prefix
+                    (provider) => provider.id !== "default" && providerAliasFor(provider) === prefix
                 );
                 if (derivedAlias) {
                     candidates.push(derivedAlias);
@@ -518,14 +519,18 @@ export class ProviderRegistry {
         // again. The loop above observes that second refresh before returning.
     }
 
-    async chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    async chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse> {
+        const requestBudget = budget ?? GetRequestAttemptBudget(req);
         const candidates = await this.getCandidateProvidersForModel(req.model);
         let lastError: unknown = null;
 
         for (let i = 0; i < candidates.length; i++) {
             const candidate = candidates[i]!;
             try {
-                const response = await candidate.chatCompletion(req);
+                const response = await candidate.chatCompletion(req, requestBudget);
                 this.circuitBreaker.recordSuccess(candidate.id);
                 return response;
             } catch (err) {
@@ -541,8 +546,10 @@ export class ProviderRegistry {
     }
 
     async *chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void> {
+        const requestBudget = budget ?? GetRequestAttemptBudget(req);
         const candidates = await this.getCandidateProvidersForModel(req.model);
         let lastError: unknown = null;
 
@@ -550,7 +557,7 @@ export class ProviderRegistry {
             const candidate = candidates[i]!;
             let yieldedAny = false;
             try {
-                const stream = candidate.chatCompletionStream(req);
+                const stream = candidate.chatCompletionStream(req, requestBudget);
                 for await (const chunk of stream) {
                     if (!yieldedAny) {
                         yieldedAny = true;
@@ -596,6 +603,8 @@ export class ProviderRegistry {
         }
 
         if (lastError) throw lastError;
-        throw new Error(`No provider available supporting image generation for model '${req.model}'`);
+        throw new Error(
+            `No provider available supporting image generation for model '${req.model}'`
+        );
     }
 }

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -580,7 +580,10 @@ export class ProviderRegistry {
         if (lastError) throw lastError;
     }
 
-    async generateImage(req: ImageGenerationRequest): Promise<ImageGenerationResponse> {
+    async generateImage(
+        req: ImageGenerationRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ImageGenerationResponse> {
         const candidates = await this.getCandidateProvidersForModel(req.model);
         let lastError: unknown = null;
 
@@ -590,7 +593,7 @@ export class ProviderRegistry {
                 continue;
             }
             try {
-                const response = await candidate.generateImage(req);
+                const response = await candidate.generateImage(req, budget);
                 this.circuitBreaker.recordSuccess(candidate.id);
                 return response;
             } catch (err) {

--- a/packages/providers/tests/registry.test.ts
+++ b/packages/providers/tests/registry.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { providerBaseId, providerTypeForAlias } from "@srouter/constants";
+import { CreateRequestAttemptBudget } from "@srouter/types";
 import { getProviderAlias, ProviderRegistry } from "../src/registry.js";
 import type { AIProvider } from "@srouter/types";
 
@@ -806,4 +807,58 @@ test("ProviderRegistry exposes separate provider-attempt behavior for one reques
     });
 
     assert.deepEqual(attempts, ["primary", "backup"]);
+});
+
+test("ProviderRegistry records provider attempts separately from transport attempts", async () => {
+    const attempts: string[] = [];
+    const first: AIProvider = {
+        id: "telemetry_primary",
+        name: "Telemetry Primary",
+        listModels: async () => [{ id: "telemetry/model", object: "model", owned_by: "telemetry" }],
+        chatCompletion: async () => {
+            attempts.push("primary");
+            throw new Error("503 upstream unavailable");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    const second: AIProvider = {
+        id: "telemetry_backup",
+        name: "Telemetry Backup",
+        listModels: async () => [{ id: "telemetry/model", object: "model", owned_by: "telemetry" }],
+        chatCompletion: async (req) => {
+            attempts.push("backup");
+            return {
+                id: "telemetry-result",
+                object: "chat.completion",
+                created: Date.now(),
+                model: req.model,
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: "assistant", content: "ok" },
+                        finish_reason: "stop"
+                    }
+                ]
+            };
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    const registry = new ProviderRegistry();
+    registry.registerProvider(first);
+    registry.registerProvider(second);
+    const budget = CreateRequestAttemptBudget(4);
+
+    await registry.chatCompletion(
+        { model: "telemetry/model", messages: [{ role: "user", content: "telemetry" }] },
+        budget
+    );
+
+    assert.deepEqual(attempts, ["primary", "backup"]);
+    assert.equal(budget.providerAttempts, 2);
+    assert.equal(budget.transportAttempts, 0);
+    assert.equal(budget.remaining, 4);
 });

--- a/packages/providers/tests/registry.test.ts
+++ b/packages/providers/tests/registry.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { providerBaseId, providerTypeForAlias } from "@srouter/constants";
 import { getProviderAlias, ProviderRegistry } from "../src/registry.js";
 import type { AIProvider } from "@srouter/types";
 
@@ -216,6 +217,41 @@ test("unknown prefix still returns descriptive error", async () => {
     );
 });
 
+test("model identity contract preserves built-in, bare, legacy, and explicit double prefixes", async () => {
+    assert.equal(providerBaseId("qoder_123"), "qoder");
+    assert.equal(providerTypeForAlias("opencode"), "opencode_zen");
+
+    const registry = new ProviderRegistry();
+    const provider: AIProvider = {
+        id: "qoder_123",
+        name: "Qoder Identity Contract",
+        listModels: async () => [
+            { id: "qoder/ultimate", object: "model", owned_by: "qoder" },
+            { id: "qoder/qoder/explicit", object: "model", owned_by: "qoder" },
+            { id: "bare-model", object: "model", owned_by: "qoder" }
+        ],
+        chatCompletion: async () => {
+            throw new Error("not used");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    registry.registerProvider(provider);
+
+    const cases = [
+        ["qoder/ultimate", provider],
+        ["qd/ultimate", provider],
+        ["qoder_123/ultimate", provider],
+        ["bare-model", provider],
+        ["qoder/qoder/explicit", provider]
+    ] as const;
+
+    for (const [modelId, expectedProvider] of cases) {
+        assert.equal(await registry.getProviderForModel(modelId), expectedProvider, modelId);
+    }
+});
+
 test("custom alias that resembles a built-in provider name must resolve to the custom alias", async () => {
     const registry = new ProviderRegistry();
     const qoderBuiltin: AIProvider = {
@@ -254,7 +290,10 @@ test("custom alias that resembles a built-in provider name must resolve to the c
     // will match. The key is that the custom provider IS found.
     const candidates = await registry.getCandidateProvidersForModel("qoder/custom-model");
     assert.ok(candidates.length > 0, "must find at least one candidate");
-    assert.ok(candidates.some((c) => c.id === uuid), "custom provider must be among candidates");
+    assert.ok(
+        candidates.some((c) => c.id === uuid),
+        "custom provider must be among candidates"
+    );
 });
 
 test("custom provider alias matches via exact alias when model list is empty", async () => {
@@ -717,4 +756,54 @@ test("ProviderRegistry automatically fails over to backup account when primary a
 
     assert.equal(chunks.length, 1);
     assert.equal(chunks[0]?.choices[0]?.delta.content, "Recovered stream from acc2!");
+});
+
+test("ProviderRegistry exposes separate provider-attempt behavior for one request", async () => {
+    const attempts: string[] = [];
+    const first: AIProvider = {
+        id: "attempt_primary",
+        name: "Attempt Primary",
+        listModels: async () => [{ id: "attempt/model", object: "model", owned_by: "attempt" }],
+        chatCompletion: async () => {
+            attempts.push("primary");
+            throw new Error("503 upstream unavailable");
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    const second: AIProvider = {
+        id: "attempt_backup",
+        name: "Attempt Backup",
+        listModels: async () => [{ id: "attempt/model", object: "model", owned_by: "attempt" }],
+        chatCompletion: async (req) => {
+            attempts.push("backup");
+            return {
+                id: "attempt-result",
+                object: "chat.completion",
+                created: Date.now(),
+                model: req.model,
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: "assistant", content: "ok" },
+                        finish_reason: "stop"
+                    }
+                ]
+            };
+        },
+        chatCompletionStream: async function* () {
+            throw new Error("not used");
+        }
+    };
+    const registry = new ProviderRegistry();
+    registry.registerProvider(first);
+    registry.registerProvider(second);
+
+    await registry.chatCompletion({
+        model: "attempt/model",
+        messages: [{ role: "user", content: "count attempts" }]
+    });
+
+    assert.deepEqual(attempts, ["primary", "backup"]);
 });

--- a/packages/types/src/attemptBudget.ts
+++ b/packages/types/src/attemptBudget.ts
@@ -1,0 +1,50 @@
+export const DEFAULT_REQUEST_ATTEMPT_LIMIT = 6;
+
+export interface RequestAttemptBudget {
+    readonly limit: number;
+    readonly used: number;
+    readonly remaining: number;
+    consume(): void;
+}
+
+class AttemptBudget implements RequestAttemptBudget {
+    public used = 0;
+
+    public constructor(public readonly limit: number) {}
+
+    public get remaining(): number {
+        return Math.max(0, this.limit - this.used);
+    }
+
+    public consume(): void {
+        if (this.remaining <= 0) {
+            throw new Error(
+                `Request upstream attempt budget exhausted after ${this.limit} attempts`
+            );
+        }
+        this.used += 1;
+    }
+}
+
+const RequestAttemptBudgets = new WeakMap<object, RequestAttemptBudget>();
+
+export function CreateRequestAttemptBudget(
+    limit = DEFAULT_REQUEST_ATTEMPT_LIMIT
+): RequestAttemptBudget {
+    if (!Number.isInteger(limit) || limit < 1) {
+        throw new Error("Request attempt limit must be a positive integer");
+    }
+    return new AttemptBudget(limit);
+}
+
+export function AttachRequestAttemptBudget<T extends object>(
+    request: T,
+    budget: RequestAttemptBudget
+): T {
+    RequestAttemptBudgets.set(request, budget);
+    return request;
+}
+
+export function GetRequestAttemptBudget(request: object): RequestAttemptBudget | undefined {
+    return RequestAttemptBudgets.get(request);
+}

--- a/packages/types/src/attemptBudget.ts
+++ b/packages/types/src/attemptBudget.ts
@@ -4,11 +4,16 @@ export interface RequestAttemptBudget {
     readonly limit: number;
     readonly used: number;
     readonly remaining: number;
+    readonly providerAttempts: number;
+    readonly transportAttempts: number;
     consume(): void;
+    recordProviderAttempt(): void;
 }
 
 class AttemptBudget implements RequestAttemptBudget {
     public used = 0;
+    public providerAttempts = 0;
+    public transportAttempts = 0;
 
     public constructor(public readonly limit: number) {}
 
@@ -23,10 +28,13 @@ class AttemptBudget implements RequestAttemptBudget {
             );
         }
         this.used += 1;
+        this.transportAttempts += 1;
+    }
+
+    public recordProviderAttempt(): void {
+        this.providerAttempts += 1;
     }
 }
-
-const RequestAttemptBudgets = new WeakMap<object, RequestAttemptBudget>();
 
 export function CreateRequestAttemptBudget(
     limit = DEFAULT_REQUEST_ATTEMPT_LIMIT
@@ -35,16 +43,4 @@ export function CreateRequestAttemptBudget(
         throw new Error("Request attempt limit must be a positive integer");
     }
     return new AttemptBudget(limit);
-}
-
-export function AttachRequestAttemptBudget<T extends object>(
-    request: T,
-    budget: RequestAttemptBudget
-): T {
-    RequestAttemptBudgets.set(request, budget);
-    return request;
-}
-
-export function GetRequestAttemptBudget(request: object): RequestAttemptBudget | undefined {
-    return RequestAttemptBudgets.get(request);
 }

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -31,6 +31,7 @@ export interface TokenImportParams {
 export interface OAuthTokens {
     accessToken: string;
     refreshToken?: string;
+    idToken?: string;
     accountId?: string;
     organizationId?: string;
     expiresIn?: number;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,3 +9,4 @@ export * from "./fallbacks.js";
 export * from "./tokenSaver.js";
 export * from "./auth.js";
 export * from "./images.js";
+export * from "./attemptBudget.js";

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -4,6 +4,7 @@ import type {
     ChatCompletionResponse,
     ModelObject
 } from "./openai.js";
+import type { RequestAttemptBudget } from "./attemptBudget.js";
 import type {
     ImageGenerationRequest,
     ImageGenerationResponse
@@ -69,9 +70,16 @@ export interface AIProvider {
     category?: ProviderCategory;
     protocol?: ProviderProtocol;
     listModels(): Promise<ModelObject[]>;
-    chatCompletion(req: ChatCompletionRequest): Promise<ChatCompletionResponse>;
+    chatCompletion(
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ChatCompletionResponse>;
     chatCompletionStream(
-        req: ChatCompletionRequest
+        req: ChatCompletionRequest,
+        budget?: RequestAttemptBudget
     ): AsyncGenerator<ChatCompletionChunk, void, void>;
-    generateImage?(req: ImageGenerationRequest): Promise<ImageGenerationResponse>;
+    generateImage?(
+        req: ImageGenerationRequest,
+        budget?: RequestAttemptBudget
+    ): Promise<ImageGenerationResponse>;
 }


### PR DESCRIPTION
## Summary

Harden SRouter reliability across chat, image, provider, executor, startup, auth, and documentation paths.

## Implemented

- Add executable reliability contracts and regression fixtures for:
  - streaming output commitment;
  - model/provider identity mapping;
  - usage and credit accounting;
  - upstream attempt counting.
- Enforce a request-level upstream attempt budget of 6 calls.
- Preserve a maximum of 3 transport attempts per candidate.
- Propagate the shared budget through all primary chat/image executor paths:
  - OpenAI;
  - Antigravity;
  - Anthropic;
  - CommandCode;
  - CodeBuddy;
  - Codex;
  - Kiro;
  - Qoder.
- Track provider attempts separately from transport attempts.
- Prevent streaming fallback after client-visible output.
- Keep tool-call buffering fallback-safe before client commitment.
- Extract the shared chat fallback candidate lifecycle.
- Align image fallback with token refresh, trigger gating, capability validation, logging, and attempt budget rules.
- Await required admin bootstrap before serving and handle tunnel autostart failures explicitly.
- Replace auth facade promise assertions with narrowed OAuth/import capabilities.
- Synchronize README version and scoped contributor verification guidance.

## Non-goals

- No public API wire-format changes.
- No database schema or database technology changes.
- No new providers.
- No dashboard redesign.
- No global queue or distributed rate limiter.
- No merge or version bump in this PR.

## Verification

Scoped checks passed:

- API targeted reliability, image, auth, startup, tool, and usage tests.
- Provider registry tests: 29 passing.
- Executor retry tests: 3 passing.
- API, types, providers, and executors builds.
- Scoped Prettier checks.
- `git diff --check`.

CI is running on Node.js 22 and Node.js 24.

## Follow-up notes

- Credit limits remain soft limits for this batch.
- Partial streamed output without usage data is not charged by the current finalization path.
- Image fallback remains a separate modality-specific path rather than forcing image behavior into the chat protocol runner.
