### PR TITLE
fix(web): format analytics chart values

### DIFF
--- a/apps/web/src/components/analytics/analytics.latency-chart.tsx
+++ b/apps/web/src/components/analytics/analytics.latency-chart.tsx
@@ -1,16 +1,17 @@
-import { formatTime } from "@/utils/format";
+import { formatDuration, formatTime } from "@/utils/format";
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import type { AnalyticsBucket } from "@srouter/types";
 
 interface Props {
     buckets: AnalyticsBucket[];
+    bucketSizeMs: number;
 }
 
-export function LatencyChart({ buckets }: Props) {
+export function LatencyChart({ buckets, bucketSizeMs }: Props) {
     const data = buckets
         .filter((b) => b.totalRequests > 0)
         .map((b) => ({
-            time: formatTime(b.bucketStart),
+            time: formatTime(b.bucketStart, bucketSizeMs),
             latency: Math.round(b.avgLatencyMs)
         }));
 
@@ -58,6 +59,7 @@ export function LatencyChart({ buckets }: Props) {
                             tickLine={false}
                             axisLine={false}
                             domain={[0, "auto"]}
+                            tickFormatter={formatDuration}
                         />
                         <Tooltip
                             contentStyle={{
@@ -70,7 +72,10 @@ export function LatencyChart({ buckets }: Props) {
                                 fontFamily: "var(--font-mono)",
                                 color: "var(--ink)"
                             }}
-                            formatter={(val: unknown) => [`${val} ms`, "Avg Latency"]}
+                            formatter={(val: unknown) => [
+                                formatDuration(Number(val ?? 0)),
+                                "Avg Latency"
+                            ]}
                         />
                         <Area
                             type="monotone"

--- a/apps/web/src/components/analytics/analytics.token-usage-chart.tsx
+++ b/apps/web/src/components/analytics/analytics.token-usage-chart.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export function TokenUsageChart({ buckets, bucketSizeMs }: Props) {
     const data = buckets.map((b) => ({
-        time: formatTime(b.bucketStart),
+        time: formatTime(b.bucketStart, bucketSizeMs),
         input: b.promptTokens ?? 0,
         output: b.completionTokens ?? 0,
         cached: b.cachedTokens ?? 0

--- a/apps/web/src/components/analytics/analytics.traffic-chart.tsx
+++ b/apps/web/src/components/analytics/analytics.traffic-chart.tsx
@@ -1,5 +1,6 @@
 import { formatTime, formatTimeUnit } from "@/utils/format";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import type { TooltipValueType } from "recharts";
 import type { AnalyticsBucket } from "@srouter/types";
 
 interface Props {
@@ -9,7 +10,7 @@ interface Props {
 
 export function TrafficChart({ buckets, bucketSizeMs }: Props) {
     const data = buckets.map((b) => ({
-        time: formatTime(b.bucketStart),
+        time: formatTime(b.bucketStart, bucketSizeMs),
         success: b.successRequests,
         error: b.errorRequests
     }));
@@ -64,6 +65,10 @@ export function TrafficChart({ buckets, bucketSizeMs }: Props) {
                                 fontFamily: "var(--font-mono)",
                                 color: "var(--ink)"
                             }}
+                            formatter={(
+                                value: TooltipValueType | undefined,
+                                name: string | number | undefined
+                            ) => [`${Number(value ?? 0).toLocaleString()} requests`, name]}
                             cursor={{ fill: "var(--canvas-soft)", opacity: 0.6 }}
                         />
                         <Legend

--- a/apps/web/src/routes/analytics.tsx
+++ b/apps/web/src/routes/analytics.tsx
@@ -84,7 +84,7 @@ function AnalyticsPage() {
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <TrafficChart buckets={data.buckets} bucketSizeMs={data.bucketSizeMs} />
-                <LatencyChart buckets={data.buckets} />
+                <LatencyChart buckets={data.buckets} bucketSizeMs={data.bucketSizeMs} />
             </div>
             <TokenUsageChart buckets={data.buckets} bucketSizeMs={data.bucketSizeMs} />
             <BreakdownTabsCard

--- a/apps/web/src/utils/format.ts
+++ b/apps/web/src/utils/format.ts
@@ -1,8 +1,26 @@
-export function formatTime(ms: number, includeSeconds = false): string {
+export function formatTime(
+    ms: number,
+    intervalMsOrIncludeSeconds: number | boolean = 0,
+    includeSeconds = false
+): string {
+    const intervalMs =
+        typeof intervalMsOrIncludeSeconds === "number" ? intervalMsOrIncludeSeconds : 0;
+    const shouldIncludeSeconds =
+        typeof intervalMsOrIncludeSeconds === "boolean"
+            ? intervalMsOrIncludeSeconds
+            : includeSeconds;
+
+    if (intervalMs >= 86_400_000) {
+        return new Date(ms).toLocaleDateString([], {
+            day: "2-digit",
+            month: "short"
+        });
+    }
+
     return new Date(ms).toLocaleTimeString([], {
         hour: "2-digit",
         minute: "2-digit",
-        ...(includeSeconds ? { second: "2-digit" } : {})
+        ...(shouldIncludeSeconds ? { second: "2-digit" } : {})
     });
 }
 
@@ -10,4 +28,12 @@ export function formatTimeUnit(intervalMs: number): string {
     if (intervalMs >= 86_400_000) return "day";
     if (intervalMs >= 3_600_000) return "hour";
     return "min";
+}
+
+export function formatDuration(ms: number): string {
+    if (ms >= 1_000) {
+        return `${(ms / 1_000).toLocaleString([], { maximumFractionDigits: 1 })} s`;
+    }
+
+    return `${ms.toLocaleString()} ms`;
 }


### PR DESCRIPTION
## Summary
- Fix analytics chart tooltip values for request counts.
- Format 30d chart labels as dates instead of local midnight times.
- Format latency values as `ms` below one second and `s` at one second or above.
- Keep `formatTime` compatible with its existing boolean argument.

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm run build` in `apps/web`
- `pnpm exec tsx --test --test-concurrency=1 --import ./tests/setup.ts tests/analytics.test.ts` in `apps/api`
- Prettier check
- `git diff --check`
