### PR TITLE
fix(web): prevent dashboard freeze when opening provider connection m…

### DIFF
--- a/apps/web/src/components/providers/providers.connect-oauth-modal.tsx
+++ b/apps/web/src/components/providers/providers.connect-oauth-modal.tsx
@@ -50,6 +50,8 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
     const [isLoadingUrl, setIsLoadingUrl] = useState(false);
     const popupRef = useRef<Window | null>(null);
 
+    const providerId = provider?.id;
+    const providerName = provider?.name;
     const baseId = provider?.id.split("_")[0]?.split("-")[0] ?? provider?.id ?? "";
     const authProviderId = provider?.id === "codebuddy-cn" ? "codebuddy-cn" : baseId;
     const isQoder = baseId === "qoder";
@@ -60,7 +62,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
 
     // Fetch backend-registered PKCE OAuth session without auto-opening popup
     useEffect(() => {
-        if (!open || !provider) {
+        if (!open || !providerId) {
             setAuthUrl("");
             setOauthState("");
             setError("");
@@ -97,7 +99,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 setIsLoadingUrl(false);
                 setError(err.message || "Failed to initiate OAuth login session");
             });
-    }, [open, provider, baseId, authProviderId]);
+    }, [open, providerId, baseId, authProviderId]);
 
     const handleOpenPopup = () => {
         if (!authUrl) return;
@@ -115,7 +117,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
 
     // Listen for postMessage from auto-closing popup window (for redirect-based OAuth)
     useEffect(() => {
-        if (!open || !provider) return;
+        if (!open || !providerId) return;
 
         const handleMessage = (event: MessageEvent) => {
             if (
@@ -127,9 +129,9 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                     popupRef.current.close();
                 }
                 void queryClient.invalidateQueries({ queryKey: ["providers"] });
-                void queryClient.invalidateQueries({ queryKey: ["providers", provider.id] });
+                void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
                 void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
-                toast.success(`${provider.name} connected successfully!`);
+                toast.success(`${providerName ?? "Provider"} connected successfully!`);
                 onOpenChange(false);
                 setCallbackUrlInput("");
                 setError("");
@@ -138,11 +140,11 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
 
         window.addEventListener("message", handleMessage);
         return () => window.removeEventListener("message", handleMessage);
-    }, [open, provider, queryClient, onOpenChange]);
+    }, [open, providerId, providerName, queryClient, onOpenChange]);
 
     // Active polling for Qoder and CodeBuddy Device/OAuth Flow
     useEffect(() => {
-        if (!open || !provider || !isPolling || !oauthState) return;
+        if (!open || !providerId || !isPolling || !oauthState) return;
 
         const interval = setInterval(async () => {
             try {
@@ -158,9 +160,9 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                         popupRef.current.close();
                     }
                     void queryClient.invalidateQueries({ queryKey: ["providers"] });
-                    void queryClient.invalidateQueries({ queryKey: ["providers", provider.id] });
+                    void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
                     void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
-                    toast.success(`${provider.name} connected successfully!`);
+                    toast.success(`${providerName ?? "Provider"} connected successfully!`);
                     onOpenChange(false);
                     setError("");
                 }
@@ -170,7 +172,17 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
         }, 2000);
 
         return () => clearInterval(interval);
-    }, [open, provider, isPolling, baseId, authProviderId, oauthState, queryClient, onOpenChange]);
+    }, [
+        open,
+        providerId,
+        providerName,
+        isPolling,
+        baseId,
+        authProviderId,
+        oauthState,
+        queryClient,
+        onOpenChange
+    ]);
 
     const callbackMutation = useMutation({
         mutationFn: (payload: { callback_url: string }) => {
@@ -241,9 +253,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                     return api.post(`/v1/auth/${authProviderId}/token`, {
                         access_token: accessToken,
                         accessToken,
-                        ...(refreshToken
-                            ? { refresh_token: refreshToken, refreshToken }
-                            : {})
+                        ...(refreshToken ? { refresh_token: refreshToken, refreshToken } : {})
                     });
                 })
             );
@@ -326,7 +336,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
 
     if (!provider) return null;
 
-    const tabsCount = (supportsBulk ? 3 : isQoder || isCodeBuddy ? 2 : 1);
+    const tabsCount = supportsBulk ? 3 : isQoder || isCodeBuddy ? 2 : 1;
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -334,7 +344,10 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                 {/* Header */}
                 <DialogHeader className="flex flex-row items-center justify-between pb-3 border-b border-border/60">
                     <div className="flex items-center gap-2.5">
-                        <ProviderIcon providerId={provider.id} className="size-6 rounded-md shadow-2xs" />
+                        <ProviderIcon
+                            providerId={provider.id}
+                            className="size-6 rounded-md shadow-2xs"
+                        />
                         <div>
                             <DialogTitle className="text-sm font-bold tracking-tight text-foreground">
                                 Connect {provider.name}
@@ -423,7 +436,8 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                                 </label>
                                 {bulkInput.split(/\r?\n/).filter((l) => l.trim()).length > 0 && (
                                     <span className="rounded-md bg-secondary px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
-                                        {bulkInput.split(/\r?\n/).filter((l) => l.trim()).length} detected
+                                        {bulkInput.split(/\r?\n/).filter((l) => l.trim()).length}{" "}
+                                        detected
                                     </span>
                                 )}
                             </div>
@@ -452,7 +466,11 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                             </p>
                             <textarea
                                 rows={5}
-                                placeholder={isCodex ? "eyJhbGciOi...\neyJhbGciOi..." : "pt-xxx...\npt-yyy..."}
+                                placeholder={
+                                    isCodex
+                                        ? "eyJhbGciOi...\neyJhbGciOi..."
+                                        : "pt-xxx...\npt-yyy..."
+                                }
                                 value={bulkInput}
                                 onChange={(e) => setBulkInput(e.target.value)}
                                 className="w-full resize-y rounded-lg border border-border/60 bg-secondary/20 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
@@ -475,7 +493,9 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                                 disabled={bulkMutation.isPending}
                                 className="h-8 text-xs font-semibold cursor-pointer gap-1.5"
                             >
-                                {bulkMutation.isPending && <Loader2 className="size-3.5 animate-spin" />}
+                                {bulkMutation.isPending && (
+                                    <Loader2 className="size-3.5 animate-spin" />
+                                )}
                                 {bulkMutation.isPending ? "Importing…" : "Import Accounts"}
                             </Button>
                         </div>
@@ -528,7 +548,9 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                             {/* Link Copy Box */}
                             <div className="space-y-1.5">
                                 <div className="flex items-center justify-between text-[11px]">
-                                    <span className="text-muted-foreground">Or copy authorization URL</span>
+                                    <span className="text-muted-foreground">
+                                        Or copy authorization URL
+                                    </span>
                                     <button
                                         type="button"
                                         onClick={() => void handleCopy()}
@@ -632,9 +654,7 @@ export function ConnectOAuthModal({ provider, open, onOpenChange }: ConnectOAuth
                             </p>
                             <input
                                 type="password"
-                                placeholder={
-                                    isCodeBuddy || isCodex ? "eyJhbGciOi..." : "pt-..."
-                                }
+                                placeholder={isCodeBuddy || isCodex ? "eyJhbGciOi..." : "pt-..."}
                                 value={patInput}
                                 onChange={(e) => setPatInput(e.target.value)}
                                 className="w-full rounded-lg border border-border/60 bg-secondary/20 px-3 py-2 text-xs font-mono text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"

--- a/apps/web/src/components/providers/providers.connection-card.tsx
+++ b/apps/web/src/components/providers/providers.connection-card.tsx
@@ -6,13 +6,21 @@ import { Switch } from "@/components/ui/switch";
 import { useCopy } from "@/hooks/useCopy";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { toast } from "sonner";
-import { Empty, EmptyContent, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty";
+import {
+    Empty,
+    EmptyContent,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+    EmptyDescription
+} from "@/components/ui/empty";
 
 interface ConnectionCardProps {
     providerName: string;
     connections: ProviderConfig[];
     roundRobin: boolean;
     isDeleting: boolean;
+    requiresOAuth?: boolean;
     onToggleRoundRobin: (enabled: boolean) => void;
     onRefresh: () => void;
     onAdd: () => void;
@@ -34,7 +42,8 @@ function getConnectionDisplayTitle(connection: ProviderConfig): string {
                     payload.email ||
                     payload["https://api.openai.com/profile"]?.email ||
                     payload.user_metadata?.email ||
-                    (typeof payload.preferred_username === "string" && payload.preferred_username.includes("@")
+                    (typeof payload.preferred_username === "string" &&
+                    payload.preferred_username.includes("@")
                         ? payload.preferred_username
                         : undefined) ||
                     (typeof payload.unique_name === "string" && payload.unique_name.includes("@")
@@ -54,6 +63,7 @@ export function ConnectionCard({
     connections,
     roundRobin,
     isDeleting,
+    requiresOAuth = false,
     onToggleRoundRobin,
     onRefresh,
     onAdd,
@@ -154,7 +164,7 @@ export function ConnectionCard({
                             className="h-7.5 text-xs font-semibold cursor-pointer shadow-2xs gap-1.5"
                         >
                             <Plus className="size-3.5" />
-                            <span>Add Key</span>
+                            <span>{requiresOAuth ? "Add Connection" : "Add Key"}</span>
                         </Button>
                     </div>
                 </div>

--- a/apps/web/src/components/providers/providers.connection-form.tsx
+++ b/apps/web/src/components/providers/providers.connection-form.tsx
@@ -136,7 +136,8 @@ export function ConnectionForm({
                 <DialogHeader className="p-0 space-y-1">
                     <DialogTitle className="sr-only">Add API Key for {providerName}</DialogTitle>
                     <DialogDescription className="text-xs text-muted-foreground">
-                        Enter credentials for {providerName} and verify the upstream connection before saving.
+                        Enter credentials for {providerName} and verify the upstream connection
+                        before saving.
                     </DialogDescription>
                 </DialogHeader>
 
@@ -148,10 +149,7 @@ export function ConnectionForm({
 
                 <form onSubmit={handleSubmit} className="space-y-4 text-xs">
                     <div className="space-y-1.5">
-                        <label
-                            htmlFor="conn-api-key"
-                            className="font-medium text-foreground block"
-                        >
+                        <label htmlFor="conn-api-key" className="font-medium text-foreground block">
                             API Key / Access Token *
                         </label>
                         <div className="relative">
@@ -168,7 +166,6 @@ export function ConnectionForm({
                                         setVerifyStatus("idle");
                                     }
                                 }}
-                                autoFocus
                                 required
                                 className="w-full rounded border border-border/80 bg-background px-3 py-2 pr-9 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-foreground"
                             />

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -23,7 +23,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
         <DialogPrimitive.Backdrop
             data-slot="dialog-overlay"
             className={cn(
-                "fixed inset-0 z-50 backdrop-blur-xs transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0",
+                "fixed inset-0 z-50 bg-black/60 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
                 className
             )}
             {...props}
@@ -38,7 +38,7 @@ function DialogContent({ className, children, ...props }: DialogPrimitive.Popup.
             <DialogPrimitive.Popup
                 data-slot="dialog-content"
                 className={cn(
-                    "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 max-h-[calc(100dvh-2rem)] flex flex-col rounded-xl border border-border/80 bg-card p-4 sm:p-6 text-foreground shadow-2xl transition duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 outline-none overflow-hidden",
+                    "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 max-h-[calc(100dvh-2rem)] flex flex-col rounded-xl border border-border/80 bg-card p-4 sm:p-6 text-foreground shadow-2xl transition duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 outline-none overflow-y-auto",
                     className
                 )}
                 {...props}

--- a/apps/web/src/hooks/useFavorites.ts
+++ b/apps/web/src/hooks/useFavorites.ts
@@ -7,7 +7,9 @@ const STORAGE_KEY = "srouter_favorite_models";
 function loadLegacyFavorites(): string[] {
     try {
         const parsed: unknown = JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
-        return Array.isArray(parsed) && parsed.every((id): id is string => typeof id === "string") ? parsed : [];
+        return Array.isArray(parsed) && parsed.every((id): id is string => typeof id === "string")
+            ? parsed
+            : [];
     } catch {
         return [];
     }
@@ -43,33 +45,53 @@ export function useFavorites() {
     const favorites = query.data ?? [];
     const favoriteSet = useMemo(() => new Set(favorites), [favorites]);
 
-    const toggleFavorite = useCallback((modelId: string) => {
-        mutation.mutate({ modelId, favorite: !favoriteSet.has(modelId) });
-    }, [favoriteSet, mutation]);
+    const toggleFavorite = useCallback(
+        (modelId: string) => {
+            mutation.mutate({ modelId, favorite: !favoriteSet.has(modelId) });
+        },
+        [favoriteSet, mutation]
+    );
 
-    const addFavorite = useCallback((modelId: string) => {
-        if (!favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: true });
-    }, [favoriteSet, mutation]);
-
-    const removeFavorite = useCallback((modelId: string) => {
-        if (favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: false });
-    }, [favoriteSet, mutation]);
-
-    const addMultipleFavorites = useCallback((modelIds: string[]) => {
-        for (const modelId of modelIds) {
+    const addFavorite = useCallback(
+        (modelId: string) => {
             if (!favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: true });
-        }
-    }, [favoriteSet, mutation]);
+        },
+        [favoriteSet, mutation]
+    );
 
-    const removeMultipleFavorites = useCallback((modelIds: string[]) => {
-        for (const modelId of modelIds) {
+    const removeFavorite = useCallback(
+        (modelId: string) => {
             if (favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: false });
-        }
-    }, [favoriteSet, mutation]);
+        },
+        [favoriteSet, mutation]
+    );
+
+    const addMultipleFavorites = useCallback(
+        (modelIds: string[]) => {
+            for (const modelId of modelIds) {
+                if (!favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: true });
+            }
+        },
+        [favoriteSet, mutation]
+    );
+
+    const removeMultipleFavorites = useCallback(
+        (modelIds: string[]) => {
+            for (const modelId of modelIds) {
+                if (favoriteSet.has(modelId)) mutation.mutate({ modelId, favorite: false });
+            }
+        },
+        [favoriteSet, mutation]
+    );
+
+    const isFavorite = useCallback(
+        (modelId: string): boolean => favoriteSet.has(modelId),
+        [favoriteSet]
+    );
 
     return {
         favorites,
-        isFavorite: (modelId: string): boolean => favoriteSet.has(modelId),
+        isFavorite,
         toggleFavorite,
         addFavorite,
         removeFavorite,

--- a/apps/web/src/hooks/useProvider.ts
+++ b/apps/web/src/hooks/useProvider.ts
@@ -17,6 +17,8 @@ export interface AddConnectionPayload {
     api_key?: string;
 }
 
+const EMPTY_HIDDEN_MODELS: string[] = [];
+
 /**
  * Loads a provider definition and exposes add/delete connection mutations with
  * query invalidation for both the detail view and the catalog.
@@ -33,13 +35,18 @@ export function useProvider(providerId: string) {
     const hiddenModelsQuery = useQuery({
         queryKey: ["providers", providerId, "hidden-models"],
         queryFn: async () => {
-            const response = await api.get<{ models: string[] }>(`/v1/providers/${providerId}/hidden-models`);
+            const response = await api.get<{ models: string[] }>(
+                `/v1/providers/${providerId}/hidden-models`
+            );
             if (response.models.length > 0 || typeof window === "undefined") return response;
             const legacyKey = `srouter_deleted_models_${providerId}`;
             let legacyModels: string[] = [];
             try {
                 const parsed: unknown = JSON.parse(localStorage.getItem(legacyKey) || "[]");
-                if (Array.isArray(parsed) && parsed.every((id): id is string => typeof id === "string")) {
+                if (
+                    Array.isArray(parsed) &&
+                    parsed.every((id): id is string => typeof id === "string")
+                ) {
                     legacyModels = parsed;
                 }
             } catch {
@@ -89,7 +96,9 @@ export function useProvider(providerId: string) {
             void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
             void queryClient.invalidateQueries({ queryKey: ["providers", "catalog"] });
             toast.success(
-                data.roundRobin ? "Round-robin load balancing enabled" : "Round-robin load balancing disabled"
+                data.roundRobin
+                    ? "Round-robin load balancing enabled"
+                    : "Round-robin load balancing disabled"
             );
         },
         onError: (err: Error) => {
@@ -126,24 +135,30 @@ export function useProvider(providerId: string) {
     });
 
     const hideModelMutation = useMutation({
-        mutationFn: (modelId: string) => api.post(`/v1/providers/${providerId}/hidden-models`, { model_id: modelId }),
+        mutationFn: (modelId: string) =>
+            api.post(`/v1/providers/${providerId}/hidden-models`, { model_id: modelId }),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
-            void queryClient.invalidateQueries({ queryKey: ["providers", providerId, "hidden-models"] });
+            void queryClient.invalidateQueries({
+                queryKey: ["providers", providerId, "hidden-models"]
+            });
         }
     });
 
     const restoreModelMutation = useMutation({
-        mutationFn: (modelId: string) => api.delete(`/v1/providers/${providerId}/hidden-models/${encodeURIComponent(modelId)}`),
+        mutationFn: (modelId: string) =>
+            api.delete(`/v1/providers/${providerId}/hidden-models/${encodeURIComponent(modelId)}`),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: ["providers", providerId] });
-            void queryClient.invalidateQueries({ queryKey: ["providers", providerId, "hidden-models"] });
+            void queryClient.invalidateQueries({
+                queryKey: ["providers", providerId, "hidden-models"]
+            });
         }
     });
 
     return {
         ...query,
-        hiddenModelIds: hiddenModelsQuery.data?.models ?? [],
+        hiddenModelIds: hiddenModelsQuery.data?.models ?? EMPTY_HIDDEN_MODELS,
         addMutation,
         deleteMutation,
         toggleRoundRobinMutation,

--- a/apps/web/src/routes/providers/$providerId.tsx
+++ b/apps/web/src/routes/providers/$providerId.tsx
@@ -29,7 +29,14 @@ import { useFavorites } from "@/hooks/useFavorites";
 import { toast } from "sonner";
 import { ProviderDetailSkeleton } from "@/components/skeletons";
 import { CATEGORY_LABELS, getProviderWebsiteUrl } from "@srouter/constants";
-import { Empty, EmptyContent, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty";
+import {
+    Empty,
+    EmptyContent,
+    EmptyHeader,
+    EmptyMedia,
+    EmptyTitle,
+    EmptyDescription
+} from "@/components/ui/empty";
 
 export const Route = createFileRoute("/providers/$providerId")({
     staticData: { title: "Providers" },
@@ -293,8 +300,9 @@ function ProviderDetailPage() {
                 <div className="flex items-start gap-3 rounded-lg border border-border/80 bg-card p-3.5 text-xs leading-relaxed text-muted-foreground">
                     <AlertTriangle className="size-4 shrink-0 mt-0.5 text-foreground" />
                     <div>
-                        <strong className="text-foreground">OAuth Token Lifecycle:</strong> SRouter manages token lifecycle and
-                        background refresh sweeper automatically for this provider account.
+                        <strong className="text-foreground">OAuth Token Lifecycle:</strong> SRouter
+                        manages token lifecycle and background refresh sweeper automatically for
+                        this provider account.
                     </div>
                 </div>
             )}
@@ -305,6 +313,7 @@ function ProviderDetailPage() {
                 connections={connections}
                 roundRobin={provider.roundRobin ?? false}
                 isDeleting={deleteMutation.isPending}
+                requiresOAuth={provider.requires_oauth}
                 onToggleRoundRobin={(enabled) => toggleRoundRobinMutation.mutate(enabled)}
                 onRefresh={() => void refetch()}
                 onAdd={handleAddConnection}


### PR DESCRIPTION
…odal (#125)

- Add bg-black/60 scrim and backdrop-blur-xs guard to DialogOverlay to prevent compositor stalls and transparent backdrop rendering
- Add overflow-y-auto to DialogContent to avoid layout clipping and unresponsiveness on small viewports
- Decouple full provider object references from ConnectOAuthModal effect dependencies to eliminate re-fetch loops on parent re-renders
- Remove native autoFocus from ConnectionForm input to prevent focus fights with Base UI FloatingFocusManager during enter transitions
- Memoize isFavorite in useFavorites and stabilize empty hiddenModelIds in useProvider
- Align ConnectionCard action label with requiresOAuth flag