### PR TITLE
feat: persist dashboard preferences in database

### DIFF
--- a/apps/api/src/controllers/favorites.controller.ts
+++ b/apps/api/src/controllers/favorites.controller.ts
@@ -1,0 +1,26 @@
+import type { Context } from "hono";
+import { addFavoriteModelDB, deleteFavoriteModelDB, getFavoriteModelsDB } from "@srouter/db";
+import { AddCustomModelSchema } from "@srouter/types";
+import { Err, Ok } from "@/utils/response.js";
+
+export class FavoritesController {
+    public static async List(c: Context): Promise<Response> {
+        return Ok(c, { models: await getFavoriteModelsDB() });
+    }
+
+    public static async Add(c: Context): Promise<Response> {
+        const Parsed = AddCustomModelSchema.safeParse(await c.req.json().catch(() => null));
+        if (!Parsed.success) return Err(c, "Invalid model payload", 400);
+        await addFavoriteModelDB(Parsed.data.model_id);
+        return Ok(c, { message: "Model added to favorites" }, 201);
+    }
+
+    public static async Remove(c: Context): Promise<Response> {
+        const ModelId = c.req.param("modelId");
+        if (!ModelId) return Err(c, "Model ID is required", 400);
+        if (!(await deleteFavoriteModelDB(decodeURIComponent(ModelId)))) {
+            return Err(c, "Favorite model not found", 404);
+        }
+        return Ok(c, { message: "Model removed from favorites" });
+    }
+}

--- a/apps/api/src/controllers/providers.controller.ts
+++ b/apps/api/src/controllers/providers.controller.ts
@@ -100,6 +100,33 @@ export class ProvidersController {
         }
     }
 
+    public static async ListHiddenModels(c: Context): Promise<Response> {
+        const ProviderId = c.req.param("providerId");
+        if (!ProviderId) return Err(c, "Provider ID is required", 400);
+        return Ok(c, { models: await ProvidersLogic.ListHiddenModels(ProviderId) });
+    }
+
+    public static async HideModel(c: Context): Promise<Response> {
+        const ProviderId = c.req.param("providerId");
+        if (!ProviderId) return Err(c, "Provider ID is required", 400);
+        const Parsed = AddCustomModelSchema.safeParse(await c.req.json().catch(() => null));
+        if (!Parsed.success) return Err(c, "Invalid model payload", 400);
+        await ProvidersLogic.HideModel(ProviderId, Parsed.data.model_id);
+        return Ok(c, { message: "Model hidden" }, 201);
+    }
+
+    public static async RestoreModel(c: Context): Promise<Response> {
+        const ProviderId = c.req.param("providerId");
+        const ModelId = c.req.param("modelId");
+        if (!ProviderId || !ModelId) return Err(c, "Provider ID and model ID are required", 400);
+        try {
+            await ProvidersLogic.RestoreModel(ProviderId, decodeURIComponent(ModelId));
+            return Ok(c, { message: "Model restored" });
+        } catch (error) {
+            return Err(c, error instanceof Error ? error.message : "Failed to restore model", 404);
+        }
+    }
+
     public static async ToggleRoundRobin(c: Context): Promise<Response> {
         const ProviderId = c.req.param("providerId");
         if (!ProviderId) return Err(c, "Provider ID is required", 400);

--- a/apps/api/src/logic/providers.logic.ts
+++ b/apps/api/src/logic/providers.logic.ts
@@ -19,6 +19,9 @@ import {
     deleteCustomModelDB,
     getAllProvidersDB,
     getCustomModelsByProviderDB,
+    getHiddenModelsByProviderDB,
+    addHiddenModelDB,
+    deleteHiddenModelDB,
     getRoundRobinDB,
     setRoundRobinDB,
     upsertProviderDB
@@ -216,6 +219,9 @@ export class ProvidersLogic {
         }
 
         const CustomModels = await ProvidersLogic.ListCustomModels(ProviderId);
+        const HiddenModels = new Set(
+            (await getHiddenModelsByProviderDB(ProviderId.toLowerCase())).map((Row) => Row.modelId.toLowerCase())
+        );
         if (CustomModels.length > 0) {
             const Merged = new Map<string, ModelObject>();
             for (const M of LiveModels) {
@@ -230,7 +236,7 @@ export class ProvidersLogic {
         return {
             ...Provider,
             connections: Connections,
-            models: LiveModels,
+            models: LiveModels.filter((Model) => !HiddenModels.has(Model.id.toLowerCase())),
             status: {
                 ...Provider.status,
                 connectedCount: ConnectedCount,
@@ -324,6 +330,19 @@ export class ProvidersLogic {
         const Deleted = await deleteCustomModelDB(ProviderId.toLowerCase(), ModelId);
         if (!Deleted) throw new Error(`Custom model '${ModelId}' not found for '${ProviderId}'`);
         registry.clearModelsCache();
+    }
+
+    public static async HideModel(ProviderId: string, ModelId: string): Promise<void> {
+        await addHiddenModelDB(ProviderId.toLowerCase(), ModelId);
+    }
+
+    public static async RestoreModel(ProviderId: string, ModelId: string): Promise<void> {
+        const Restored = await deleteHiddenModelDB(ProviderId.toLowerCase(), ModelId);
+        if (!Restored) throw new Error(`Hidden model '${ModelId}' not found for '${ProviderId}'`);
+    }
+
+    public static async ListHiddenModels(ProviderId: string): Promise<string[]> {
+        return (await getHiddenModelsByProviderDB(ProviderId.toLowerCase())).map((Row) => Row.modelId);
     }
 
     public static async SetRoundRobin(ProviderId: string, Enabled: boolean): Promise<ProviderDefinition> {

--- a/apps/api/src/routes/v1/providers.ts
+++ b/apps/api/src/routes/v1/providers.ts
@@ -2,8 +2,13 @@ import { Hono } from "hono";
 import { ProvidersController } from "@/controllers/providers.controller.js";
 import { RequireAdmin } from "@/middleware/AdminAuth.js";
 import { ApiKeyAuth } from "@/middleware/ApiKeyAuth.js";
+import { FavoritesController } from "@/controllers/favorites.controller.js";
 
 export const ProvidersRouter = new Hono();
+
+ProvidersRouter.get("/favorites", ApiKeyAuth, FavoritesController.List);
+ProvidersRouter.post("/favorites", RequireAdmin, FavoritesController.Add);
+ProvidersRouter.delete("/favorites/:modelId{.+}", RequireAdmin, FavoritesController.Remove);
 
 ProvidersRouter.get("/providers", ApiKeyAuth, ProvidersController.ListProviders);
 ProvidersRouter.get("/providers/catalog", ApiKeyAuth, ProvidersController.GetCatalog);
@@ -31,4 +36,12 @@ ProvidersRouter.patch(
     "/providers/:providerId/round-robin",
     RequireAdmin,
     ProvidersController.ToggleRoundRobin
+);
+
+ProvidersRouter.get("/providers/:providerId/hidden-models", ApiKeyAuth, ProvidersController.ListHiddenModels);
+ProvidersRouter.post("/providers/:providerId/hidden-models", RequireAdmin, ProvidersController.HideModel);
+ProvidersRouter.delete(
+    "/providers/:providerId/hidden-models/:modelId{.+}",
+    RequireAdmin,
+    ProvidersController.RestoreModel
 );

--- a/apps/web/src/hooks/useFavorites.ts
+++ b/apps/web/src/hooks/useFavorites.ts
@@ -1,119 +1,75 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
 
 const STORAGE_KEY = "srouter_favorite_models";
-const EVENT_NAME = "srouter:favorites-updated";
 
-function loadFavorites(): string[] {
+function loadLegacyFavorites(): string[] {
     try {
-        const raw = localStorage.getItem(STORAGE_KEY);
-        if (!raw) return [];
-        const parsed = JSON.parse(raw);
-        return Array.isArray(parsed) ? parsed : [];
+        const parsed: unknown = JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+        return Array.isArray(parsed) && parsed.every((id): id is string => typeof id === "string") ? parsed : [];
     } catch {
         return [];
     }
 }
 
-function saveFavorites(favorites: string[]): void {
-    try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
-        window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: favorites }));
-    } catch (e) {
-        console.error("Failed to save favorite models to localStorage:", e);
-    }
-}
-
-/**
- * Hook for managing pinned/favorite models across the dashboard and playground.
- */
 export function useFavorites() {
-    const [favorites, setFavorites] = useState<string[]>(loadFavorites);
+    const queryClient = useQueryClient();
+    const query = useQuery({
+        queryKey: ["favorite-models"],
+        queryFn: async () => {
+            const response = await api.get<{ models: string[] }>("/v1/favorites");
+            if (response.models.length > 0 || typeof window === "undefined") return response.models;
 
-    useEffect(() => {
-        const handleUpdate = (e: Event) => {
-            const customEvent = e as CustomEvent<string[]>;
-            if (customEvent.detail) {
-                setFavorites(customEvent.detail);
-            } else {
-                setFavorites(loadFavorites());
+            const legacyFavorites = loadLegacyFavorites();
+            for (const modelId of legacyFavorites) {
+                await api.post("/v1/favorites", { model_id: modelId });
             }
-        };
+            if (legacyFavorites.length > 0) localStorage.removeItem(STORAGE_KEY);
+            return legacyFavorites;
+        }
+    });
 
-        const handleStorage = (e: StorageEvent) => {
-            if (e.key === STORAGE_KEY) {
-                setFavorites(loadFavorites());
-            }
-        };
+    const mutation = useMutation({
+        mutationFn: ({ modelId, favorite }: { modelId: string; favorite: boolean }) =>
+            favorite
+                ? api.post("/v1/favorites", { model_id: modelId })
+                : api.delete(`/v1/favorites/${encodeURIComponent(modelId)}`),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["favorite-models"] });
+        }
+    });
 
-        window.addEventListener(EVENT_NAME, handleUpdate);
-        window.addEventListener("storage", handleStorage);
-
-        return () => {
-            window.removeEventListener(EVENT_NAME, handleUpdate);
-            window.removeEventListener("storage", handleStorage);
-        };
-    }, []);
-
+    const favorites = query.data ?? [];
     const favoriteSet = useMemo(() => new Set(favorites), [favorites]);
 
-    const isFavorite = useCallback(
-        (modelId: string): boolean => {
-            return favoriteSet.has(modelId);
-        },
-        [favoriteSet]
-    );
-
     const toggleFavorite = useCallback((modelId: string) => {
-        setFavorites((prev) => {
-            const exists = prev.includes(modelId);
-            const next = exists ? prev.filter((id) => id !== modelId) : [...prev, modelId];
-            saveFavorites(next);
-            return next;
-        });
-    }, []);
+        mutation.mutate({ modelId, favorite: !favoriteSet.has(modelId) });
+    }, [favoriteSet, mutation]);
 
     const addFavorite = useCallback((modelId: string) => {
-        setFavorites((prev) => {
-            if (prev.includes(modelId)) return prev;
-            const next = [...prev, modelId];
-            saveFavorites(next);
-            return next;
-        });
-    }, []);
+        if (!favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: true });
+    }, [favoriteSet, mutation]);
 
     const removeFavorite = useCallback((modelId: string) => {
-        setFavorites((prev) => {
-            if (!prev.includes(modelId)) return prev;
-            const next = prev.filter((id) => id !== modelId);
-            saveFavorites(next);
-            return next;
-        });
-    }, []);
+        if (favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: false });
+    }, [favoriteSet, mutation]);
 
     const addMultipleFavorites = useCallback((modelIds: string[]) => {
-        setFavorites((prev) => {
-            const set = new Set(prev);
-            for (const id of modelIds) {
-                set.add(id);
-            }
-            const next = Array.from(set);
-            saveFavorites(next);
-            return next;
-        });
-    }, []);
+        for (const modelId of modelIds) {
+            if (!favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: true });
+        }
+    }, [favoriteSet, mutation]);
 
     const removeMultipleFavorites = useCallback((modelIds: string[]) => {
-        setFavorites((prev) => {
-            const removeSet = new Set(modelIds);
-            const next = prev.filter((id) => !removeSet.has(id));
-            saveFavorites(next);
-            return next;
-        });
-    }, []);
+        for (const modelId of modelIds) {
+            if (favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: false });
+        }
+    }, [favoriteSet, mutation]);
 
     return {
         favorites,
-        isFavorite,
+        isFavorite: (modelId: string): boolean => favoriteSet.has(modelId),
         toggleFavorite,
         addFavorite,
         removeFavorite,

--- a/apps/web/src/hooks/useProvider.ts
+++ b/apps/web/src/hooks/useProvider.ts
@@ -30,6 +30,30 @@ export function useProvider(providerId: string) {
         enabled: Boolean(providerId)
     });
 
+    const hiddenModelsQuery = useQuery({
+        queryKey: ["providers", providerId, "hidden-models"],
+        queryFn: async () => {
+            const response = await api.get<{ models: string[] }>(`/v1/providers/${providerId}/hidden-models`);
+            if (response.models.length > 0 || typeof window === "undefined") return response;
+            const legacyKey = `srouter_deleted_models_${providerId}`;
+            let legacyModels: string[] = [];
+            try {
+                const parsed: unknown = JSON.parse(localStorage.getItem(legacyKey) || "[]");
+                if (Array.isArray(parsed) && parsed.every((id): id is string => typeof id === "string")) {
+                    legacyModels = parsed;
+                }
+            } catch {
+                legacyModels = [];
+            }
+            for (const modelId of legacyModels) {
+                await api.post(`/v1/providers/${providerId}/hidden-models`, { model_id: modelId });
+            }
+            if (legacyModels.length > 0) localStorage.removeItem(legacyKey);
+            return { models: legacyModels };
+        },
+        enabled: Boolean(providerId)
+    });
+
     const addMutation = useMutation({
         mutationFn: (payload: AddConnectionPayload) =>
             api.post<ProviderDefinition>("/v1/providers", payload),
@@ -101,12 +125,31 @@ export function useProvider(providerId: string) {
         }
     });
 
+    const hideModelMutation = useMutation({
+        mutationFn: (modelId: string) => api.post(`/v1/providers/${providerId}/hidden-models`, { model_id: modelId }),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
+            void queryClient.invalidateQueries({ queryKey: ["providers", providerId, "hidden-models"] });
+        }
+    });
+
+    const restoreModelMutation = useMutation({
+        mutationFn: (modelId: string) => api.delete(`/v1/providers/${providerId}/hidden-models/${encodeURIComponent(modelId)}`),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
+            void queryClient.invalidateQueries({ queryKey: ["providers", providerId, "hidden-models"] });
+        }
+    });
+
     return {
         ...query,
+        hiddenModelIds: hiddenModelsQuery.data?.models ?? [],
         addMutation,
         deleteMutation,
         toggleRoundRobinMutation,
         addModelMutation,
-        deleteModelMutation
+        deleteModelMutation,
+        hideModelMutation,
+        restoreModelMutation
     };
 }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import { APP_VERSION } from "@srouter/constants";
+import { api } from "@/lib/api";
 
 export interface AppSettings {
     // Appearance
@@ -39,6 +40,18 @@ const DEFAULT_SETTINGS: AppSettings = {
 
 const STORAGE_KEY = "srouter_app_settings";
 
+const SERVER_SETTING_KEYS: Partial<Record<keyof AppSettings, string>> = {
+    requestTimeoutSec: "request_timeout_sec",
+    autoRetryOn429: "auto_retry_on_429",
+    maxRetries: "max_retries",
+    retryDelayMs: "retry_delay_ms",
+    tokenRefreshLeadMin: "token_refresh_lead_min",
+    loggingLevel: "logging_level",
+    logRetentionDays: "log_retention_days",
+    recordTokenUsage: "record_token_usage",
+    maskSensitiveHeaders: "mask_sensitive_headers"
+};
+
 export function useSettings() {
     const [settings, setSettings] = useState<AppSettings>(() => {
         if (typeof window === "undefined") return DEFAULT_SETTINGS;
@@ -50,12 +63,49 @@ export function useSettings() {
         }
     });
 
+    useEffect(() => {
+        void api.get<{ settings?: Record<string, string> }>("/v1/settings").then((response) => {
+            const server = response.settings ?? {};
+            const keys = Object.values(SERVER_SETTING_KEYS).filter(
+                (key): key is string => key !== undefined
+            );
+            if (!keys.some((key) => key in server)) {
+                const migrated: Record<string, string> = {};
+                for (const [key, serverKey] of Object.entries(SERVER_SETTING_KEYS)) {
+                    if (serverKey) migrated[serverKey] = String(settings[key as keyof AppSettings]);
+                }
+                void api.patch("/v1/settings", { settings: migrated });
+                return;
+            }
+            const hydrated = { ...settings };
+            for (const [key, serverKey] of Object.entries(SERVER_SETTING_KEYS)) {
+                const value = serverKey ? server[serverKey] : undefined;
+                if (value === undefined) continue;
+                const settingKey = key as keyof AppSettings;
+                const current = settings[settingKey];
+                hydrated[settingKey] = (typeof current === "boolean"
+                    ? value === "true"
+                    : typeof current === "number"
+                      ? Number(value)
+                      : value) as never;
+            }
+            setSettings(hydrated);
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(hydrated));
+        }).catch(() => undefined);
+    }, []);
+
     const updateSetting = useCallback(
         <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
             setSettings((prev) => {
                 const updated = { ...prev, [key]: value };
                 try {
                     localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+                    const serverKey = SERVER_SETTING_KEYS[key];
+                    if (serverKey) {
+                        void api.patch("/v1/settings", {
+                            settings: { [serverKey]: String(value) }
+                        });
+                    }
                 } catch (e) {
                     console.error("Failed to save settings to localStorage", e);
                 }

--- a/apps/web/src/routes/providers/$providerId.tsx
+++ b/apps/web/src/routes/providers/$providerId.tsx
@@ -47,7 +47,10 @@ function ProviderDetailPage() {
         deleteMutation,
         toggleRoundRobinMutation,
         addModelMutation,
-        deleteModelMutation
+        deleteModelMutation,
+        hiddenModelIds,
+        hideModelMutation,
+        restoreModelMutation
     } = useProvider(providerId);
 
     const [modelSearch, setModelSearch] = useState("");
@@ -59,47 +62,21 @@ function ProviderDetailPage() {
     const { copied, copy } = useCopy();
     const { isFavorite } = useFavorites();
 
-    const storageKey = `srouter_deleted_models_${providerId}`;
-    const [deletedModelIds, setDeletedModelIds] = useState<string[]>(() => {
-        try {
-            const saved = localStorage.getItem(storageKey);
-            return saved ? JSON.parse(saved) : [];
-        } catch {
-            return [];
-        }
-    });
+    const deletedModelIds = hiddenModelIds;
 
     const handleRestoreModel = (modelId: string) => {
-        setDeletedModelIds((prev) => {
-            const updated = prev.filter((id) => id !== modelId);
-            try {
-                localStorage.setItem(storageKey, JSON.stringify(updated));
-            } catch {}
-            return updated;
-        });
+        restoreModelMutation.mutate(modelId);
         toast.success(`Model "${modelId}" restored`);
     };
 
     const handleRestoreMultiple = (modelIds: string[]) => {
         const removeSet = new Set(modelIds);
-        setDeletedModelIds((prev) => {
-            const updated = prev.filter((id) => !removeSet.has(id));
-            try {
-                localStorage.setItem(storageKey, JSON.stringify(updated));
-            } catch {}
-            return updated;
-        });
+        for (const modelId of modelIds) restoreModelMutation.mutate(modelId);
         toast.success(`Restored ${modelIds.length} hidden model${modelIds.length > 1 ? "s" : ""}`);
     };
 
     const handleDeleteModel = (modelId: string) => {
-        setDeletedModelIds((prev) => {
-            const updated = prev.includes(modelId) ? prev : [...prev, modelId];
-            try {
-                localStorage.setItem(storageKey, JSON.stringify(updated));
-            } catch {}
-            return updated;
-        });
+        hideModelMutation.mutate(modelId);
         toast.info(`Model "${modelId}" hidden from list`, {
             action: {
                 label: "Undo",
@@ -109,14 +86,7 @@ function ProviderDetailPage() {
     };
 
     const handleDeleteMultipleModels = (modelIds: string[]) => {
-        setDeletedModelIds((prev) => {
-            const set = new Set([...prev, ...modelIds]);
-            const updated = Array.from(set);
-            try {
-                localStorage.setItem(storageKey, JSON.stringify(updated));
-            } catch {}
-            return updated;
-        });
+        for (const modelId of modelIds) hideModelMutation.mutate(modelId);
         toast.info(`Hidden ${modelIds.length} model${modelIds.length > 1 ? "s" : ""} from list`, {
             action: {
                 label: "Undo",
@@ -127,10 +97,7 @@ function ProviderDetailPage() {
 
     const handleRestoreAllModels = () => {
         const count = deletedModelIds.length;
-        setDeletedModelIds([]);
-        try {
-            localStorage.removeItem(storageKey);
-        } catch {}
+        for (const modelId of deletedModelIds) restoreModelMutation.mutate(modelId);
         toast.success(`Restored ${count} hidden model${count > 1 ? "s" : ""}`);
     };
 

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -214,6 +214,22 @@ const TABLES: TableDef[] = [
             { name: "created_at", definition: "INTEGER NOT NULL" },
             { name: "PRIMARY KEY (provider_id, model_id)", definition: "" }
         ]
+    },
+    {
+        name: "hidden_models",
+        columns: [
+            { name: "provider_id", definition: "TEXT NOT NULL" },
+            { name: "model_id", definition: "TEXT NOT NULL" },
+            { name: "created_at", definition: "INTEGER NOT NULL" },
+            { name: "PRIMARY KEY (provider_id, model_id)", definition: "" }
+        ]
+    },
+    {
+        name: "favorite_models",
+        columns: [
+            { name: "model_id", definition: "TEXT PRIMARY KEY" },
+            { name: "created_at", definition: "INTEGER NOT NULL" }
+        ]
     }
 ];
 
@@ -224,7 +240,9 @@ const INDEXES: IndexDef[] = [
     { sql: "CREATE INDEX IF NOT EXISTS idx_request_logs_model ON request_logs(model);" },
     { sql: "CREATE INDEX IF NOT EXISTS idx_fallback_rules_priority ON fallback_rules(priority ASC, created_at ASC);" },
     { sql: "CREATE INDEX IF NOT EXISTS idx_providers_provider_id ON providers(provider_id);" },
-    { sql: "CREATE INDEX IF NOT EXISTS idx_custom_models_provider ON custom_models(provider_id, created_at ASC);" }
+    { sql: "CREATE INDEX IF NOT EXISTS idx_custom_models_provider ON custom_models(provider_id, created_at ASC);" },
+    { sql: "CREATE INDEX IF NOT EXISTS idx_hidden_models_provider ON hidden_models(provider_id, created_at ASC);" },
+    { sql: "CREATE INDEX IF NOT EXISTS idx_favorite_models_created ON favorite_models(created_at ASC);" }
 ];
 
 const ADMIN_TABLES = (pg: boolean) => {

--- a/packages/db/src/favoriteModels.ts
+++ b/packages/db/src/favoriteModels.ts
@@ -1,0 +1,24 @@
+import { db, isPostgres } from "./db.js";
+import { num, str } from "./row-utils.js";
+
+interface FavoriteModelDBShape {
+    model_id: string;
+    created_at: number;
+}
+
+export async function getFavoriteModelsDB(): Promise<string[]> {
+    const Rows = (await db.prepare("SELECT model_id FROM favorite_models ORDER BY created_at ASC").all()) as unknown as FavoriteModelDBShape[];
+    return Rows.map((Row) => str(Row.model_id));
+}
+
+export async function addFavoriteModelDB(modelId: string): Promise<void> {
+    const Sql = isPostgres()
+        ? "INSERT INTO favorite_models (model_id, created_at) VALUES (?, ?) ON CONFLICT (model_id) DO NOTHING"
+        : "INSERT OR IGNORE INTO favorite_models (model_id, created_at) VALUES (?, ?)";
+    await db.prepare(Sql).run(modelId, Date.now());
+}
+
+export async function deleteFavoriteModelDB(modelId: string): Promise<boolean> {
+    const Result = await db.prepare("DELETE FROM favorite_models WHERE model_id = ?").run(modelId);
+    return num(Result.changes) > 0;
+}

--- a/packages/db/src/hiddenModels.ts
+++ b/packages/db/src/hiddenModels.ts
@@ -1,0 +1,48 @@
+import { db, isPostgres } from "./db.js";
+import { num, str } from "./row-utils.js";
+
+export interface HiddenModelRow {
+    providerId: string;
+    modelId: string;
+    createdAt: number;
+}
+
+interface HiddenModelDBShape {
+    provider_id: string;
+    model_id: string;
+    created_at: number;
+}
+
+export async function getHiddenModelsByProviderDB(providerId: string): Promise<HiddenModelRow[]> {
+    const Rows = (await db
+        .prepare("SELECT * FROM hidden_models WHERE provider_id = ? ORDER BY created_at ASC")
+        .all(providerId)) as unknown as HiddenModelDBShape[];
+    return Rows.map(mapHiddenModelRow);
+}
+
+export async function addHiddenModelDB(providerId: string, modelId: string): Promise<HiddenModelRow> {
+    const CreatedAt = Date.now();
+    const Sql = isPostgres()
+        ? `INSERT INTO hidden_models (provider_id, model_id, created_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT (provider_id, model_id) DO NOTHING`
+        : `INSERT OR IGNORE INTO hidden_models (provider_id, model_id, created_at)
+           VALUES (?, ?, ?)`;
+    await db.prepare(Sql).run(providerId, modelId, CreatedAt);
+    return { providerId, modelId, createdAt: CreatedAt };
+}
+
+export async function deleteHiddenModelDB(providerId: string, modelId: string): Promise<boolean> {
+    const Result = await db
+        .prepare("DELETE FROM hidden_models WHERE provider_id = ? AND model_id = ?")
+        .run(providerId, modelId);
+    return num(Result.changes) > 0;
+}
+
+function mapHiddenModelRow(row: HiddenModelDBShape): HiddenModelRow {
+    return {
+        providerId: str(row.provider_id),
+        modelId: str(row.model_id),
+        createdAt: num(row.created_at)
+    };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,8 @@ export * from "./settings.js";
 export * from "./fallbacks.js";
 export * from "./tokenSaver.js";
 export * from "./customModels.js";
+export * from "./hiddenModels.js";
+export * from "./favoriteModels.js";
 export * from "./row-utils.js";
 export * from "./client.js";
 export {


### PR DESCRIPTION
## Summary
- Move favorite models from `localStorage` to the database.
- Move hidden provider models from `localStorage` to the database.
- Add database-backed APIs for favorites and hidden models.
- Synchronize operational dashboard settings with `system_settings`.
- Migrate existing browser-local favorite and hidden-model data on first load.
- Keep theme and UI density as local preferences.

## Verification
- `pnpm run build` in `packages/db`
- `pnpm run build` in `apps/api`
- `pnpm run build` in `apps/web`
- `git diff --check`
