### PR TITLE
feat(quota): add OpenAI Codex OAuth usage

### DIFF
--- a/apps/api/src/logic/quota.logic.ts
+++ b/apps/api/src/logic/quota.logic.ts
@@ -33,6 +33,7 @@ export class QuotaLogic {
                                 providerId: p.providerId,
                                 name: p.name,
                                 accessToken: p.accessToken,
+                                accountId: p.accountId,
                                 enabled: p.enabled
                             });
                             if (account) {

--- a/packages/providers/src/quota/base.ts
+++ b/packages/providers/src/quota/base.ts
@@ -5,6 +5,7 @@ export interface ProviderQuotaContext {
     providerId: string;
     name: string;
     accessToken?: string;
+    accountId?: string;
     enabled: boolean;
 }
 

--- a/packages/providers/src/quota/index.ts
+++ b/packages/providers/src/quota/index.ts
@@ -2,10 +2,12 @@ import type { ProviderQuotaAccount } from "@srouter/types";
 import { type IProviderQuotaFetcher, type ProviderQuotaContext } from "./base.js";
 import { AntigravityQuotaFetcher } from "./antigravity.js";
 import { CodeBuddyCNQuotaFetcher } from "./codebuddy.js";
+import { OpenAICodexQuotaFetcher } from "./openai-codex.js";
 
 export * from "./base.js";
 export * from "./antigravity.js";
 export * from "./codebuddy.js";
+export * from "./openai-codex.js";
 
 export async function fetchAntigravityLiveQuota(
     providerId: string,
@@ -41,7 +43,8 @@ export async function fetchCodeBuddyCNLiveQuota(
 
 const QUOTA_FETCHERS: IProviderQuotaFetcher[] = [
     new AntigravityQuotaFetcher(),
-    new CodeBuddyCNQuotaFetcher()
+    new CodeBuddyCNQuotaFetcher(),
+    new OpenAICodexQuotaFetcher()
 ];
 
 export function findQuotaFetcher(providerId: string): IProviderQuotaFetcher | undefined {
@@ -52,7 +55,9 @@ export function isOAuthQuotaSupported(providerId: string): boolean {
     return Boolean(findQuotaFetcher(providerId));
 }
 
-export async function fetchLiveOAuthQuota(ctx: ProviderQuotaContext): Promise<ProviderQuotaAccount | null> {
+export async function fetchLiveOAuthQuota(
+    ctx: ProviderQuotaContext
+): Promise<ProviderQuotaAccount | null> {
     const fetcher = findQuotaFetcher(ctx.providerId) || findQuotaFetcher(ctx.id);
     if (!fetcher) {
         return null;

--- a/packages/providers/src/quota/openai-codex.ts
+++ b/packages/providers/src/quota/openai-codex.ts
@@ -1,0 +1,117 @@
+import { isProviderBaseId } from "@srouter/constants";
+import type { LiveModelQuotaItem, ProviderQuotaAccount } from "@srouter/types";
+import { type IProviderQuotaFetcher, type ProviderQuotaContext, formatResetIn } from "./base.js";
+
+interface JsonRecord {
+    [key: string]: unknown;
+}
+
+interface RateLimitWindow {
+    usedPercent: number;
+    resetAt?: number;
+    name: string;
+}
+
+function IsRecord(value: unknown): value is JsonRecord {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function ReadNumber(record: JsonRecord, ...keys: string[]): number | undefined {
+    for (const key of keys) {
+        const value = record[key];
+        if (typeof value === "number" && Number.isFinite(value)) return value;
+        if (typeof value === "string" && value.trim() !== "") {
+            const parsed = Number(value);
+            if (Number.isFinite(parsed)) return parsed;
+        }
+    }
+    return undefined;
+}
+
+function ReadWindow(value: unknown, name: string): RateLimitWindow | undefined {
+    if (!IsRecord(value)) return undefined;
+    const usedPercent = ReadNumber(value, "used_percent", "usedPercent");
+    if (usedPercent === undefined) return undefined;
+    const resetAt = ReadNumber(value, "reset_at", "resets_at", "resetAt", "resetsAt");
+    return { usedPercent: Math.max(0, Math.min(100, usedPercent)), resetAt, name };
+}
+
+function GetWindows(payload: JsonRecord): RateLimitWindow[] {
+    const result: RateLimitWindow[] = [];
+    const candidates: Array<[string, unknown]> = [];
+    const rateLimit = payload.rate_limit ?? payload.rateLimits;
+    if (IsRecord(rateLimit)) {
+        candidates.push(["5-hour", rateLimit.primary_window ?? rateLimit.primary]);
+        candidates.push(["Weekly", rateLimit.secondary_window ?? rateLimit.secondary]);
+    }
+    const byLimitId = payload.rate_limits_by_limit_id ?? payload.rateLimitsByLimitId;
+    if (IsRecord(byLimitId)) {
+        for (const [limitId, value] of Object.entries(byLimitId)) {
+            if (!IsRecord(value)) continue;
+            const nested = value.primary_window ?? value.primary;
+            candidates.push([limitId, nested]);
+        }
+    }
+    for (const [name, value] of candidates) {
+        const window = ReadWindow(value, name);
+        if (window && !result.some((item) => item.name === window.name)) result.push(window);
+    }
+    return result;
+}
+
+export class OpenAICodexQuotaFetcher implements IProviderQuotaFetcher {
+    public readonly providerKey = "openai_codex";
+
+    public canHandle(providerId: string): boolean {
+        return isProviderBaseId(providerId, "openai_codex");
+    }
+
+    public async fetchQuota(ctx: ProviderQuotaContext): Promise<ProviderQuotaAccount> {
+        const accessToken = ctx.accessToken || "";
+        if (!accessToken) throw new Error("OpenAI Codex quota requires an access token");
+
+        const Res = await fetch("https://chatgpt.com/backend-api/wham/usage", {
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                Accept: "application/json",
+                "User-Agent": "codex_cli_rs/0.136.0",
+                originator: "codex_cli_rs",
+                ...(ctx.accountId ? { "ChatGPT-Account-ID": ctx.accountId } : {})
+            }
+        });
+        if (!Res.ok) throw new Error(`OpenAI Codex quota fetch failed: HTTP ${Res.status}`);
+
+        const Payload = await Res.json();
+        if (!IsRecord(Payload)) throw new Error("OpenAI Codex quota returned an invalid response");
+        const windows = GetWindows(Payload);
+        if (windows.length === 0) throw new Error("OpenAI Codex quota returned no rate limits");
+
+        const Quotas: LiveModelQuotaItem[] = windows.map((window) => {
+            const remaining = 100 - window.usedPercent;
+            const resetTime = window.resetAt
+                ? new Date(window.resetAt * 1000).toISOString()
+                : undefined;
+            return {
+                name: `Codex ${window.name}`,
+                used: Math.round(window.usedPercent),
+                limit: 100,
+                percentage: `${Math.round(remaining)}%`,
+                percentageValue: Math.round(remaining),
+                resetIn: formatResetIn(resetTime),
+                resetTime,
+                status: remaining <= 5 ? "exhausted" : remaining <= 20 ? "warning" : "ok"
+            };
+        });
+
+        const planType = typeof Payload.plan_type === "string" ? Payload.plan_type : undefined;
+        return {
+            id: ctx.id,
+            provider: planType ? `OpenAI Codex (${planType})` : "OpenAI Codex",
+            account: ctx.name || "OpenAI Codex Account",
+            enabled: ctx.enabled,
+            quotaType: "live_provider_quota",
+            totalQuotas: Quotas.length,
+            quotas: Quotas
+        };
+    }
+}

--- a/packages/providers/tests/openai-codex-quota.test.ts
+++ b/packages/providers/tests/openai-codex-quota.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { OpenAICodexQuotaFetcher } from "../src/quota/openai-codex.js";
+
+test("OpenAI Codex quota maps primary and secondary windows", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_input, init) => {
+        assert.equal(new Headers(init?.headers).get("ChatGPT-Account-ID"), "acct_123");
+        return new Response(
+            JSON.stringify({
+                plan_type: "plus",
+                rate_limit: {
+                    primary_window: { used_percent: 25, reset_at: 1_800_000_000 },
+                    secondary_window: { used_percent: 60, reset_at: 1_800_100_000 }
+                }
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+    };
+
+    try {
+        const result = await new OpenAICodexQuotaFetcher().fetchQuota({
+            id: "openai_codex_1",
+            providerId: "openai_codex",
+            name: "Codex account",
+            accessToken: "token",
+            accountId: "acct_123",
+            enabled: true
+        });
+
+        assert.equal(result.provider, "OpenAI Codex (plus)");
+        assert.deepEqual(
+            result.quotas?.map((quota) => [quota.name, quota.percentageValue]),
+            [
+                ["Codex 5-hour", 75],
+                ["Codex Weekly", 40]
+            ]
+        );
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});


### PR DESCRIPTION
## Summary
- Add live quota fetching for OpenAI Codex OAuth accounts.
- Display primary and secondary Codex rate-limit windows in the quota dashboard.
- Forward the stored ChatGPT account ID for multi-account quota lookup.

## Test Plan
- `cd packages/providers && pnpm run build`
- `cd packages/providers && pnpm exec tsx --test tests/openai-codex-quota.test.ts`
- `cd apps/api && pnpm run build`
- Prettier check and `git diff --check`
